### PR TITLE
Release 0.1.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,7 +702,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openresearch-cli"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openresearch-cli"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 description = "OpenResearch CLI (orx) — Rust port"
 repository = "https://github.com/alphaXiv/openresearch-cli"


### PR DESCRIPTION
Bumps the version to 0.1.17 to ship `orx --version` / `orx version [--check] [--json]` / `orx update` and the passive update nudge (#2), which missed the v0.1.16 release (its tag was cut on a pre-merge commit).

Once #3 (release-on-bump automation, dispatch-releases mode — no secrets needed) is merged, **merging this PR is the release**: the bump workflow dispatches the cargo-dist release for `v0.1.17`, and the tag is created by the successful release itself. Lockfile regenerated; local build reports `orx 0.1.17`.

Merge #3 first — its merge is a guaranteed no-op dress rehearsal (v0.1.16 already exists). If this PR merges first instead, #3's own merge-push will notice 0.1.17 is unreleased and dispatch it then; order is safe either way.