### PR TITLE
Align create-experiment with GitHub App API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,7 +675,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openresearch-cli"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openresearch-cli"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 description = "OpenResearch CLI (orx) — Rust port"
 repository = "https://github.com/alphaXiv/openresearch-cli"

--- a/SKILL.md
+++ b/SKILL.md
@@ -270,15 +270,14 @@ is chosen by flags:
 # Child node, branched off an existing experiment:
 orx create-experiment <projectId> --title "Larger batch size" --parent <experimentId>
 
-# Root node imported from a GitHub repo (owner/repo, via the org's GitHub App):
-orx create-experiment <projectId> --title "Baseline" --repo lino-levan/sortbench --ref main
-
-# Empty root node:
-orx create-experiment <projectId> --title "Scratch baseline"
+# Baseline (root) node on the project's bound repo:
+orx create-experiment <projectId> --title "Baseline"
 ```
 
-- `--parent` and `--repo` are mutually exclusive (`--parent` ⇒ child, `--repo` ⇒
-  root-from-repo, neither ⇒ empty root).
+- `--parent` selects the shape: with `--parent` ⇒ child; without it ⇒ baseline
+  (root) on the repo the project is already bound to. The repo a project works on
+  is chosen when the **project** is created (on the web), so there is no `--repo`
+  flag here.
 - **A `--parent` child inherits the parent's run command** (and branches off its
   code). You do **not** set a run command on the child — keep it and vary the code
   via a dev session (see "the experiment-tree model" above).
@@ -289,9 +288,6 @@ orx create-experiment <projectId> --title "Scratch baseline"
   Piling round after round of children onto the root is the flat-fan failure (see
   "Shape the tree"). Co-equal options of the same decision are siblings under one
   parent — don't chain them into a line either.
-- `--repo` takes a GitHub `owner/repo` that is reachable through the org's GitHub
-  App installation — it is imported as a tarball, **not** an arbitrary
-  `git clone` URL. `--ref` (branch/tag/commit) only applies with `--repo`.
 - `--description` is optional but **strongly recommended for children**: use it to
   record the hypothesis / the concrete change this node makes. It's the node's
   free-form notes field (the same one `orx exp desc` reads/writes), and it's how

--- a/src/client.rs
+++ b/src/client.rs
@@ -417,23 +417,15 @@ pub struct CreateChildBody {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CreateEmptyBaselineBody {
-    pub title: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct ImportBaselineBody {
-    pub repo_full_name: String,
-    #[serde(rename = "ref")]
-    pub ref_: String,
-    /// Always `null` in the TS caller; serialized as JSON `null`.
-    pub patch: Option<Value>,
-    pub title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Auto-generate suggested first experiments off the baseline. Defaults to
+    /// true server-side when omitted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub generate_suggestions: Option<bool>,
 }
 
 // The TS field is literally `ref` (a Rust keyword), so the struct field is
@@ -665,27 +657,13 @@ pub async fn create_child_experiment(
     .await
 }
 
-pub async fn create_empty_baseline(
-    creds: &Credentials,
-    project_id: &str,
-    body: &CreateEmptyBaselineBody,
-) -> Result<ExperimentEnvelope> {
-    let body = serde_json::to_value(body)?;
-    api_post(
-        creds,
-        &format!("/projects/{}/create-empty-baseline", project_id),
-        body,
-    )
-    .await
-}
-
 pub async fn import_baseline(
     creds: &Credentials,
     project_id: &str,
     body: &ImportBaselineBody,
 ) -> Result<ExperimentEnvelope> {
-    // Plain serde: `ref_` renames to `ref`, and `description: None` is omitted
-    // (skip_serializing_if) to match the TS caller, which never sends the key.
+    // Repo is bound at project creation; this just materializes the baseline on
+    // it. `None` fields are omitted so the server applies its defaults.
     let json = serde_json::to_value(body)?;
     api_post(
         creds,

--- a/src/commands/create_experiment.rs
+++ b/src/commands/create_experiment.rs
@@ -1,17 +1,19 @@
 //!
-//! Creates an experiment node. Three shapes, picked by flags:
+//! Creates an experiment node. Two shapes, picked by flags:
 //!   --parent <id>   -> child experiment branched off that parent
-//!   --repo a/b      -> root experiment imported from a GitHub repo
-//!   (neither)       -> empty root experiment
+//!   (no parent)     -> baseline (root) experiment on the project's bound repo
 //! A title is always required.
+//!
+//! Note: the repo a project works on is chosen when the PROJECT is created (on
+//! the web), not here — so there is no longer a `--repo` flag. The baseline is
+//! materialized on whatever repo the project is already bound to.
 
 use crate::client::{
-    create_child_experiment, create_empty_baseline, import_baseline, CreateChildBody,
-    CreateEmptyBaselineBody, Experiment, ImportBaselineBody,
+    create_child_experiment, import_baseline, CreateChildBody, Experiment, ImportBaselineBody,
 };
 use crate::error::{require_credentials, Result};
 
-const USAGE: &str = "Usage: orx create-experiment <projectId> --title \"<title>\" [--parent <experimentId>] [--repo <owner/repo> [--ref <ref>]] [--description \"<text>\"]";
+const USAGE: &str = "Usage: orx create-experiment <projectId> --title \"<title>\" [--parent <experimentId>] [--description \"<text>\"]";
 
 pub async fn run(args: crate::CreateExperimentArgs) -> Result<()> {
     let title = match args.title {
@@ -21,16 +23,6 @@ pub async fn run(args: crate::CreateExperimentArgs) -> Result<()> {
             std::process::exit(1);
         }
     };
-
-    if args.parent.is_some() && args.repo.is_some() {
-        eprintln!("Choose one of --parent or --repo, not both.");
-        eprintln!("(--parent makes a child node; --repo makes a root node from a git repo.)");
-        std::process::exit(1);
-    }
-    if args.ref_.is_some() && args.repo.is_none() {
-        eprintln!("--ref only applies together with --repo.");
-        std::process::exit(1);
-    }
 
     let creds = require_credentials().await;
     let description = args.description;
@@ -50,34 +42,21 @@ pub async fn run(args: crate::CreateExperimentArgs) -> Result<()> {
         .await?;
         experiment = envelope.experiment;
         kind = "child".to_string();
-    } else if let Some(repo) = args.repo {
-        // The repo must be a GitHub repo ("owner/repo") reachable through the
-        // org's GitHub App installation -- it's imported via tarball, not an
-        // arbitrary `git clone` URL. `patch` is required by the endpoint; we
-        // send null.
+    } else {
+        // Baseline on the project's already-bound GitHub repo. The server
+        // branches `orx/<slug>` off the repo's default branch.
         let envelope = import_baseline(
             &creds,
             &args.project_id,
             &ImportBaselineBody {
-                repo_full_name: repo.clone(),
-                ref_: args.ref_.unwrap_or_default(),
-                patch: None,
-                title,
+                title: Some(title),
                 description,
+                generate_suggestions: None,
             },
         )
         .await?;
         experiment = envelope.experiment;
-        kind = format!("root (from {})", repo);
-    } else {
-        let envelope = create_empty_baseline(
-            &creds,
-            &args.project_id,
-            &CreateEmptyBaselineBody { title, description },
-        )
-        .await?;
-        experiment = envelope.experiment;
-        kind = "root (empty)".to_string();
+        kind = "baseline".to_string();
     }
 
     println!("\u{2713} Created {} experiment", kind);

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,7 @@ enum Command {
     /// Render a W&B metric across runs to a PNG.
     Chart(ChartArgs),
 
-    /// Add an experiment node (child, git-repo root, or empty root).
+    /// Add an experiment node (child of a parent, or a baseline root).
     #[command(name = "create-experiment")]
     CreateExperiment(CreateExperimentArgs),
 
@@ -262,15 +262,10 @@ pub struct CreateExperimentArgs {
     /// Experiment description.
     #[arg(long)]
     pub description: Option<String>,
-    /// Parent experiment id -> create a child.
+    /// Parent experiment id -> create a child. Omit to create a baseline on the
+    /// project's bound repo.
     #[arg(long)]
     pub parent: Option<String>,
-    /// GitHub repo `owner/repo` -> create a root from it.
-    #[arg(long)]
-    pub repo: Option<String>,
-    /// Branch/tag/commit for `--repo`.
-    #[arg(long)]
-    pub ref_: Option<String>,
 }
 
 #[derive(Args, Debug)]


### PR DESCRIPTION
## Summary

Aligns the `create-experiment` command with the current backend API, where a project's repo is bound at **project-creation time** (on the web) rather than being passed per-experiment.

`create-experiment` now has **two shapes** instead of three:
- `--parent <id>` → child experiment branched off that parent
- (no `--parent`) → baseline (root) experiment materialized on the project's already-bound repo

## Changes
- Drop the `--repo <owner/repo>` and `--ref <ref>` flags and the related mutual-exclusion validation.
- Remove the `create-empty-baseline` path (`CreateEmptyBaselineBody` / `create_empty_baseline`).
- Simplify `ImportBaselineBody` to optional `title`/`description` plus a `generateSuggestions` toggle; `import_baseline` now just materializes the baseline on the bound repo and lets the server apply defaults for omitted fields.
- Update `SKILL.md` docs and command help text to describe the two-shape model.

## Verification
Ran the same checks as CI locally, all green:
- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo build --locked` — ok
- `cargo test --locked` — 2 passed
- `orx create-experiment --help` — confirms `--repo`/`--ref` removed, help reflects the new model