### PR TITLE
Add orx skill install for agent skills directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "fd-lock"
 version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,6 +718,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "urlencoding",
  "uuid",
@@ -1145,6 +1152,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,6 @@ fd-lock = "4"
 [profile.dist]
 inherits = "release"
 lto = "thin"
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -1,12 +1,28 @@
+use std::path::{Path, PathBuf};
+
 use crate::config;
-use crate::error::{require_credentials, Result};
+use crate::error::{anyhow, require_credentials, Result};
+use crate::{SkillAgent, SkillCommand, SkillInstallArgs};
 
 // Bundled top-level overview, shipped with the CLI so `orx skill` works without
 // a round-trip. Deeper references are fetched live from the API. Embedded at
 // compile time from the repo-root SKILL.md.
 const SKILL_MD: &str = include_str!("../../SKILL.md");
 
+// Per the Agent Skills convention, the directory name is the skill's identity
+// and must match the `name:` in SKILL.md's frontmatter.
+const SKILL_DIR_NAME: &str = "openresearch-cli";
+
+// Claude Code reads its own skills tree; Codex, Cursor, and OpenCode all read
+// the cross-agent standard location (agentskills.io).
+const CLAUDE_SKILLS: &str = ".claude/skills";
+const AGENTS_SKILLS: &str = ".agents/skills";
+
 pub async fn run(args: crate::SkillArgs) -> Result<()> {
+    if let Some(SkillCommand::Install(install)) = args.command {
+        return install_skill(install).await;
+    }
+
     // With a path: fetch the canonical doc from the API (same docs the assistant
     // reads), so the schema never drifts from a hand-maintained copy.
     if let Some(path) = args.path {
@@ -36,4 +52,94 @@ pub async fn run(args: crate::SkillArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Skill directories (relative to `$HOME`) for an agent selection.
+fn install_dirs(agent: SkillAgent, all: bool) -> Vec<&'static str> {
+    if all {
+        return vec![CLAUDE_SKILLS, AGENTS_SKILLS];
+    }
+    match agent {
+        SkillAgent::Claude => vec![CLAUDE_SKILLS],
+        SkillAgent::Codex | SkillAgent::Cursor | SkillAgent::Opencode => vec![AGENTS_SKILLS],
+    }
+}
+
+/// Writes the bundled SKILL.md under `home/rel/openresearch-cli/`, creating
+/// directories as needed. Returns the file path and whether it was (re)written
+/// — false means an identical copy was already there, so re-runs are no-ops.
+async fn install_into(home: &Path, rel: &str) -> Result<(PathBuf, bool)> {
+    let dir = home.join(rel).join(SKILL_DIR_NAME);
+    let path = dir.join("SKILL.md");
+    if matches!(tokio::fs::read_to_string(&path).await, Ok(existing) if existing == SKILL_MD) {
+        return Ok((path, false));
+    }
+    tokio::fs::create_dir_all(&dir).await?;
+    tokio::fs::write(&path, SKILL_MD).await?;
+    Ok((path, true))
+}
+
+/// `orx skill install` — no login or network needed; the skill is embedded in
+/// the binary, and placing the folder is the entire installation.
+async fn install_skill(args: SkillInstallArgs) -> Result<()> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow!("could not determine home directory"))?;
+    let rels = install_dirs(args.agent, args.all);
+    for rel in &rels {
+        let (path, wrote) = install_into(&home, rel).await?;
+        if wrote {
+            println!("✓ wrote {}", path.display());
+        } else {
+            println!("✓ already up to date: {}", path.display());
+        }
+    }
+    if rels.contains(&AGENTS_SKILLS) {
+        println!("~/{AGENTS_SKILLS} is read by Codex, Cursor, and OpenCode.");
+    }
+    println!("New agent sessions discover the skill automatically; restart any open session.");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::ValueEnum;
+
+    #[test]
+    fn install_dirs_mapping() {
+        assert_eq!(install_dirs(SkillAgent::Claude, false), vec![CLAUDE_SKILLS]);
+        for agent in [SkillAgent::Codex, SkillAgent::Cursor, SkillAgent::Opencode] {
+            assert_eq!(install_dirs(agent, false), vec![AGENTS_SKILLS]);
+        }
+        assert_eq!(install_dirs(SkillAgent::Claude, true), vec![CLAUDE_SKILLS, AGENTS_SKILLS]);
+    }
+
+    #[test]
+    fn desktop_variants_are_aliases() {
+        let parse = |s| SkillAgent::from_str(s, false).unwrap();
+        assert_eq!(parse("claude-desktop"), SkillAgent::Claude);
+        assert_eq!(parse("codex-desktop"), SkillAgent::Codex);
+        assert!(SkillAgent::from_str("nope", false).is_err());
+    }
+
+    #[tokio::test]
+    async fn install_writes_then_noops() {
+        let home = tempfile::tempdir().unwrap();
+        let (path, wrote) = install_into(home.path(), CLAUDE_SKILLS).await.unwrap();
+        assert!(wrote);
+        assert_eq!(
+            path,
+            home.path().join(CLAUDE_SKILLS).join(SKILL_DIR_NAME).join("SKILL.md")
+        );
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), SKILL_MD);
+
+        // Identical content already present — second run reports up to date.
+        let (_, wrote) = install_into(home.path(), CLAUDE_SKILLS).await.unwrap();
+        assert!(!wrote);
+
+        // A stale copy (e.g. from an older binary) gets overwritten.
+        std::fs::write(&path, "old").unwrap();
+        let (_, wrote) = install_into(home.path(), CLAUDE_SKILLS).await.unwrap();
+        assert!(wrote);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), SKILL_MD);
+    }
 }

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -176,5 +176,16 @@ pub async fn run(args: crate::UpdateArgs) -> Result<()> {
     // Keep the nudge cache in sync so it doesn't fire on a stale answer.
     updates::write_check_cache(&latest.version.to_string());
     println!("✓ Updated orx {} → {}.", current, latest.version);
+
+    // The refreshed SKILL.md ships inside the *new* binary, which this (old)
+    // process can't read — so nudge instead of silently leaving stale copies.
+    if let Some(home) = dirs::home_dir() {
+        if [".claude/skills", ".agents/skills"]
+            .iter()
+            .any(|rel| home.join(rel).join("openresearch-cli").exists())
+        {
+            println!("Installed orx skills may be stale — run: orx skill install --all");
+        }
+    }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,7 @@ enum Command {
     /// Operate on one experiment node (status / run command / run / cancel).
     Exp(ExpArgs),
 
-    /// Print CLI usage for agents, or fetch a skill doc.
+    /// Print CLI usage for agents, fetch a skill doc, or install the skill.
     Skill(SkillArgs),
 
     /// Search alphaXiv literature by full-text query (no login required).
@@ -338,9 +338,41 @@ pub struct ExpRunArgs {
     pub force: bool,
 }
 
+// `install` resolves as a subcommand before the positional, so `orx skill
+// <path>` keeps working for any doc path except one literally named "install".
 #[derive(Args, Debug)]
+#[command(args_conflicts_with_subcommands = true)]
 pub struct SkillArgs {
+    #[command(subcommand)]
+    pub command: Option<SkillCommand>,
+    /// Skill doc path to fetch from the API (omit for the bundled overview).
     pub path: Option<String>,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SkillCommand {
+    /// Install the bundled skill into your agent's global skills directory.
+    Install(SkillInstallArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct SkillInstallArgs {
+    /// Which agent to install for (desktop variants are aliases).
+    #[arg(long, value_enum, default_value_t = SkillAgent::Claude)]
+    pub agent: SkillAgent,
+    /// Install for every supported agent.
+    #[arg(long, conflicts_with = "agent")]
+    pub all: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, clap::ValueEnum)]
+pub enum SkillAgent {
+    #[value(alias = "claude-desktop")]
+    Claude,
+    #[value(alias = "codex-desktop")]
+    Codex,
+    Cursor,
+    Opencode,
 }
 
 #[derive(Args, Debug)]


### PR DESCRIPTION
## Summary
- New `orx skill install [--agent claude|codex|cursor|opencode] [--all]` writes the embedded SKILL.md to the agent's **global** skills directory, so the skill works in every project:
  - `claude` (alias `claude-desktop`) → `~/.claude/skills/openresearch-cli/SKILL.md`
  - `codex` / `cursor` / `opencode` (alias `codex-desktop`) → `~/.agents/skills/openresearch-cli/SKILL.md` — the cross-agent [Agent Skills standard](https://agentskills.io) location read by Codex, Cursor, and OpenCode
- Idempotent (identical content → "already up to date"), creates dirs, needs no login or network.
- `orx skill` / `orx skill <path>` are unchanged — `install` resolves as a subcommand before the positional (`args_conflicts_with_subcommands`), so the only reserved doc name is literally `install`.
- `orx update` now prints a `run: orx skill install --all` nudge when skills are installed, since the refreshed SKILL.md ships inside the new binary.

Pairs with the openresearch.sh PR that adds an explicit skill-install step to the agent-aware connect modal — this needs to be released before that ships.

## Test plan
- `cargo test` — 3 new tests: install-dir mapping, desktop-alias parsing, write→noop→overwrite-stale idempotency (tempdir)
- `cargo clippy --all-targets` clean
- Manual against a throwaway `HOME`: `--all` writes both paths; rerun reports up to date; `--agent codex-desktop` alias parses; `--agent nope` errors with the value list; `orx skill` still prints the overview