### PR TITLE
chore: bump version to 0.1.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,7 +702,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openresearch-cli"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openresearch-cli"
-version = "0.1.25"
+version = "0.1.26"
 edition = "2021"
 description = "OpenResearch CLI (orx) — Rust port"
 repository = "https://github.com/alphaXiv/openresearch-cli"


### PR DESCRIPTION
Bumps the crate version `0.1.25 → 0.1.26` so the multi-provider `orx compute` from #15 ships in a released version.

#15 (all providers/regions + `DISK` column + `--provider` filter, plus the catalog-deserialization fix) merged without a version bump, so it isn't in a tagged release yet. Merging this PR cuts tag **v0.1.26** via the tag-on-bump release flow.

## Changes
- `Cargo.toml`: `version = "0.1.26"`
- `Cargo.lock`: regenerated (the `openresearch-cli` entry → `0.1.26`), so `--locked` release builds and the "version sanity" CI check pass.

No code changes.