### PR TITLE
Add orx version / orx update and a passive update nudge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,6 +642,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,7 +707,9 @@ dependencies = [
  "anyhow",
  "clap",
  "dirs",
+ "fd-lock",
  "reqwest",
+ "semver",
  "serde",
  "serde_json",
  "tokio",
@@ -919,6 +948,19 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "rustls"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ anyhow = "1"
 dirs = "5"
 urlencoding = "2"
 uuid = { version = "1", features = ["v4"] }
+semver = "1"
+fd-lock = "4"
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ Run the tests with `cargo test`.
 | `orx exp cancel <expId>` | Cancels the in-flight run. |
 | `orx lit "<query>" [--limit <n>] [--json]` | Full-text search alphaXiv's paper corpus (no login required). |
 | `orx paper <id\|url> [--full]` | Fetch a paper's machine-readable report, or its full text with `--full`. |
+| `orx version [--check] [--json]` | Prints the CLI version; `--check` compares it to the latest release. |
+| `orx update [--dry-run] [--force]` | Updates orx by re-running the release installer (installer installs only). |
+
+### Updating
+
+`orx update` only manages binaries installed by the release installer script
+(it checks the cargo-dist install receipt at
+`${XDG_CONFIG_HOME:-~/.config}/openresearch-cli/`). If you installed with
+`cargo install`, update the same way instead. In interactive terminals orx
+also checks for new releases in the background at most once a day and prints
+a one-line notice to stderr; set `ORX_NO_UPDATE_CHECK=1` (or
+`OPENRESEARCH_CLI_DISABLE_UPDATE=1`) to turn that off. Agents, scripts, pipes,
+and CI never see the notice.
 
 ### Configuration
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -34,4 +34,6 @@ pub mod query;
 pub mod runs;
 pub mod search_logs;
 pub mod skill;
+pub mod update;
+pub mod version;
 pub mod wandb;

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -1,0 +1,180 @@
+//! The `update` command — update orx in place by re-running the release
+//! installer.
+//!
+//! The mechanism mirrors what axoupdater (uv's `self update`) does: download
+//! the `openresearch-cli-installer.sh` asset from the target release and run
+//! it pinned to the existing install prefix via `CARGO_DIST_FORCE_INSTALL_DIR`.
+//! The installer owns the hard parts — checksum verification and the atomic
+//! rename into `~/.cargo/bin` (never an in-place overwrite, which on macOS
+//! trips the kernel's per-inode code-signature cache and SIGKILLs the binary).
+//!
+//! Guards, in order:
+//!   - `OPENRESEARCH_CLI_DISABLE_UPDATE=1` refuses outright (same switch the
+//!     installer honors).
+//!   - an exclusive file lock, so concurrent `orx update` runs fail fast
+//!     instead of corrupting each other.
+//!   - no install receipt -> this binary wasn't installed by the installer
+//!     script (most likely `cargo install`); refuse with the right
+//!     alternative, since both paths land in `~/.cargo/bin/orx`.
+//!   - receipt prefix or version not matching the running binary -> another
+//!     copy exists or something else overwrote it; require `--force`.
+//!   - Nix-store / Homebrew paths and unwritable bin dirs refuse with
+//!     targeted messages.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crate::error::{anyhow, Result};
+use crate::updates;
+
+const INSTALL_HINT: &str = "curl --proto '=https' --tlsv1.2 -LsSf \
+https://github.com/alphaXiv/openresearch-cli/releases/latest/download/openresearch-cli-installer.sh | sh";
+
+pub async fn run(args: crate::UpdateArgs) -> Result<()> {
+    if std::env::var("OPENRESEARCH_CLI_DISABLE_UPDATE").as_deref() == Ok("1") {
+        return Err(anyhow!(
+            "Updates are disabled for this install (OPENRESEARCH_CLI_DISABLE_UPDATE=1)."
+        ));
+    }
+
+    // One updater at a time. The lock file lives in our config dir; flock is
+    // advisory and released automatically when the process exits.
+    let lock_path = crate::config::config_dir().join("update.lock");
+    if let Some(parent) = lock_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let lock_file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(&lock_path)?;
+    let mut lock = fd_lock::RwLock::new(lock_file);
+    let _guard = lock
+        .try_write()
+        .map_err(|_| anyhow!("Another `orx update` is already running."))?;
+
+    let current = updates::current_version();
+    let exe = std::env::current_exe()?
+        .canonicalize()
+        .map_err(|e| anyhow!("Could not resolve the running executable: {}", e))?;
+
+    // Package-manager-shaped paths get a targeted refusal before any network.
+    let exe_str = exe.to_string_lossy();
+    if exe_str.starts_with("/nix/store/") {
+        return Err(anyhow!(
+            "This orx is managed by Nix ({}). Update it through your Nix configuration.",
+            exe.display()
+        ));
+    }
+    if exe_str.starts_with("/opt/homebrew/") || exe_str.contains("/Cellar/") {
+        return Err(anyhow!(
+            "This orx looks Homebrew-managed ({}). Update it with `brew upgrade`.",
+            exe.display()
+        ));
+    }
+
+    // The receipt is the only discriminator between an installer-managed
+    // binary and a `cargo install` one — both live at ~/.cargo/bin/orx.
+    let Some(receipt) = updates::load_receipt()? else {
+        return Err(anyhow!(
+            "orx was not installed by the installer script (no receipt at {}),\n\
+             so `orx update` won't touch it. Update it the way it was installed:\n\
+             - cargo: cargo install --path . (or your original cargo install invocation)\n\
+             - or reinstall with the installer: {}",
+            updates::receipt_path().display(),
+            INSTALL_HINT
+        ));
+    };
+
+    let prefix = PathBuf::from(&receipt.install_prefix);
+    let prefix = prefix.canonicalize().unwrap_or(prefix);
+    if !updates::exe_matches_prefix(&exe, &prefix) && !args.force {
+        return Err(anyhow!(
+            "The running orx is at {} but the installer's receipt says it installed to {}.\n\
+             Are multiple copies of orx installed? Pass --force to update the receipt's copy anyway.",
+            exe.display(),
+            prefix.display()
+        ));
+    }
+    if receipt.version != current.to_string() && !args.force {
+        return Err(anyhow!(
+            "The running orx is {} but the install receipt records {} — something other than\n\
+             the installer (likely `cargo install`) overwrote {}. Updating would clobber it.\n\
+             Pass --force to proceed anyway.",
+            current,
+            receipt.version,
+            exe.display()
+        ));
+    }
+
+    // Probe writability of the bin dir up front (root-owned installs,
+    // read-only filesystems) so we fail before downloading anything.
+    if let Some(bin_dir) = exe.parent() {
+        let probe = bin_dir.join(format!(".orx-update-probe-{}", uuid::Uuid::new_v4()));
+        match std::fs::File::create(&probe) {
+            Ok(_) => {
+                let _ = std::fs::remove_file(&probe);
+            }
+            Err(e) => {
+                return Err(anyhow!(
+                    "No write permission for {} ({}). If orx was installed with sudo,\n\
+                     update it the same way or reinstall per-user.",
+                    bin_dir.display(),
+                    e
+                ));
+            }
+        }
+    }
+
+    let latest = updates::fetch_latest(Duration::from_secs(10)).await?;
+    if latest.version <= current {
+        println!("orx {} is up to date.", current);
+        return Ok(());
+    }
+
+    if args.dry_run {
+        println!(
+            "orx {} → {} is available. Re-run without --dry-run to update.",
+            current, latest.version
+        );
+        return Ok(());
+    }
+
+    eprintln!("Updating orx {} → {} ...", current, latest.version);
+
+    // Pin the installer to the same release the manifest described, so the
+    // version we report is exactly the version that gets installed.
+    let installer = updates::fetch_release_asset(
+        &latest.tag,
+        &format!("{}-installer.sh", updates::APP_NAME),
+        Duration::from_secs(60),
+    )
+    .await?;
+    let script = std::env::temp_dir().join(format!("orx-installer-{}.sh", uuid::Uuid::new_v4()));
+    std::fs::write(&script, &installer)?;
+
+    // `sh <script>` rather than executing the file: immune to noexec /tmp
+    // mounts. The installer verifies artifact checksums and renames the new
+    // binary into place atomically; replacing a running orx is safe on
+    // macOS/Linux (old processes keep the old inode).
+    let mut cmd = std::process::Command::new("sh");
+    cmd.arg(&script)
+        .env("CARGO_DIST_FORCE_INSTALL_DIR", &receipt.install_prefix);
+    if !receipt.modify_path {
+        cmd.env("OPENRESEARCH_CLI_NO_MODIFY_PATH", "1");
+    }
+    let status = cmd.status();
+    let _ = std::fs::remove_file(&script);
+    let status = status.map_err(|e| anyhow!("Could not run the installer: {}", e))?;
+    if !status.success() {
+        return Err(anyhow!(
+            "The installer exited with {}. The previous orx is untouched.",
+            status
+        ));
+    }
+
+    // Keep the nudge cache in sync so it doesn't fire on a stale answer.
+    updates::write_check_cache(&latest.version.to_string());
+    println!("✓ Updated orx {} → {}.", current, latest.version);
+    Ok(())
+}

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -1,0 +1,48 @@
+//! The `version` command — print the CLI version, optionally comparing it to
+//! the latest GitHub release.
+//!
+//! `--json` (which implies `--check`) is the agent-facing form: one stable
+//! JSON object on stdout, exit 0 whether or not an update is available, so
+//! harnesses can poll deliberately instead of scraping stderr nudges.
+
+use std::time::Duration;
+
+use crate::error::Result;
+use crate::updates;
+
+pub async fn run(args: crate::VersionArgs) -> Result<()> {
+    let current = updates::current_version();
+
+    if !args.check && !args.json {
+        println!("orx {}", current);
+        return Ok(());
+    }
+
+    let latest = updates::fetch_latest(Duration::from_secs(10)).await?;
+    // Keep the passive nudge's cache in sync with this explicit check.
+    updates::write_check_cache(&latest.version.to_string());
+    let update_available = latest.version > current;
+
+    if args.json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "current": current.to_string(),
+                "latest": latest.version.to_string(),
+                "updateAvailable": update_available,
+            })
+        );
+        return Ok(());
+    }
+
+    println!("orx {}", current);
+    if update_available {
+        println!(
+            "A new release is available: {} → {}. Run `orx update` to upgrade.",
+            current, latest.version
+        );
+    } else {
+        println!("orx is up to date.");
+    }
+    Ok(())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,7 +42,7 @@ pub struct Credentials {
     pub token: String,
 }
 
-fn config_dir() -> PathBuf {
+pub(crate) fn config_dir() -> PathBuf {
     let base = std::env::var_os("XDG_CONFIG_HOME")
         .map(PathBuf::from)
         .unwrap_or_else(|| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod commands;
 mod config;
 mod error;
 mod output;
+mod updates;
 
 use clap::{Args, Parser, Subcommand};
 
@@ -24,6 +25,7 @@ use clap::{Args, Parser, Subcommand};
 #[command(
     name = "orx",
     about = "OpenResearch CLI",
+    version,
     disable_help_subcommand = true
 )]
 struct Cli {
@@ -93,6 +95,12 @@ enum Command {
 
     /// Fetch a paper's machine-readable report (or `--full` text) from alphaXiv.
     Paper(PaperArgs),
+
+    /// Show the CLI version; `--check` compares it to the latest release.
+    Version(VersionArgs),
+
+    /// Update orx to the latest release (installer-script installs only).
+    Update(UpdateArgs),
 }
 
 #[derive(Args, Debug)]
@@ -332,6 +340,27 @@ pub struct LitArgs {
 }
 
 #[derive(Args, Debug)]
+pub struct VersionArgs {
+    /// Also check the latest released version on GitHub.
+    #[arg(long)]
+    pub check: bool,
+    /// Emit a JSON object instead of text (implies --check).
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct UpdateArgs {
+    /// Report whether an update is available without installing anything.
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Update even when the binary doesn't match the install receipt
+    /// (multiple copies, or a `cargo install` overwrote it).
+    #[arg(long)]
+    pub force: bool,
+}
+
+#[derive(Args, Debug)]
 pub struct PaperArgs {
     /// arXiv id, versioned id (`2401.12345v2`), or an arXiv/alphaXiv URL.
     pub id: String,
@@ -349,7 +378,18 @@ async fn main() {
         Cli::command().print_help().ok();
         return;
     };
-    if let Err(err) = dispatch(command).await {
+    // Passive update nudge (skipped for the commands that manage updates
+    // themselves). Interactive terminals only; never delays or fails the
+    // command, never touches stdout or the exit code.
+    let nudge =
+        (!matches!(command, Command::Version(_) | Command::Update(_))).then(updates::Nudge::start);
+
+    let result = dispatch(command).await;
+    if let Some(nudge) = nudge {
+        nudge.finish().await;
+    }
+
+    if let Err(err) = result {
         // Match the TS: print only the message, exit 1.
         eprintln!("{}", err);
         std::process::exit(1);
@@ -377,5 +417,7 @@ async fn dispatch(command: Command) -> error::Result<()> {
         Command::Skill(args) => commands::skill::run(args).await,
         Command::Lit(args) => commands::lit::run(args).await,
         Command::Paper(args) => commands::paper::run(args).await,
+        Command::Version(args) => commands::version::run(args).await,
+        Command::Update(args) => commands::update::run(args).await,
     }
 }

--- a/src/updates.rs
+++ b/src/updates.rs
@@ -1,0 +1,391 @@
+//! Self-update plumbing shared by `orx version`, `orx update`, and the passive
+//! update nudge.
+//!
+//! Latest-version discovery deliberately avoids the GitHub REST API: its
+//! unauthenticated limit is 60 requests/hour *per IP*, which is routinely
+//! exhausted on the datacenter/NAT addresses agents run from. Instead we fetch
+//! the `dist-manifest.json` asset that cargo-dist uploads to every release via
+//! the documented `releases/latest/download/<asset>` permalink — a plain CDN
+//! redirect with no API rate limit.
+//!
+//! The cargo-dist shell installer writes an install receipt to
+//! `${XDG_CONFIG_HOME:-~/.config}/openresearch-cli/openresearch-cli-receipt.json`.
+//! That receipt is the only thing distinguishing an installer-managed binary
+//! from a `cargo install` one (both live at `~/.cargo/bin/orx` because
+//! dist-workspace.toml sets `install-path = "CARGO_HOME"`), so `orx update`
+//! refuses to touch the binary unless the receipt matches it.
+
+use std::io::IsTerminal;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use semver::Version;
+use serde::{Deserialize, Serialize};
+
+use crate::error::{anyhow, Result};
+
+/// GitHub repo the released binaries come from.
+pub const REPO_URL: &str = "https://github.com/alphaXiv/openresearch-cli";
+
+/// The cargo-dist app name (the *package* name, not the `orx` bin name) — used
+/// in release asset names and the receipt path.
+pub const APP_NAME: &str = "openresearch-cli";
+
+/// How long a cached update check stays fresh.
+const CHECK_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Sent on requests to GitHub — some CDNs reject the default (empty) UA.
+const UA: &str = concat!("openresearch-cli/", env!("CARGO_PKG_VERSION"));
+
+pub fn current_version() -> Version {
+    // The crate version is always valid semver; a panic here is a build bug.
+    Version::parse(env!("CARGO_PKG_VERSION")).expect("CARGO_PKG_VERSION is valid semver")
+}
+
+fn http() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(reqwest::Client::new)
+}
+
+// ---------------------------------------------------------------------------
+// Latest-version discovery (dist-manifest.json)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct LatestRelease {
+    pub version: Version,
+    /// The git tag (e.g. `v0.1.15`), used to pin asset downloads to the same
+    /// release the manifest described.
+    pub tag: String,
+}
+
+#[derive(Deserialize)]
+struct DistManifest {
+    announcement_tag: String,
+    #[serde(default)]
+    releases: Vec<ManifestRelease>,
+}
+
+#[derive(Deserialize)]
+struct ManifestRelease {
+    app_name: String,
+    app_version: String,
+}
+
+/// Extracts our app's version (and the release tag) from a dist-manifest body.
+fn parse_manifest(body: &str) -> Result<LatestRelease> {
+    let manifest: DistManifest = serde_json::from_str(body)?;
+    let release = manifest
+        .releases
+        .iter()
+        .find(|r| r.app_name == APP_NAME)
+        .ok_or_else(|| anyhow!("Release manifest has no entry for {}", APP_NAME))?;
+    let version = Version::parse(&release.app_version)
+        .map_err(|e| anyhow!("Could not parse version {:?}: {}", release.app_version, e))?;
+    Ok(LatestRelease {
+        version,
+        tag: manifest.announcement_tag,
+    })
+}
+
+/// Fetches the latest released version from GitHub (rate-limit-free permalink).
+pub async fn fetch_latest(timeout: Duration) -> Result<LatestRelease> {
+    let url = format!("{}/releases/latest/download/dist-manifest.json", REPO_URL);
+    let res = http()
+        .get(&url)
+        .header("user-agent", UA)
+        .timeout(timeout)
+        .send()
+        .await
+        .map_err(|e| {
+            anyhow!(
+                "Could not fetch the release manifest from {}: {}",
+                REPO_URL,
+                e
+            )
+        })?;
+    let status = res.status();
+    if !status.is_success() {
+        let reason = status.canonical_reason().unwrap_or("");
+        return Err(anyhow!(
+            "Release manifest request failed ({} {})",
+            status.as_u16(),
+            reason
+        ));
+    }
+    let body = res.text().await?;
+    parse_manifest(&body)
+}
+
+/// Downloads a release asset pinned to `tag` and returns its bytes.
+pub async fn fetch_release_asset(tag: &str, asset: &str, timeout: Duration) -> Result<Vec<u8>> {
+    let url = format!("{}/releases/download/{}/{}", REPO_URL, tag, asset);
+    let res = http()
+        .get(&url)
+        .header("user-agent", UA)
+        .timeout(timeout)
+        .send()
+        .await
+        .map_err(|e| anyhow!("Could not download {}: {}", url, e))?;
+    let status = res.status();
+    if !status.is_success() {
+        let reason = status.canonical_reason().unwrap_or("");
+        return Err(anyhow!(
+            "Download of {} failed ({} {})",
+            url,
+            status.as_u16(),
+            reason
+        ));
+    }
+    Ok(res.bytes().await?.to_vec())
+}
+
+// ---------------------------------------------------------------------------
+// Install receipt (written by the cargo-dist shell installer)
+// ---------------------------------------------------------------------------
+
+/// The fields of the cargo-dist install receipt that `orx update` relies on.
+#[derive(Debug, Deserialize)]
+pub struct Receipt {
+    pub install_prefix: String,
+    pub version: String,
+    #[serde(default)]
+    pub modify_path: bool,
+}
+
+pub fn receipt_path() -> PathBuf {
+    let base = std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            dirs::home_dir()
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join(".config")
+        });
+    base.join(APP_NAME)
+        .join(format!("{}-receipt.json", APP_NAME))
+}
+
+/// Reads the install receipt. `Ok(None)` when it does not exist (i.e. the
+/// shell installer never ran on this machine); `Err` when it exists but cannot
+/// be parsed, since silently treating a corrupt receipt as "not installed by
+/// the installer" would point users at the wrong update path.
+pub fn load_receipt() -> Result<Option<Receipt>> {
+    let path = receipt_path();
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(anyhow!("Could not read {}: {}", path.display(), e)),
+    };
+    let receipt: Receipt = serde_json::from_str(&raw)
+        .map_err(|e| anyhow!("Install receipt at {} is malformed: {}", path.display(), e))?;
+    Ok(Some(receipt))
+}
+
+/// Whether the running executable lives under the receipt's install prefix.
+/// The receipt records the prefix root (e.g. `~/.cargo`), while the binary sits
+/// in its `bin/` subdirectory for the cargo-home layout — so a trailing `bin`
+/// component is stripped from the exe's directory before comparing. Both paths
+/// should be canonicalized by the caller.
+pub fn exe_matches_prefix(exe: &Path, prefix: &Path) -> bool {
+    let Some(dir) = exe.parent() else {
+        return false;
+    };
+    let dir = if dir.file_name() == Some(std::ffi::OsStr::new("bin")) {
+        dir.parent().unwrap_or(dir)
+    } else {
+        dir
+    };
+    dir == prefix
+}
+
+// ---------------------------------------------------------------------------
+// Update-check cache (the passive nudge's 24h throttle)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, Deserialize)]
+struct CheckCache {
+    /// Unix seconds of the last completed (or attempted) check.
+    checked_at: u64,
+    /// Latest version seen at that time.
+    latest: String,
+}
+
+fn cache_path() -> PathBuf {
+    crate::config::config_dir().join("update-check.json")
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn read_cache() -> Option<CheckCache> {
+    let raw = std::fs::read_to_string(cache_path()).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+/// Best-effort cache write; errors are swallowed because the cache only exists
+/// to throttle a best-effort background check.
+pub fn write_check_cache(latest: &str) {
+    let cache = CheckCache {
+        checked_at: now_unix(),
+        latest: latest.to_string(),
+    };
+    let path = cache_path();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(body) = serde_json::to_string(&cache) {
+        let _ = std::fs::write(&path, body);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Passive nudge
+// ---------------------------------------------------------------------------
+
+/// Whether the passive update check may run at all. Interactive terminals
+/// only: agents, scripts, pipes, and CI see zero behavior change.
+fn nudge_enabled() -> bool {
+    let opted_out = std::env::var_os("ORX_NO_UPDATE_CHECK").is_some()
+        // The generic convention honored by update-notifier and friends.
+        || std::env::var_os("NO_UPDATE_NOTIFIER").is_some()
+        // cargo-dist's own "don't manage updates for this install" switch; the
+        // installer already honors it, so it is the one mental model.
+        || std::env::var("OPENRESEARCH_CLI_DISABLE_UPDATE").as_deref() == Ok("1")
+        || std::env::var_os("CI").is_some();
+    !opted_out && std::io::stderr().is_terminal()
+}
+
+/// The passive update nudge, modeled on the gh CLI / update-notifier pattern:
+/// the message shown this run comes from the *cached* previous check (so it is
+/// instant), and a background refresh updates the cache for the next run at
+/// most once per [`CHECK_TTL`].
+pub struct Nudge {
+    message: Option<String>,
+    refresh: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl Nudge {
+    pub fn start() -> Nudge {
+        if !nudge_enabled() {
+            return Nudge {
+                message: None,
+                refresh: None,
+            };
+        }
+
+        let current = current_version();
+        let cache = read_cache();
+
+        let message = cache
+            .as_ref()
+            .and_then(|c| Version::parse(&c.latest).ok())
+            .filter(|latest| *latest > current)
+            .map(|latest| {
+                format!(
+                    "A new release of orx is available: {} → {}. Run `orx update` to upgrade.",
+                    current, latest
+                )
+            });
+
+        let stale = cache
+            .as_ref()
+            .map(|c| now_unix().saturating_sub(c.checked_at) >= CHECK_TTL.as_secs())
+            .unwrap_or(true);
+        let refresh = stale.then(|| {
+            let prev_latest = cache.map(|c| c.latest);
+            tokio::spawn(async move {
+                let latest = fetch_latest(Duration::from_secs(3))
+                    .await
+                    .ok()
+                    .map(|l| l.version.to_string());
+                // On fetch failure, refresh checked_at with the old answer so
+                // errors don't cause a retry on every invocation.
+                let value = latest
+                    .or(prev_latest)
+                    .unwrap_or_else(|| current.to_string());
+                write_check_cache(&value);
+            })
+        });
+
+        Nudge { message, refresh }
+    }
+
+    /// Called after the real command finished: gives the background refresh a
+    /// short grace window (it usually finished while the command did its own
+    /// network work), then prints the nudge — stderr only, exit code untouched.
+    pub async fn finish(self) {
+        if let Some(handle) = self.refresh {
+            if tokio::time::timeout(Duration::from_millis(250), handle)
+                .await
+                .is_err()
+            {
+                // Took too long; the next stale run will try again.
+            }
+        }
+        if let Some(message) = self.message {
+            eprintln!("\n{}", message);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{exe_matches_prefix, parse_manifest};
+    use semver::Version;
+    use std::path::Path;
+
+    #[test]
+    fn parses_dist_manifest() {
+        let body = r#"{
+            "dist_version": "0.32.0",
+            "announcement_tag": "v0.1.15",
+            "announcement_is_prerelease": false,
+            "releases": [{
+                "app_name": "openresearch-cli",
+                "app_version": "0.1.15",
+                "artifacts": ["openresearch-cli-installer.sh"]
+            }]
+        }"#;
+        let latest = parse_manifest(body).unwrap();
+        assert_eq!(latest.tag, "v0.1.15");
+        assert_eq!(latest.version, Version::new(0, 1, 15));
+    }
+
+    #[test]
+    fn manifest_without_our_app_is_an_error() {
+        let body = r#"{"announcement_tag": "v1.0.0", "releases": [{"app_name": "other", "app_version": "1.0.0"}]}"#;
+        assert!(parse_manifest(body).is_err());
+    }
+
+    #[test]
+    fn semver_ordering_not_lexicographic() {
+        // The case string comparison gets wrong.
+        assert!(Version::parse("0.1.15").unwrap() > Version::parse("0.1.9").unwrap());
+    }
+
+    #[test]
+    fn exe_prefix_matching() {
+        let cases = [
+            // cargo-home layout: receipt prefix is the root, binary in bin/.
+            ("/home/u/.cargo/bin/orx", "/home/u/.cargo", true),
+            // flat layout: binary directly in the prefix.
+            ("/opt/orx/orx", "/opt/orx", true),
+            // foreign binary elsewhere on PATH.
+            ("/usr/local/bin/orx", "/home/u/.cargo", false),
+        ];
+        for (exe, prefix, want) in cases {
+            assert_eq!(
+                exe_matches_prefix(Path::new(exe), Path::new(prefix)),
+                want,
+                "exe={} prefix={}",
+                exe,
+                prefix
+            );
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds version visibility and self-update to `orx`:

- **`orx --version`** — clap's standard flag (was missing).
- **`orx version [--check] [--json]`** — prints the CLI version; `--check` compares against the latest GitHub release. `--json` (implies `--check`) emits `{"current":…,"latest":…,"updateAvailable":…}` on stdout with exit 0 either way, so agent harnesses can poll deliberately.
- **`orx update [--dry-run] [--force]`** — updates in place by downloading the release's own `openresearch-cli-installer.sh` (pinned to the release tag) and running it with `CARGO_DIST_FORCE_INSTALL_DIR` set to the receipt's install prefix. The installer owns checksum verification and the atomic rename into `~/.cargo/bin`.
- **Passive nudge** — at most one background latest-version check per 24h (cache in the config dir), printed to **stderr only on interactive terminals**, never in CI or pipes, never altering exit codes — agent invocations stay byte-identical. Opt-outs: `ORX_NO_UPDATE_CHECK`, `NO_UPDATE_NOTIFIER`, `OPENRESEARCH_CLI_DISABLE_UPDATE=1`.

## Why this design

- **Latest-version discovery avoids the GitHub REST API**: its unauthenticated cap is 60 req/h *per IP*, routinely exhausted on the datacenter/NAT IPs agents run from. Instead we fetch the `dist-manifest.json` asset cargo-dist already uploads, via the documented `releases/latest/download/` permalink — a CDN redirect with no API rate limit.
- **Same mechanism as axoupdater (what `uv self update` uses), without the dependency**: axoupdater's HTTP stack is native-tls/OpenSSL with no rustls option, which conflicts with this repo's deliberate rustls choice for the static musl builds. Re-running our own installer keeps update == fresh install (receipt, PATH handling, checksums all owned by cargo-dist).
- **The install receipt is the safety interlock**: with `install-path = "CARGO_HOME"`, a `cargo install` and the shell installer write the *same* `~/.cargo/bin/orx`. `orx update` refuses when there's no receipt (cargo-install copy), when the receipt's prefix doesn't contain the running exe, or when the receipt's version doesn't match the binary (something overwrote it) — each with a targeted message; `--force` overrides the latter two. Nix-store/Homebrew paths and unwritable bin dirs get specific refusals before any download.
- **Hardening**: exclusive flock so concurrent `orx update` runs fail fast; the installer is invoked as `sh <script>` (immune to `noexec /tmp`); replacement is an atomic rename, never an in-place overwrite (which on macOS invalidates the kernel's per-inode code-signature cache → SIGKILL).

## Testing

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build --locked`, `cargo test --locked` all pass.
- Unit tests cover manifest parsing, semver ordering (the `0.1.9` vs `0.1.15` lexicographic trap), and receipt-prefix matching (cargo-home and flat layouts).
- Smoke-tested live: `orx version --json` correctly reported `0.1.14 → 0.1.15` against the real release; `orx update --dry-run` correctly *refused* a dev-build binary that didn't match this machine's real install receipt, and `--dry-run --force` completed the full check path.

## Note for maintainers

`main`'s Cargo.toml says `0.1.14` while the latest tag is `v0.1.15` — the version-check feature compares against exactly this value, so the release flow should bump the manifest before tagging.