### PR TITLE
Add Cursor to install-skills

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,7 +702,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openresearch-cli"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openresearch-cli"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2021"
 description = "OpenResearch CLI (orx) — Rust port"
 repository = "https://github.com/alphaXiv/openresearch-cli"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Run the tests with `cargo test`.
 |---|---|
 | `orx login [--api-url <url>]` | Opens your browser, authenticates, and stores a personal access token. |
 | `orx logout` | Removes the stored token. |
-| `orx install-skills [--agent claude\|codex\|opencode\|cursor\|all]` | Installs the `orx` skill shim into local coding agents (Claude Code, Codex, OpenCode, Cursor) so they auto-discover the CLI (also runs after `orx login`). |
+| `orx install-skills [--agent claude\|codex\|opencode\|cursor\|all]` | Installs the `orx` skill shim into local coding agents (Claude Code, Codex, OpenCode, Cursor) so they auto-discover the CLI (`orx login` also offers this). |
 | `orx projects [--all]` | Lists your projects, grouped by organization. `--all` includes archived. |
 | `orx compute [--gpu <id>] [--count <n>]` | Lists the GPU compute catalog, sorted by price. |
 | `orx exp status <expId>` | Shows an experiment's status, branch, parent, run command, and latest run, plus a local `git diff` recipe for what the run changed. |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Run the tests with `cargo test`.
 |---|---|
 | `orx login [--api-url <url>]` | Opens your browser, authenticates, and stores a personal access token. |
 | `orx logout` | Removes the stored token. |
-| `orx install-skills [--agent claude\|codex\|opencode\|all]` | Installs the `orx` skill shim into local coding agents (Claude Code, Codex, OpenCode) so they auto-discover the CLI (also runs after `orx login`). |
+| `orx install-skills [--agent claude\|codex\|opencode\|cursor\|all]` | Installs the `orx` skill shim into local coding agents (Claude Code, Codex, OpenCode, Cursor) so they auto-discover the CLI (also runs after `orx login`). |
 | `orx projects [--all]` | Lists your projects, grouped by organization. `--all` includes archived. |
 | `orx compute [--gpu <id>] [--count <n>]` | Lists the GPU compute catalog, sorted by price. |
 | `orx exp status <expId>` | Shows an experiment's status, branch, parent, run command, and latest run, plus a local `git diff` recipe for what the run changed. |

--- a/src/commands/install_skills.rs
+++ b/src/commands/install_skills.rs
@@ -9,8 +9,9 @@
 //!
 //! Detection is by config-home presence: `~/.claude` means Claude Code is set up,
 //! `~/.codex` means Codex is, `~/.config/opencode` means OpenCode is, `~/.cursor`
-//! means Cursor is. This command also runs best-effort after `orx login` (see
-//! `install_present_quietly`) so the typical user never invokes it by hand.
+//! means Cursor is. After `orx login`, the install is *offered* interactively
+//! (see `offer_install_after_login`) — what gets written where is listed up
+//! front, and nothing is written without a yes.
 
 use std::path::PathBuf;
 
@@ -147,22 +148,76 @@ pub async fn run(args: crate::InstallSkillsArgs) -> Result<()> {
     Ok(())
 }
 
-/// Best-effort install into every agent already present on the machine. Never
-/// fails or panics — meant to run after `orx login` as a convenience. Stays
-/// silent when an agent isn't set up (so we don't create `~/.codex` for someone
-/// who only uses Claude, and vice versa).
-pub async fn install_present_quietly() {
-    for agent in ALL {
-        if !agent.is_present() {
-            continue;
+/// A path with the home directory shortened to `~`, for prompt readability.
+fn tilde(path: &std::path::Path) -> String {
+    let s = path.to_string_lossy();
+    match dirs::home_dir() {
+        Some(home) => match path.strip_prefix(&home) {
+            Ok(rel) => format!("~/{}", rel.display()),
+            Err(_) => s.into_owned(),
+        },
+        None => s.into_owned(),
+    }
+}
+
+/// The consent prompt's body: one line per detected agent, name → target file.
+fn describe_targets(agents: &[Agent]) -> String {
+    let width = agents.iter().map(|a| a.label().len()).max().unwrap_or(0);
+    agents
+        .iter()
+        .filter_map(|a| {
+            let target = a.target()?;
+            Some(format!(
+                "  {:<width$} \u{2192} {}",
+                a.label(),
+                tilde(&target)
+            ))
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Offer (never force) the skill install after `orx login`. Transparent and
+/// consensual: lists exactly what would be written where before asking, writes
+/// nothing without a yes, and never fails the login over it. Skips entirely
+/// when stdin/stderr isn't a terminal (CI, agents, pipes) or no agent is set up
+/// on this machine.
+pub async fn offer_install_after_login() {
+    use std::io::IsTerminal;
+
+    let present: Vec<Agent> = ALL.into_iter().filter(|a| a.is_present()).collect();
+    if present.is_empty() || !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
+        return;
+    }
+
+    println!(
+        "\norx ships one agent skill: a small file teaching your coding agent to run\n\
+         `orx skill` for the live guide. It can be installed now ({} file{}) for the\n\
+         agent{} detected on this machine:",
+        present.len(),
+        if present.len() == 1 { "" } else { "s" },
+        if present.len() == 1 { "" } else { "s" },
+    );
+    println!("{}", describe_targets(&present));
+    print!("Install? [Y/n] ");
+    let _ = std::io::Write::flush(&mut std::io::stdout());
+
+    let mut answer = String::new();
+    if std::io::stdin().read_line(&mut answer).is_err() {
+        return;
+    }
+    if matches!(answer.trim().to_lowercase().as_str(), "" | "y" | "yes") {
+        for agent in present {
+            if let Ok(path) = write_shim(agent).await {
+                println!(
+                    "\u{2713} Installed {} skill \u{2192} {}",
+                    agent.label(),
+                    tilde(&path)
+                );
+            }
         }
-        if let Ok(path) = write_shim(agent).await {
-            println!(
-                "\u{2713} Installed {} skill \u{2192} {}",
-                agent.label(),
-                path.display()
-            );
-        }
+    } else {
+        println!("Skipped. You can install any time with: orx install-skills");
     }
 }
 
@@ -223,3 +278,26 @@ If any command reports `Not logged in`, ask the user to run `orx login` first.
 Research goal:
 $ARGUMENTS
 "#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn describe_targets_lists_name_and_path_per_agent() {
+        let body = describe_targets(&[Agent::Claude, Agent::Cursor]);
+        let lines: Vec<&str> = body.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("Claude Code"));
+        assert!(lines[0].contains(".claude/skills/orx/SKILL.md"));
+        assert!(lines[1].contains("Cursor"));
+        assert!(lines[1].contains(".cursor/skills/orx/SKILL.md"));
+    }
+
+    #[test]
+    fn tilde_shortens_home() {
+        let home = dirs::home_dir().unwrap();
+        assert_eq!(tilde(&home.join(".claude")), "~/.claude");
+        assert_eq!(tilde(std::path::Path::new("/etc/hosts")), "/etc/hosts");
+    }
+}

--- a/src/commands/install_skills.rs
+++ b/src/commands/install_skills.rs
@@ -8,9 +8,9 @@
 //! as that guide changes — which it does, often.
 //!
 //! Detection is by config-home presence: `~/.claude` means Claude Code is set up,
-//! `~/.codex` means Codex is, `~/.config/opencode` means OpenCode is. This command
-//! also runs best-effort after `orx login` (see `install_present_quietly`) so the
-//! typical user never invokes it by hand.
+//! `~/.codex` means Codex is, `~/.config/opencode` means OpenCode is, `~/.cursor`
+//! means Cursor is. This command also runs best-effort after `orx login` (see
+//! `install_present_quietly`) so the typical user never invokes it by hand.
 
 use std::path::PathBuf;
 
@@ -40,9 +40,10 @@ pub enum Agent {
     Claude,
     Codex,
     OpenCode,
+    Cursor,
 }
 
-const ALL: [Agent; 3] = [Agent::Claude, Agent::Codex, Agent::OpenCode];
+const ALL: [Agent; 4] = [Agent::Claude, Agent::Codex, Agent::OpenCode, Agent::Cursor];
 
 impl Agent {
     fn label(self) -> &'static str {
@@ -50,37 +51,43 @@ impl Agent {
             Agent::Claude => "Claude Code",
             Agent::Codex => "Codex",
             Agent::OpenCode => "OpenCode",
+            Agent::Cursor => "Cursor",
         }
     }
 
-    /// The agent's config home (`~/.claude`, `~/.codex`, `~/.config/opencode`).
-    /// `None` only if we can't resolve the user's home directory at all.
+    /// The agent's config home (`~/.claude`, `~/.codex`, `~/.config/opencode`,
+    /// `~/.cursor`). `None` only if we can't resolve the user's home directory
+    /// at all.
     fn home(self) -> Option<PathBuf> {
         Some(match self {
             Agent::Claude => dirs::home_dir()?.join(".claude"),
             Agent::Codex => dirs::home_dir()?.join(".codex"),
             Agent::OpenCode => xdg_config_home().join("opencode"),
+            Agent::Cursor => dirs::home_dir()?.join(".cursor"),
         })
     }
 
-    /// Where the shim file lands. Claude and OpenCode discover skills under
-    /// `skills/<name>/SKILL.md` (OpenCode also scans `~/.claude/skills`, but we
-    /// write its native path so OpenCode-only users are covered); Codex exposes
-    /// `prompts/<name>.md` as `/<name>`. Claude and Codex resolve to `/orx`;
-    /// OpenCode auto-loads the skill via its `skill` tool (no slash command).
+    /// Where the shim file lands. Claude, OpenCode, and Cursor discover skills
+    /// under `skills/<name>/SKILL.md` (OpenCode and Cursor also scan
+    /// `~/.claude/skills`, but we write their native paths so users without
+    /// Claude are covered); Codex exposes `prompts/<name>.md` as `/<name>`.
+    /// Claude and Codex resolve to `/orx`; OpenCode auto-loads the skill via its
+    /// `skill` tool (no slash command).
     fn target(self) -> Option<PathBuf> {
         let home = self.home()?;
         Some(match self {
-            Agent::Claude | Agent::OpenCode => home.join("skills").join("orx").join("SKILL.md"),
+            Agent::Claude | Agent::OpenCode | Agent::Cursor => {
+                home.join("skills").join("orx").join("SKILL.md")
+            }
             Agent::Codex => home.join("prompts").join("orx.md"),
         })
     }
 
     fn shim(self) -> &'static str {
         match self {
-            // OpenCode reads the same SKILL.md format as Claude Code (name +
-            // description frontmatter), so it shares the shim.
-            Agent::Claude | Agent::OpenCode => CLAUDE_SKILL,
+            // OpenCode and Cursor read the same SKILL.md format as Claude Code
+            // (name + description frontmatter), so they share the shim.
+            Agent::Claude | Agent::OpenCode | Agent::Cursor => CLAUDE_SKILL,
             Agent::Codex => CODEX_PROMPT,
         }
     }
@@ -109,10 +116,11 @@ pub async fn run(args: crate::InstallSkillsArgs) -> Result<()> {
         Some("claude") => vec![Agent::Claude],
         Some("codex") => vec![Agent::Codex],
         Some("opencode") => vec![Agent::OpenCode],
+        Some("cursor") => vec![Agent::Cursor],
         Some("all") | Some("both") => ALL.to_vec(),
         Some(other) => {
             return Err(anyhow!(
-                "unknown agent '{other}' (expected: claude, codex, opencode, or all)"
+                "unknown agent '{other}' (expected: claude, codex, opencode, cursor, or all)"
             ))
         }
         None => {

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -35,10 +35,10 @@ pub async fn run(args: crate::LoginArgs) -> Result<()> {
     save_credentials(&Credentials { api_url, token }).await?;
     println!("\u{2713} Logged in. Credentials saved.");
 
-    // Install the `orx` skill shim into any coding agent already set up here, so
-    // it auto-discovers how to drive the CLI. Best-effort: never fail login over
-    // it.
-    crate::commands::install_skills::install_present_quietly().await;
+    // Offer to install the `orx` skill shim into any coding agent already set up
+    // here, so it auto-discovers how to drive the CLI. Consent-gated and
+    // best-effort: writes nothing without a yes, never fails login over it.
+    crate::commands::install_skills::offer_install_after_login().await;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,7 @@ enum Command {
     /// Print CLI usage for agents, or fetch a skill doc.
     Skill(SkillArgs),
 
-    /// Install the OpenResearch skill into local coding agents (Claude Code, Codex, OpenCode).
+    /// Install the OpenResearch skill into local coding agents (Claude Code, Codex, OpenCode, Cursor).
     #[command(name = "install-skills")]
     InstallSkills(InstallSkillsArgs),
 
@@ -349,8 +349,8 @@ pub struct SkillArgs {
 
 #[derive(Args, Debug)]
 pub struct InstallSkillsArgs {
-    /// Which agent(s) to install into: `claude`, `codex`, `opencode`, or `all`.
-    /// Defaults to every agent already set up on this machine.
+    /// Which agent(s) to install into: `claude`, `codex`, `opencode`, `cursor`,
+    /// or `all`. Defaults to every agent already set up on this machine.
     #[arg(long)]
     pub agent: Option<String>,
 }


### PR DESCRIPTION
## Summary
Extends #6's `orx install-skills` with **Cursor** as a fourth agent, and makes the post-login install **consent-based**:
- Cursor shim lands at `~/.cursor/skills/orx/SKILL.md` — same Agent Skills SKILL.md format as Claude Code, so it reuses the existing `CLAUDE_SKILL` shim. Detected via `~/.cursor`, `--agent cursor` accepted, README updated.
- `orx login` no longer silently writes into agent config dirs. Interactively it now prints exactly what would be installed (file count, agent → path table, what the file does) and asks `Install? [Y/n]`; a no prints the `orx install-skills` hint and writes nothing. Non-TTY runs (CI, agents, pipes) skip the offer entirely — previously they wrote silently.
- Explicit `orx install-skills` behavior is unchanged.
- **Bumps the version to 0.1.20**, so merging dispatches the v0.1.20 release (release-on-bump).

Example prompt:
```
orx ships one agent skill: a small file teaching your coding agent to run
`orx skill` for the live guide. It can be installed now (2 files) for the
agents detected on this machine:
  Claude Code → ~/.claude/skills/orx/SKILL.md
  Cursor      → ~/.cursor/skills/orx/SKILL.md
Install? [Y/n]
```

Supersedes #7. Pairs with alphaXiv/openresearch.sh#355, whose Cursor dropdown entry needs this release.

## Test plan
- `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --locked` — green (8 tests, incl. prompt-body formatting and tilde-path tests)
- Manual with a throwaway `HOME`: `install-skills` auto-detect/explicit/error paths verified; non-TTY login path skips the prompt by construction (IsTerminal gate, same pattern as the update nudge)