### PR TITLE
feat: provider-pluggable compute (--provider on exp run + orx instance create)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,7 +702,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openresearch-cli"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openresearch-cli"
-version = "0.1.28"
+version = "0.1.29"
 edition = "2021"
 description = "OpenResearch CLI (orx) — Rust port"
 repository = "https://github.com/alphaXiv/openresearch-cli"

--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ Run the tests with `cargo test`.
 | `orx install-skills [--agent claude\|codex\|opencode\|cursor\|all]` | Installs the `orx` skill shim into local coding agents (Claude Code, Codex, OpenCode, Cursor) so they auto-discover the CLI (`orx login` also offers this). |
 | `orx projects [--all]` | Lists your projects, grouped by organization. `--all` includes archived. |
 | `orx compute [--gpu <id>] [--count <n>] [--provider <name>] \| --cpu]` | Lists the GPU compute catalog across all providers and regions, or CPU-only offers with `--cpu`, sorted by price. |
+| `orx instance create <orgId> (--gpu <id> [--count <n>] [--disk <gb>] [--provider <name>] \| --cpu <flavor> [--vcpus <n>])` | Spins up a standalone instance in an organization (not tied to an experiment), like the dashboard's "Spin up". |
 | `orx exp status <expId>` | Shows an experiment's status, branch, parent, run command, and latest run, plus a local `git diff` recipe for what the run changed. |
 | `orx exp cmd <expId> [--set <command>]` | Views or sets the experiment's run command. |
-| `orx exp run <expId> (--gpu <id> [--count <n>] [--disk <gb>] \| --cpu <flavor> [--vcpus <n>] \| --sandbox <id>)` | Launches a run on new GPU, new CPU-only, or existing compute. |
+| `orx exp run <expId> (--gpu <id> [--count <n>] [--disk <gb>] [--provider <name>] \| --cpu <flavor> [--vcpus <n>] \| --sandbox <id>)` | Launches a run on new GPU, new CPU-only, or existing compute. |
 | `orx exp cancel <expId>` | Cancels the in-flight run. |
 | `orx lit "<query>" [--limit <n>] [--json]` | Full-text search alphaXiv's paper corpus (no login required). |
 | `orx paper <id\|url> [--full]` | Fetch a paper's machine-readable report, or its full text with `--full`. |

--- a/SKILL.md
+++ b/SKILL.md
@@ -94,6 +94,7 @@ orx logout         # remove the stored token
 | `orx project edit <projectId> [--name "<n>"] [--description "<text>" \| --description-stdin]` | Edit a project's name and/or description (pass at least one). `--description-stdin` overwrites the description from stdin (long markdown). |
 | `orx create-experiment <projectId> --title "<t>" [...]` | Add an experiment node; prints its git branch. See below. |
 | `orx compute [--gpu <id>] [--count <n>] [--provider <name>] \| --cpu]` | List the GPU compute catalog across all providers, or CPU-only offers with `--cpu` (price-sorted). See below. |
+| `orx instance create <orgId> (--gpu <id> [--count <n>] [--disk <gb>] [--provider <name>] \| --cpu <flavor> [--vcpus <n>])` | Spin up a standalone instance in an org (not tied to an experiment), like the dashboard's "Spin up". See below. |
 | `orx exp status/cmd/run/cancel/wait <expId>` | Inspect, run, cancel, and wait on a single experiment node. `status` prints the node's branch, its parent's branch, the latest run's full commit SHA, and a ready-to-paste local `git diff` recipe. See below. |
 | `orx exp desc <expId> [--set "<text>" \| --stdin]` | Read or overwrite the experiment's description (free-form notes). See below. |
 | `orx report upload <projectId> <folder> [--title "<t>"]` | Upload a report folder (`report.md` + `images/`) to the project. Appears on the project page and its public view. `orx report list <projectId>` lists them; `orx report show <projectId> <reportId\|slug>` prints a report's markdown to stdout (works on any public project). See below. |
@@ -432,7 +433,8 @@ orx compute                            # browse GPU offers across all providers 
 orx compute --gpu H100_SXM --count 1   # filter by gpu / count
 orx compute --provider vast            # filter by provider
 orx compute --cpu                      # browse CPU-only offers (price-sorted)
-orx exp run <expId> --gpu H100_SXM --count 1 [--disk 100]     # launch on a NEW GPU instance
+orx exp run <expId> --gpu H100_SXM --count 1 [--disk 100]     # launch on a NEW GPU instance (RunPod)
+orx exp run <expId> --gpu H100_SXM --provider vast       # launch on another provider's GPU
 orx exp run <expId> --cpu cpu5c --vcpus 8                 # launch on a NEW CPU-only instance
 orx exp run <expId> --sandbox <sandboxId>                 # launch on an EXISTING node
 orx exp cancel <expId>                 # cancel the in-flight run
@@ -453,10 +455,11 @@ Rules and notes:
   parent** (the tell-tale of "queued before pushing") — push and retry, or pass
   `--force` to run the unchanged code deliberately.
 - **Pick compute with exactly one of `--gpu`, `--cpu`, or `--sandbox`.** With
-  `--gpu`, `--count` defaults to `1` and `--disk` to `100` (GB). New instances are
-  **RunPod-only** — the server picks the cheapest matching RunPod offer for the
-  chosen (gpu, count); browse valid gpu ids and prices with `orx compute` (which
-  lists every provider, not only RunPod).
+  `--gpu`, `--count` defaults to `1` and `--disk` to `100` (GB). A new GPU
+  instance defaults to **RunPod** (the cheapest matching RunPod offer for the
+  chosen gpu/count); pass `--provider <name>` to launch from another provider
+  shown in `orx compute` (e.g. `vast`, `lambda`). New CPU instances are
+  RunPod-only. Browse valid gpu ids, providers, and prices with `orx compute`.
 - **GPU ids are exact enum strings, not family names.** `--gpu H100` is invalid —
   the variant suffix is part of the id (`H100_SXM`, `H100_PCIE`, `A100_SXM_80GB`,
   `RTX_4090`, …). Use the exact `GPU` column value from `orx compute`; run it
@@ -469,6 +472,27 @@ Rules and notes:
 - `orx exp run` **queues** the run and returns immediately — it does not wait.
   Follow progress with `orx runs <projectId>` and `orx logs <runId>`, or block
   with `orx exp wait` (below).
+
+## Spinning up a standalone instance — `orx instance create`
+
+Provision a persistent instance in an **organization**, not tied to any
+experiment — the CLI equivalent of the dashboard's org "Spin up" panel. Use this
+for ad-hoc/manual compute (you SSH in yourself); experiment runs use `orx exp run`
+instead.
+
+```sh
+orx instance create <orgId> --gpu H100_SXM --count 1 [--disk 100]   # GPU box (cheapest provider)
+orx instance create <orgId> --gpu H100_SXM --provider runpod        # pin a provider
+orx instance create <orgId> --cpu cpu5g --vcpus 8                    # CPU-only box
+```
+
+- `<orgId>` comes from `orx projects` (the `org:` line). The flags mirror
+  `orx exp run`: exactly one of `--gpu` or `--cpu`; `--count`/`--disk` apply to
+  `--gpu`, `--vcpus` to `--cpu`.
+- Unlike `orx exp run`, omitting `--provider` picks the **cheapest** matching
+  offer across all providers; pass `--provider <name>` to pin one.
+- The box provisions asynchronously — the command prints its id and current
+  status; its SSH host appears once it's online.
 
 ## Waiting on runs — `orx exp wait`
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -556,6 +556,10 @@ pub enum RunTarget {
         gpu_count: i64,
         #[serde(rename = "diskGb")]
         disk_gb: i64,
+        /// Single lowercase word — same under camelCase, so no rename needed.
+        /// Omitted from the payload when `None`.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        provider: Option<String>,
     },
     /// Provision a fresh CPU-only instance.
     #[serde(rename = "new-cpu")]
@@ -573,6 +577,74 @@ struct RunBody {
     /// Bypass the server's "branch unchanged vs parent" guard. Omitted when false.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     force: bool,
+}
+
+/// The `target` of a standalone instance (`POST /sandboxes`). Mirrors
+/// `RunTarget`'s `New`/`NewCpu` variants, minus `Existing` — a standalone box is
+/// always freshly provisioned, never an existing-sandbox reuse. Kept separate
+/// from `RunTarget` because the two hit different endpoints whose contracts may
+/// diverge.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SandboxTarget {
+    /// Provision a fresh GPU instance.
+    New {
+        gpu: String,
+        #[serde(rename = "gpuCount")]
+        gpu_count: i64,
+        #[serde(rename = "diskGb")]
+        disk_gb: i64,
+        /// Single lowercase word — same under camelCase, so no rename needed.
+        /// Omitted from the payload when `None`.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        provider: Option<String>,
+    },
+    /// Provision a fresh CPU-only instance.
+    #[serde(rename = "new-cpu")]
+    NewCpu {
+        #[serde(rename = "cpuFlavor")]
+        cpu_flavor: String,
+        #[serde(rename = "vcpuCount")]
+        vcpu_count: i64,
+    },
+}
+
+/// Body of `POST /sandboxes`. `projectId` is intentionally omitted — the server
+/// rejects it for `new`/`new-cpu` (those are org-level standalone only).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateSandboxBody {
+    pub organization_id: String,
+    pub target: SandboxTarget,
+}
+
+/// A sandbox as returned by `POST /sandboxes`. Mirrors the API's `zSandbox`;
+/// fields are nullable while a hosted box is still provisioning.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Sandbox {
+    pub id: String,
+    pub organization_id: String,
+    pub project_id: Option<String>,
+    pub ssh_hostname: Option<String>,
+    pub ssh_port: Option<i64>,
+    pub ssh_username: Option<String>,
+    pub status: String,
+    pub machine_type: String,
+    pub created_by: Option<String>,
+    pub updated_at: String,
+    pub provision_warnings: Option<String>,
+    pub provider_name: Option<String>,
+    pub provider_instance_id: Option<String>,
+    pub price_per_hour: Option<f64>,
+    pub gpu: Option<String>,
+    pub gpu_count: Option<i64>,
+    pub vcpu_count: Option<i64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SandboxEnvelope {
+    pub sandbox: Sandbox,
 }
 
 // ---------------------------------------------------------------------------
@@ -900,6 +972,15 @@ pub async fn start_experiment_run(
     api_post(creds, &format!("/experiments/{}/run", exp_id), body).await
 }
 
+/// Spin up a standalone instance in an org (no experiment) — `POST /sandboxes`.
+pub async fn create_sandbox(
+    creds: &Credentials,
+    body: &CreateSandboxBody,
+) -> Result<SandboxEnvelope> {
+    let body = serde_json::to_value(body)?;
+    api_post(creds, "/sandboxes", body).await
+}
+
 pub async fn cancel_experiment_run(creds: &Credentials, exp_id: &str) -> Result<()> {
     request_no_content(
         creds,
@@ -1104,7 +1185,11 @@ pub async fn fetch_paper_markdown(kind: &str, paper_id: &str) -> Result<Option<S
 
 #[cfg(test)]
 mod tests {
-    use super::{ListCatalog, ListCpuCatalog};
+    use super::{
+        CreateSandboxBody, ListCatalog, ListCpuCatalog, RunBody, RunTarget, SandboxEnvelope,
+        SandboxTarget,
+    };
+    use serde_json::json;
 
     /// The GPU catalog wire format carries `disk` as a discriminated union and an
     /// optional `region`, plus `bandwidth*` fields the CLI ignores. Pin that we
@@ -1180,5 +1265,165 @@ mod tests {
         assert_eq!(parsed.offers.len(), 1);
         assert!(parsed.offers[0].disk.sizable);
         assert_eq!(parsed.offers[0].disk.per_gb_hour, Some(0.0001));
+    }
+
+    /// The `new` GPU run target serializes with the discriminant and camelCase
+    /// keys the API expects, including `provider` when set.
+    #[test]
+    fn serializes_run_target_new_with_provider() {
+        let target = RunTarget::New {
+            gpu: "H100_SXM".into(),
+            gpu_count: 1,
+            disk_gb: 100,
+            provider: Some("runpod".into()),
+        };
+        assert_eq!(
+            serde_json::to_value(&target).unwrap(),
+            json!({"type": "new", "gpu": "H100_SXM", "gpuCount": 1, "diskGb": 100, "provider": "runpod"}),
+        );
+    }
+
+    /// A `None` provider must be omitted from the payload entirely (so the server
+    /// falls back to its own default), not sent as `null`.
+    #[test]
+    fn serializes_run_target_new_without_provider() {
+        let target = RunTarget::New {
+            gpu: "H100_SXM".into(),
+            gpu_count: 2,
+            disk_gb: 200,
+            provider: None,
+        };
+        let value = serde_json::to_value(&target).unwrap();
+        assert_eq!(
+            value,
+            json!({"type": "new", "gpu": "H100_SXM", "gpuCount": 2, "diskGb": 200}),
+        );
+        assert!(value.get("provider").is_none());
+    }
+
+    /// `force` is omitted when false and present when true.
+    #[test]
+    fn serializes_run_body_force_flag() {
+        let target = RunTarget::New {
+            gpu: "H100_SXM".into(),
+            gpu_count: 1,
+            disk_gb: 100,
+            provider: Some("vast".into()),
+        };
+        let with_force = serde_json::to_value(RunBody {
+            target: target.clone(),
+            force: true,
+        })
+        .unwrap();
+        assert_eq!(with_force.get("force"), Some(&json!(true)));
+
+        let without_force = serde_json::to_value(RunBody {
+            target,
+            force: false,
+        })
+        .unwrap();
+        assert!(without_force.get("force").is_none());
+    }
+
+    /// The standalone GPU sandbox target mirrors the run target's wire shape.
+    #[test]
+    fn serializes_sandbox_target_new() {
+        let target = SandboxTarget::New {
+            gpu: "H100_SXM".into(),
+            gpu_count: 2,
+            disk_gb: 100,
+            provider: Some("vast".into()),
+        };
+        assert_eq!(
+            serde_json::to_value(&target).unwrap(),
+            json!({"type": "new", "gpu": "H100_SXM", "gpuCount": 2, "diskGb": 100, "provider": "vast"}),
+        );
+    }
+
+    /// Omitting the provider must drop the key entirely — that's what lets the
+    /// server pick the cheapest offer across providers for `instance create`.
+    #[test]
+    fn serializes_sandbox_target_new_without_provider() {
+        let target = SandboxTarget::New {
+            gpu: "H100_SXM".into(),
+            gpu_count: 1,
+            disk_gb: 100,
+            provider: None,
+        };
+        let value = serde_json::to_value(&target).unwrap();
+        assert_eq!(
+            value,
+            json!({"type": "new", "gpu": "H100_SXM", "gpuCount": 1, "diskGb": 100}),
+        );
+        assert!(value.get("provider").is_none());
+    }
+
+    /// The CPU sandbox target uses the `new-cpu` discriminant and camelCase keys.
+    #[test]
+    fn serializes_sandbox_target_new_cpu() {
+        let target = SandboxTarget::NewCpu {
+            cpu_flavor: "cpu5g".into(),
+            vcpu_count: 8,
+        };
+        assert_eq!(
+            serde_json::to_value(&target).unwrap(),
+            json!({"type": "new-cpu", "cpuFlavor": "cpu5g", "vcpuCount": 8}),
+        );
+    }
+
+    /// The create-sandbox body sends `organizationId` and never a `projectId`
+    /// (the server rejects a project-scoped `new`/`new-cpu`).
+    #[test]
+    fn serializes_create_sandbox_body_without_project() {
+        let body = CreateSandboxBody {
+            organization_id: "org_123".into(),
+            target: SandboxTarget::NewCpu {
+                cpu_flavor: "cpu5c".into(),
+                vcpu_count: 2,
+            },
+        };
+        let value = serde_json::to_value(&body).unwrap();
+        assert_eq!(value.get("organizationId"), Some(&json!("org_123")));
+        assert!(value.get("projectId").is_none());
+    }
+
+    /// `POST /sandboxes` returns a freshly-provisioning box: ssh fields are still
+    /// `null` while the GPU/provider/price fields are already populated from the
+    /// offer. Pin that we decode that shape (camelCase keys, nulls → `None`).
+    #[test]
+    fn deserializes_sandbox_envelope_while_provisioning() {
+        let json = r#"{
+            "sandbox": {
+                "id": "sb_1",
+                "organizationId": "org_1",
+                "projectId": null,
+                "sshHostname": null,
+                "sshPort": null,
+                "sshUsername": null,
+                "status": "provisioning",
+                "machineType": "persistent",
+                "createdBy": "user_1",
+                "updatedAt": "2026-06-18T00:00:00Z",
+                "provisionWarnings": null,
+                "providerName": "runpod",
+                "providerInstanceId": null,
+                "pricePerHour": 2.5,
+                "gpu": "H100_SXM",
+                "gpuCount": 1,
+                "vcpuCount": null
+            }
+        }"#;
+
+        let parsed: SandboxEnvelope = serde_json::from_str(json).expect("should deserialize");
+        let sb = parsed.sandbox;
+        assert_eq!(sb.id, "sb_1");
+        assert_eq!(sb.status, "provisioning");
+        assert_eq!(sb.project_id, None);
+        assert_eq!(sb.ssh_hostname, None);
+        assert_eq!(sb.provider_name.as_deref(), Some("runpod"));
+        assert_eq!(sb.gpu.as_deref(), Some("H100_SXM"));
+        assert_eq!(sb.gpu_count, Some(1));
+        assert_eq!(sb.vcpu_count, None);
+        assert_eq!(sb.price_per_hour, Some(2.5));
     }
 }

--- a/src/commands/compute.rs
+++ b/src/commands/compute.rs
@@ -4,10 +4,9 @@
 //! The GPU catalog endpoint (`GET /compute/catalog`) spans every configured
 //! provider and region; this command lists all of them, sorted by price
 //! ascending (the order the API returns), and can be narrowed with `--gpu`,
-//! `--count`, and `--provider`. Note that experiment runs launched on a *new*
-//! instance (`orx exp run --gpu ...`) are still RunPod-only, so an offer from
-//! another provider shown here is browsable but not directly launchable as a new
-//! instance. CPU offers (`--cpu`) are RunPod-only to begin with.
+//! `--count`, and `--provider`. Any provider shown here is launchable as a new
+//! instance via `orx exp run --gpu ... --provider ...` or `orx instance create`.
+//! CPU offers (`--cpu`) are RunPod-only.
 
 use crate::client::{list_catalog, list_cpu_catalog, Disk};
 use crate::error::{require_credentials, Result};

--- a/src/commands/exp.rs
+++ b/src/commands/exp.rs
@@ -380,6 +380,11 @@ async fn launch(creds: &crate::config::Credentials, args: ExpRunArgs) -> Result<
     if chosen > 1 {
         return Err(anyhow!("Pass exactly one of --sandbox, --gpu, or --cpu."));
     }
+    if args.provider.is_some() && args.gpu.is_none() {
+        return Err(anyhow!(
+            "--provider only applies with --gpu (it selects among new GPU offers)."
+        ));
+    }
     let target = if let Some(sandbox_id) = &args.sandbox {
         RunTarget::Existing {
             sandbox_id: sandbox_id.clone(),
@@ -389,6 +394,9 @@ async fn launch(creds: &crate::config::Credentials, args: ExpRunArgs) -> Result<
             gpu: gpu.clone(),
             gpu_count: args.count.unwrap_or(1),
             disk_gb: args.disk.unwrap_or(100),
+            // Omitted = server default (RunPod). The server validates the name
+            // and 400s on an unknown provider, so no client-side check.
+            provider: args.provider.clone(),
         }
     } else if let Some(cpu_flavor) = &args.cpu {
         RunTarget::NewCpu {

--- a/src/commands/instance.rs
+++ b/src/commands/instance.rs
@@ -1,0 +1,87 @@
+//! The `instance` command group: spin up standalone compute in an organization,
+//! independent of any experiment.
+//!
+//!   orx instance create <orgId> --gpu <id> [--count N] [--disk GB] [--provider P]
+//!   orx instance create <orgId> --cpu <cpu5c|cpu5g|cpu5m> [--vcpus 2|8|32]
+//!
+//! This is the CLI equivalent of the dashboard's org "Spin up" panel — it hits
+//! `POST /sandboxes`, which provisions an org-level (not project-scoped) box.
+
+use crate::client::{create_sandbox, CreateSandboxBody, SandboxTarget};
+use crate::error::{anyhow, require_credentials, Result};
+use crate::{InstanceCommand, InstanceCreateArgs};
+
+pub async fn run(args: crate::InstanceArgs) -> Result<()> {
+    let creds = require_credentials().await;
+    match args.command {
+        InstanceCommand::Create(create_args) => create(&creds, create_args).await,
+    }
+}
+
+/// `orx instance create <orgId> …` — provision a standalone GPU or CPU instance.
+async fn create(creds: &crate::config::Credentials, args: InstanceCreateArgs) -> Result<()> {
+    // Resolve the target: exactly one of --gpu or --cpu.
+    if args.gpu.is_some() && args.cpu.is_some() {
+        return Err(anyhow!("Pass exactly one of --gpu or --cpu."));
+    }
+    if args.provider.is_some() && args.gpu.is_none() {
+        return Err(anyhow!(
+            "--provider only applies with --gpu (it selects among new GPU offers)."
+        ));
+    }
+    let target = if let Some(gpu) = &args.gpu {
+        SandboxTarget::New {
+            gpu: gpu.clone(),
+            gpu_count: args.count.unwrap_or(1),
+            disk_gb: args.disk.unwrap_or(100),
+            // Omitted = the server picks the cheapest matching offer across all
+            // providers (matching the dashboard's spin-up). The server validates
+            // the name and 400s on an unknown provider, so no client-side check.
+            provider: args.provider.clone(),
+        }
+    } else if let Some(cpu_flavor) = &args.cpu {
+        SandboxTarget::NewCpu {
+            cpu_flavor: cpu_flavor.clone(),
+            vcpu_count: args.vcpus.unwrap_or(8),
+        }
+    } else {
+        return Err(anyhow!(
+            "Choose compute: --gpu <id> [--count N] [--disk GB] [--provider P], \
+             or --cpu <cpu5c|cpu5g|cpu5m> [--vcpus 2|8|32]. \
+             See `orx compute` for available GPUs."
+        ));
+    };
+
+    let sandbox = create_sandbox(
+        creds,
+        &CreateSandboxBody {
+            organization_id: args.org_id.clone(),
+            target,
+        },
+    )
+    .await?
+    .sandbox;
+
+    println!("\u{2713} Instance requested");
+    println!("  id:       {}", sandbox.id);
+    println!("  status:   {}", sandbox.status);
+    println!("  type:     {}", sandbox.machine_type);
+    if let Some(provider) = &sandbox.provider_name {
+        println!("  provider: {}", provider);
+    }
+    match (&sandbox.gpu, sandbox.vcpu_count) {
+        (Some(gpu), _) => {
+            println!("  gpu:      {} x{}", gpu, sandbox.gpu_count.unwrap_or(1));
+        }
+        (None, Some(vcpus)) => println!("  vcpus:    {}", vcpus),
+        _ => {}
+    }
+    if let Some(price) = sandbox.price_per_hour {
+        println!("  price:    ${:.2}/hr", price);
+    }
+    // sshHostname is null until the box finishes provisioning, so there's no
+    // host to print yet — and there's no `orx` command to poll it.
+    println!("\n  The box is provisioning; its SSH host appears once it's online.");
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -27,6 +27,7 @@ pub mod exp;
 pub mod experiments;
 pub mod explore;
 pub mod install_skills;
+pub mod instance;
 pub mod lit;
 pub mod login;
 pub mod logout;

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,9 @@ enum Command {
     /// List the GPU compute catalog.
     Compute(ComputeArgs),
 
+    /// Spin up standalone compute in an organization (no experiment).
+    Instance(InstanceArgs),
+
     /// Operate on one experiment node (status / run command / run / cancel).
     Exp(ExpArgs),
 
@@ -314,6 +317,47 @@ pub struct ComputeArgs {
 }
 
 #[derive(Args, Debug)]
+pub struct InstanceArgs {
+    #[command(subcommand)]
+    pub command: InstanceCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum InstanceCommand {
+    /// Provision a standalone instance in an org (GPU with `--gpu`, or CPU with
+    /// `--cpu`). Not tied to an experiment — like the dashboard's "Spin up".
+    Create(InstanceCreateArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct InstanceCreateArgs {
+    /// Organization id (from `orx projects`).
+    pub org_id: String,
+    /// Provision a GPU instance with this GPU id, e.g. `H100_SXM` — the exact id
+    /// from `orx compute`, not a family name like `H100`.
+    #[arg(long)]
+    pub gpu: Option<String>,
+    /// GPUs per instance (with `--gpu`; default 1).
+    #[arg(long)]
+    pub count: Option<i64>,
+    /// Disk in GB (with `--gpu`; default 100).
+    #[arg(long)]
+    pub disk: Option<i64>,
+    /// Provider to provision from (with `--gpu`), e.g. runpod, vast, lambda.
+    /// Omit to pick the cheapest matching offer across providers (like the
+    /// dashboard). See `orx compute` for providers; validated server-side.
+    #[arg(long)]
+    pub provider: Option<String>,
+    /// Provision a CPU-only instance with this flavor: cpu5c (compute), cpu5g
+    /// (general), or cpu5m (memory-optimized). Mutually exclusive with `--gpu`.
+    #[arg(long)]
+    pub cpu: Option<String>,
+    /// vCPUs for a CPU instance (with `--cpu`): 2, 8, or 32 (default 8).
+    #[arg(long)]
+    pub vcpus: Option<i64>,
+}
+
+#[derive(Args, Debug)]
 pub struct ExpArgs {
     #[command(subcommand)]
     pub command: ExpCommand,
@@ -412,6 +456,10 @@ pub struct ExpRunArgs {
     /// Disk in GB (with `--gpu`; default 100).
     #[arg(long)]
     pub disk: Option<i64>,
+    /// Provider to provision from (with `--gpu`), e.g. runpod, vast, lambda.
+    /// Defaults to runpod when omitted; validated server-side.
+    #[arg(long)]
+    pub provider: Option<String>,
     /// Provision a CPU-only instance with this flavor: cpu5c (compute), cpu5g
     /// (general), or cpu5m (memory-optimized). Mutually exclusive with `--gpu`.
     #[arg(long)]
@@ -530,6 +578,7 @@ async fn dispatch(command: Command) -> error::Result<()> {
         Command::CreateProject(args) => commands::create_project::run(args).await,
         Command::CreateExperiment(args) => commands::create_experiment::run(args).await,
         Command::Compute(args) => commands::compute::run(args).await,
+        Command::Instance(args) => commands::instance::run(args).await,
         Command::Exp(args) => commands::exp::run(args).await,
         Command::Report(args) => commands::report::run(args).await,
         Command::Skill(args) => commands::skill::run(args).await,


### PR DESCRIPTION
## Summary

Two ways to spin up GPUs from any provider, not just RunPod:

1. **`orx exp run --provider <name>`** — provision an experiment run on a chosen provider. Omitting it defaults to RunPod (unchanged behavior).
2. **`orx instance create <orgId> (--gpu … | --cpu …)`** — a new top-level command that spins up a **standalone org-level instance** (not tied to an experiment), the CLI equivalent of the dashboard's "Spin up" panel. Omitting `--provider` lets the server pick the cheapest matching offer across providers (matching the dashboard).

Provider is passed as a free-form string and validated server-side, so new backend providers never require a CLI release.

## Dependency

The `--provider` flag on `orx exp run` requires the backend to accept `provider` on the run target: **alphaXiv/openresearch.sh#403** (merge that first). The new `orx instance create` command targets the already-existing `POST /sandboxes` endpoint and works independently.

## Notable design points

- **Two commands, two defaults — intentional.** `exp run` omit → RunPod (preserves prior behavior); `instance create` omit → cheapest (mirrors the dashboard). Each command's `--help` and `SKILL.md` state its own default.
- `SandboxTarget` is kept separate from `RunTarget` (different endpoints whose contracts may diverge; `RunTarget` additionally has `Existing`).
- A standalone instance is org-level (`projectId = null`) and cannot be fed to `orx exp run --sandbox` (the server requires a matching project) — it's for ad-hoc/manual use. The output messaging reflects this.

## Files

- `src/main.rs` — `--provider` on `ExpRunArgs`; new `Instance` command + `InstanceCreateArgs` + dispatch.
- `src/client.rs` — `provider` on `RunTarget::New`; new `SandboxTarget` / `CreateSandboxBody` / `Sandbox` / `create_sandbox`; serde + deserialize tests.
- `src/commands/instance.rs` (new), `src/commands/exp.rs`, `src/commands/compute.rs` (stale-doc fix), `src/commands/mod.rs`.
- `README.md`, `SKILL.md` — document the flag and the new command.

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --locked` — 18 pass (incl. 8 new serde/deserialize tests pinning the exact wire shapes)
- [x] `orx instance create --help` and `orx exp run --help` parse with the new flags
- [ ] `orx exp run <expId> --gpu <id>` (no `--provider`) → RunPod (needs backend #403)
- [ ] `orx exp run <expId> --gpu <id> --provider vast` → Vast (needs backend #403)
- [ ] `orx instance create <orgId> --gpu <id>` → cheapest provider; `--provider runpod` pins RunPod
- [ ] `orx instance create <orgId> --cpu cpu5g --vcpus 8` → CPU box
- [ ] `--provider` without `--gpu`, and `--gpu`+`--cpu` together, both error before any network call
- [ ] Unknown provider / no available offer / non-member org all surface a readable error
