### PR TITLE
feat: orx compute lists all providers/regions + DISK column

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Run the tests with `cargo test`.
 | `orx logout` | Removes the stored token. |
 | `orx install-skills [--agent claude\|codex\|opencode\|cursor\|all]` | Installs the `orx` skill shim into local coding agents (Claude Code, Codex, OpenCode, Cursor) so they auto-discover the CLI (`orx login` also offers this). |
 | `orx projects [--all]` | Lists your projects, grouped by organization. `--all` includes archived. |
-| `orx compute [--gpu <id>] [--count <n>] \| --cpu]` | Lists the GPU compute catalog, or CPU-only offers with `--cpu`, sorted by price. |
+| `orx compute [--gpu <id>] [--count <n>] [--provider <name>] \| --cpu]` | Lists the GPU compute catalog across all providers and regions, or CPU-only offers with `--cpu`, sorted by price. |
 | `orx exp status <expId>` | Shows an experiment's status, branch, parent, run command, and latest run, plus a local `git diff` recipe for what the run changed. |
 | `orx exp cmd <expId> [--set <command>]` | Views or sets the experiment's run command. |
 | `orx exp run <expId> (--gpu <id> [--count <n>] [--disk <gb>] \| --cpu <flavor> [--vcpus <n>] \| --sandbox <id>)` | Launches a run on new GPU, new CPU-only, or existing compute. |

--- a/SKILL.md
+++ b/SKILL.md
@@ -88,7 +88,7 @@ orx logout         # remove the stored token
 | `orx create-project <orgId> --name "<n>" [--repo <owner/repo>]` | Create a project **and its baseline (root node)**: bound to a GitHub repo, or on a fresh blank repo when `--repo` is omitted. See below. |
 | `orx project edit <projectId> [--name "<n>"] [--description "<text>" \| --description-stdin]` | Edit a project's name and/or description (pass at least one). `--description-stdin` overwrites the description from stdin (long markdown). |
 | `orx create-experiment <projectId> --title "<t>" [...]` | Add an experiment node; prints its git branch. See below. |
-| `orx compute [--gpu <id>] [--count <n>] \| --cpu]` | List the GPU compute catalog, or CPU-only offers with `--cpu` (price-sorted). See below. |
+| `orx compute [--gpu <id>] [--count <n>] [--provider <name>] \| --cpu]` | List the GPU compute catalog across all providers, or CPU-only offers with `--cpu` (price-sorted). See below. |
 | `orx exp status/cmd/run/cancel/wait <expId>` | Inspect, run, cancel, and wait on a single experiment node. `status` prints the node's branch, its parent's branch, the latest run's full commit SHA, and a ready-to-paste local `git diff` recipe. See below. |
 | `orx exp desc <expId> [--set "<text>" \| --stdin]` | Read or overwrite the experiment's description (free-form notes). See below. |
 | `orx report upload <projectId> <folder> [--title "<t>"]` | Upload a report folder (`report.md` + `images/`) to the project. Appears on the project page and its public view. `orx report list <projectId>` lists them. See below. |
@@ -357,8 +357,9 @@ you launch.
 orx exp status <expId>                 # status, branch, parent, run command, latest run + commit, local diff recipe
 orx exp cmd <expId>                    # print the current run command
 orx exp cmd <baseId> --set "bash run.sh"   # set it ONCE on the baseline; children inherit it
-orx compute                            # browse GPU offers (price-sorted)
-orx compute --gpu H100_SXM --count 1   # filter the catalog
+orx compute                            # browse GPU offers across all providers (price-sorted)
+orx compute --gpu H100_SXM --count 1   # filter by gpu / count
+orx compute --provider vast            # filter by provider
 orx compute --cpu                      # browse CPU-only offers (price-sorted)
 orx exp run <expId> --gpu H100_SXM --count 1 [--disk 100]     # launch on a NEW GPU instance
 orx exp run <expId> --cpu cpu5c --vcpus 8                 # launch on a NEW CPU-only instance
@@ -383,7 +384,8 @@ Rules and notes:
 - **Pick compute with exactly one of `--gpu`, `--cpu`, or `--sandbox`.** With
   `--gpu`, `--count` defaults to `1` and `--disk` to `100` (GB). New instances are
   **RunPod-only** — the server picks the cheapest matching RunPod offer for the
-  chosen (gpu, count); browse valid gpu ids and prices with `orx compute`.
+  chosen (gpu, count); browse valid gpu ids and prices with `orx compute` (which
+  lists every provider, not only RunPod).
 - **GPU ids are exact enum strings, not family names.** `--gpu H100` is invalid —
   the variant suffix is part of the id (`H100_SXM`, `H100_PCIE`, `A100_SXM_80GB`,
   `RTX_4090`, …). Use the exact `GPU` column value from `orx compute`; run it

--- a/src/client.rs
+++ b/src/client.rs
@@ -93,6 +93,21 @@ pub struct Run {
     pub duration_seconds: i64,
 }
 
+/// Disk pricing for an offer. Mirrors the backend `zDisk` discriminated union,
+/// keyed on the `sizable` bool: when `true`, `per_gb_hour` is set and the disk
+/// bills per GB/hour; when `false`, `included_gb` is set and the offer bundles a
+/// fixed capacity. Modeled as a flat struct with optional payloads rather than an
+/// enum because serde's tagged enums can't key on a bool discriminator, and an
+/// untagged enum would not apply the container's `camelCase` rename to variant
+/// fields. The unused payload is simply `None`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Disk {
+    pub sizable: bool,
+    pub per_gb_hour: Option<f64>,
+    pub included_gb: Option<f64>,
+}
+
 /// A single GPU offer from the compute catalog (`GET /compute/catalog`).
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -106,8 +121,7 @@ pub struct GpuOffer {
     /// System RAM in GB.
     pub ram_gb: f64,
     pub price_per_hour: f64,
-    /// Disk storage rate while running, USD per GB per hour.
-    pub disk_per_gb_hour: f64,
+    pub disk: Disk,
     pub region: Option<String>,
 }
 
@@ -130,8 +144,7 @@ pub struct CpuOffer {
     /// System RAM in GB.
     pub ram_gb: f64,
     pub price_per_hour: f64,
-    /// Disk storage rate while running, USD per GB per hour.
-    pub disk_per_gb_hour: f64,
+    pub disk: Disk,
     pub region: Option<String>,
 }
 
@@ -1041,4 +1054,85 @@ pub async fn fetch_paper_markdown(kind: &str, paper_id: &str) -> Result<Option<S
         ));
     }
     Ok(Some(res.text().await?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ListCatalog, ListCpuCatalog};
+
+    /// The GPU catalog wire format carries `disk` as a discriminated union and an
+    /// optional `region`, plus `bandwidth*` fields the CLI ignores. Pin that we
+    /// decode both disk shapes, treat a missing region as `None`, and tolerate the
+    /// extra fields — this is exactly the drift that previously broke `orx compute`.
+    #[test]
+    fn deserializes_gpu_catalog_with_disk_union_and_optional_region() {
+        let json = r#"{
+            "offers": [
+                {
+                    "provider": "runpod",
+                    "offerId": "a",
+                    "gpu": "H100_SXM",
+                    "gpuCount": 1,
+                    "vcpus": 16,
+                    "ramGb": 188,
+                    "pricePerHour": 2.5,
+                    "disk": { "sizable": true, "perGbHour": 0.0001 },
+                    "bandwidthInPerGb": 0,
+                    "bandwidthOutPerGb": 0,
+                    "region": "US_CA"
+                },
+                {
+                    "provider": "lambda",
+                    "offerId": "b",
+                    "gpu": "A100_SXM_80GB",
+                    "gpuCount": 8,
+                    "vcpus": 124,
+                    "ramGb": 1800,
+                    "pricePerHour": 14.0,
+                    "disk": { "sizable": false, "includedGb": 1024 },
+                    "bandwidthInPerGb": 0,
+                    "bandwidthOutPerGb": 0
+                }
+            ]
+        }"#;
+
+        let parsed: ListCatalog = serde_json::from_str(json).expect("should deserialize");
+        assert_eq!(parsed.offers.len(), 2);
+
+        let sizable = &parsed.offers[0];
+        assert_eq!(sizable.region.as_deref(), Some("US_CA"));
+        assert!(sizable.disk.sizable);
+        assert_eq!(sizable.disk.per_gb_hour, Some(0.0001));
+        assert_eq!(sizable.disk.included_gb, None);
+
+        let fixed = &parsed.offers[1];
+        // `region` absent on the wire must decode to `None`.
+        assert_eq!(fixed.region, None);
+        assert!(!fixed.disk.sizable);
+        assert_eq!(fixed.disk.included_gb, Some(1024.0));
+        assert_eq!(fixed.disk.per_gb_hour, None);
+    }
+
+    /// CPU offers share the same `disk` union; pin that the CPU catalog decodes too.
+    #[test]
+    fn deserializes_cpu_catalog_with_disk_union() {
+        let json = r#"{
+            "offers": [
+                {
+                    "provider": "runpod",
+                    "offerId": "c",
+                    "cpuFlavor": "cpu5c",
+                    "vcpus": 4,
+                    "ramGb": 16,
+                    "pricePerHour": 0.1,
+                    "disk": { "sizable": true, "perGbHour": 0.0001 }
+                }
+            ]
+        }"#;
+
+        let parsed: ListCpuCatalog = serde_json::from_str(json).expect("should deserialize");
+        assert_eq!(parsed.offers.len(), 1);
+        assert!(parsed.offers[0].disk.sizable);
+        assert_eq!(parsed.offers[0].disk.per_gb_hour, Some(0.0001));
+    }
 }

--- a/src/commands/compute.rs
+++ b/src/commands/compute.rs
@@ -1,13 +1,15 @@
 //! The `compute` command. Lists the GPU offer catalog as a price-sorted table,
 //! or the CPU-only catalog with `--cpu`.
 //!
-//! The catalog endpoint spans every provider, but experiment runs launched on a
-//! *new* instance (`orx exp run --gpu ...`) are RunPod-only — the server
-//! resolves the cheapest matching RunPod offer for the chosen (gpu, count). So
-//! this command filters to RunPod offers: everything it lists is launchable.
-//! CPU offers are RunPod-only to begin with, so no filtering is needed there.
+//! The GPU catalog endpoint (`GET /compute/catalog`) spans every configured
+//! provider and region; this command lists all of them, sorted by price
+//! ascending (the order the API returns), and can be narrowed with `--gpu`,
+//! `--count`, and `--provider`. Note that experiment runs launched on a *new*
+//! instance (`orx exp run --gpu ...`) are still RunPod-only, so an offer from
+//! another provider shown here is browsable but not directly launchable as a new
+//! instance. CPU offers (`--cpu`) are RunPod-only to begin with.
 
-use crate::client::{list_catalog, list_cpu_catalog};
+use crate::client::{list_catalog, list_cpu_catalog, Disk};
 use crate::error::{require_credentials, Result};
 use crate::output::print_table;
 
@@ -25,14 +27,17 @@ pub async fn run(args: crate::ComputeArgs) -> Result<()> {
     // The API already returns offers sorted by price ascending; keep that order.
     let filtered: Vec<_> = offers
         .into_iter()
-        // Runs only launch on RunPod (see module docs); hide unlaunchable offers.
-        .filter(|o| o.provider == "runpod")
         .filter(|o| {
             args.gpu
                 .as_ref()
                 .is_none_or(|g| o.gpu.eq_ignore_ascii_case(g))
         })
         .filter(|o| args.count.is_none_or(|c| o.gpu_count == c))
+        .filter(|o| {
+            args.provider
+                .as_ref()
+                .is_none_or(|p| o.provider.eq_ignore_ascii_case(p))
+        })
         .collect();
 
     if filtered.is_empty() {
@@ -47,6 +52,7 @@ pub async fn run(args: crate::ComputeArgs) -> Result<()> {
                 o.gpu.clone(),
                 o.gpu_count.to_string(),
                 format!("${:.2}", o.price_per_hour),
+                fmt_disk(&o.disk),
                 format!("{:.0}", o.vcpus),
                 format!("{:.0}", o.ram_gb),
                 o.region.clone().unwrap_or_else(|| "—".to_string()),
@@ -57,12 +63,24 @@ pub async fn run(args: crate::ComputeArgs) -> Result<()> {
 
     print_table(
         &[
-            "GPU", "COUNT", "$/HR", "VCPUS", "RAM(GB)", "REGION", "PROVIDER",
+            "GPU", "COUNT", "$/HR", "DISK", "VCPUS", "RAM(GB)", "REGION", "PROVIDER",
         ],
         &rows,
     );
 
     Ok(())
+}
+
+/// Formats an offer's disk pricing for the `DISK` column: sizable offers show a
+/// per-GB/hour rate, fixed offers show the bundled capacity. Falls back to `—`
+/// if the expected payload is missing for the given `sizable` flag.
+fn fmt_disk(disk: &Disk) -> String {
+    let value = if disk.sizable {
+        disk.per_gb_hour.map(|r| format!("${:.4}/GB·hr", r))
+    } else {
+        disk.included_gb.map(|gb| format!("{:.0}GB incl", gb))
+    };
+    value.unwrap_or_else(|| "—".to_string())
 }
 
 /// Lists the CPU-only offer catalog as a price-sorted table. Launch one with
@@ -82,6 +100,7 @@ async fn run_cpu(creds: &crate::config::Credentials) -> Result<()> {
                 o.cpu_flavor.clone(),
                 format!("{:.0}", o.vcpus),
                 format!("${:.2}", o.price_per_hour),
+                fmt_disk(&o.disk),
                 format!("{:.0}", o.ram_gb),
                 o.region.clone().unwrap_or_else(|| "—".to_string()),
                 o.provider.clone(),
@@ -90,7 +109,9 @@ async fn run_cpu(creds: &crate::config::Credentials) -> Result<()> {
         .collect();
 
     print_table(
-        &["FLAVOR", "VCPUS", "$/HR", "RAM(GB)", "REGION", "PROVIDER"],
+        &[
+            "FLAVOR", "VCPUS", "$/HR", "DISK", "RAM(GB)", "REGION", "PROVIDER",
+        ],
         &rows,
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -295,6 +295,9 @@ pub struct ComputeArgs {
     /// Filter to a specific GPU count per instance. GPU mode only.
     #[arg(long)]
     pub count: Option<i64>,
+    /// Filter to one provider (e.g. `runpod`, `vast`, `lambda`). Case-insensitive. GPU mode only.
+    #[arg(long)]
+    pub provider: Option<String>,
 }
 
 #[derive(Args, Debug)]


### PR DESCRIPTION
## What

`orx compute` now lists **every GPU across all providers and regions**, adds a `--provider` filter, and shows a new **DISK** column.

## Why

The backend `GET /compute/catalog` wire format changed and the CLI was out of sync:

- Each offer's flat `diskPerGbHour` became a nested `disk` **discriminated union** (`{sizable:true, perGbHour}` | `{sizable:false, includedGb}`).
- `region` became optional; new `bandwidthInPerGb`/`bandwidthOutPerGb` fields were added.

Because the client decodes with strict serde, the now-missing `disk_per_gb_hour` field made **`orx compute` (and `orx compute --cpu`) fail at JSON decode**. So this is a fix as much as a feature.

## Changes

- **`client.rs`** — add a `Disk` struct mirroring the backend `zDisk` union (keyed on the `sizable` bool, with optional payloads), replacing `disk_per_gb_hour` on both `GpuOffer` and `CpuOffer`. Two round-trip tests pin both disk shapes, a missing `region`, and the ignored `bandwidth*` fields.
- **`compute.rs`** — remove the RunPod-only filter; add a case-insensitive `--provider` filter; add a **DISK** column to both the GPU and CPU tables; rewrite the module doc.
- **`main.rs`** — add the `--provider` flag to `ComputeArgs`.
- **`README.md` / `SKILL.md`** — document the all-providers behavior and `--provider`. The "new instances are RunPod-only" note for `orx exp run` is kept (still true server-side); docs clarify `orx compute` now browses all providers regardless.

> Note: a bool-discriminated union can't be modeled as a serde `untagged` enum here — container `rename_all` doesn't rename struct-variant fields and tagged enums can't key on a bool. Hence the flat-struct `Disk`.

## Verification

- CI trio passes locally: `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --locked` (10/10, incl. 2 new catalog tests).
- Smoke-tested against the live API: `orx compute` now lists runpod/vast/vultr across many regions; DISK renders both `$0.0002/GB·hr` and `90GB incl`; region-less offers show `—`; `--provider`/`--gpu`/`--count`/`--cpu` all filter correctly.