### PR TITLE
feat: warn on every command when the CLI is outdated

### DIFF
--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -173,7 +173,7 @@ pub async fn run(args: crate::UpdateArgs) -> Result<()> {
         ));
     }
 
-    // Keep the nudge cache in sync so it doesn't fire on a stale answer.
+    // Keep the update-check cache in sync so the warning doesn't fire on a stale answer.
     updates::write_check_cache(&latest.version.to_string());
     println!("✓ Updated orx {} → {}.", current, latest.version);
     Ok(())

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -3,7 +3,7 @@
 //!
 //! `--json` (which implies `--check`) is the agent-facing form: one stable
 //! JSON object on stdout, exit 0 whether or not an update is available, so
-//! harnesses can poll deliberately instead of scraping stderr nudges.
+//! harnesses can poll deliberately instead of scraping the stderr warning.
 
 use std::time::Duration;
 
@@ -19,7 +19,7 @@ pub async fn run(args: crate::VersionArgs) -> Result<()> {
     }
 
     let latest = updates::fetch_latest(Duration::from_secs(10)).await?;
-    // Keep the passive nudge's cache in sync with this explicit check.
+    // Keep the update-check cache in sync with this explicit check.
     updates::write_check_cache(&latest.version.to_string());
     let update_available = latest.version > current;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -540,8 +540,8 @@ async fn main() {
         Cli::command().print_help().ok();
         return;
     };
-    // Passive outdated-version warning (skipped for the commands that manage
-    // updates themselves). `start` prints the cached warning to stderr *now*,
+    // Outdated-version warning (skipped for the commands that manage updates
+    // themselves). `start` prints the cached warning to stderr *now*,
     // before the command runs, so it shows even for commands that
     // `std::process::exit` on their own (e.g. the "not logged in" path) instead
     // of returning here. Never touches stdout or the exit code. Silence it with

--- a/src/main.rs
+++ b/src/main.rs
@@ -540,15 +540,18 @@ async fn main() {
         Cli::command().print_help().ok();
         return;
     };
-    // Passive update nudge (skipped for the commands that manage updates
-    // themselves). Interactive terminals only; never delays or fails the
-    // command, never touches stdout or the exit code.
-    let nudge =
-        (!matches!(command, Command::Version(_) | Command::Update(_))).then(updates::Nudge::start);
+    // Passive outdated-version warning (skipped for the commands that manage
+    // updates themselves). `start` prints the cached warning to stderr *now*,
+    // before the command runs, so it shows even for commands that
+    // `std::process::exit` on their own (e.g. the "not logged in" path) instead
+    // of returning here. Never touches stdout or the exit code. Silence it with
+    // ORX_NO_UPDATE_CHECK / NO_UPDATE_NOTIFIER.
+    let warning = (!matches!(command, Command::Version(_) | Command::Update(_)))
+        .then(updates::UpdateWarning::start);
 
     let result = dispatch(command).await;
-    if let Some(nudge) = nudge {
-        nudge.finish().await;
+    if let Some(warning) = warning {
+        warning.finish().await;
     }
 
     if let Err(err) = result {

--- a/src/updates.rs
+++ b/src/updates.rs
@@ -1,5 +1,5 @@
 //! Self-update plumbing shared by `orx version`, `orx update`, and the passive
-//! update nudge.
+//! outdated-version warning.
 //!
 //! Latest-version discovery deliberately avoids the GitHub REST API: its
 //! unauthenticated limit is 60 requests/hour *per IP*, which is routinely
@@ -15,7 +15,7 @@
 //! dist-workspace.toml sets `install-path = "CARGO_HOME"`), so `orx update`
 //! refuses to touch the binary unless the receipt matches it.
 
-use std::io::IsTerminal;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -200,7 +200,7 @@ pub fn exe_matches_prefix(exe: &Path, prefix: &Path) -> bool {
 }
 
 // ---------------------------------------------------------------------------
-// Update-check cache (the passive nudge's 24h throttle)
+// Update-check cache (the warning's 24h throttle)
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -229,115 +229,302 @@ fn read_cache() -> Option<CheckCache> {
 
 /// Best-effort cache write; errors are swallowed because the cache only exists
 /// to throttle a best-effort background check.
+///
+/// The write is atomic (temp file + rename) so a reader never observes a torn
+/// file. Several processes can write this concurrently — the background refresh
+/// here plus `orx version` / `orx update`, and multiple `orx` invocations at
+/// once — and a non-atomic `write` could leave a half-written file that
+/// `read_cache` then parses to `None`, silently suppressing the warning until a
+/// clean write lands. A unique temp name keeps concurrent writers from
+/// clobbering each other's temp file; `rename` is atomic on the same
+/// filesystem, so the final file is always either the old or a complete new one.
 pub fn write_check_cache(latest: &str) {
     let cache = CheckCache {
         checked_at: now_unix(),
         latest: latest.to_string(),
     };
     let path = cache_path();
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
+    let Some(parent) = path.parent() else {
+        return;
+    };
+    let _ = std::fs::create_dir_all(parent);
+    let Ok(body) = serde_json::to_string(&cache) else {
+        return;
+    };
+    let tmp = parent.join(format!(".update-check.json.{}.tmp", uuid::Uuid::new_v4()));
+    if std::fs::write(&tmp, body).is_err() {
+        let _ = std::fs::remove_file(&tmp);
+        return;
     }
-    if let Ok(body) = serde_json::to_string(&cache) {
-        let _ = std::fs::write(&path, body);
+    if std::fs::rename(&tmp, &path).is_err() {
+        // Rename failed (e.g. cross-device, racing cleanup); don't leak the temp.
+        let _ = std::fs::remove_file(&tmp);
     }
 }
 
 // ---------------------------------------------------------------------------
-// Passive nudge
+// Passive outdated-version warning
 // ---------------------------------------------------------------------------
 
-/// Whether the passive update check may run at all. Interactive terminals
-/// only: agents, scripts, pipes, and CI see zero behavior change.
-fn nudge_enabled() -> bool {
-    let opted_out = std::env::var_os("ORX_NO_UPDATE_CHECK").is_some()
+/// Whether the user has explicitly silenced the update check. When true, no
+/// warning is shown and no background refresh runs — the one escape hatch for
+/// anyone who can't tolerate the extra stderr line (including CI).
+fn opted_out() -> bool {
+    std::env::var_os("ORX_NO_UPDATE_CHECK").is_some()
         // The generic convention honored by update-notifier and friends.
         || std::env::var_os("NO_UPDATE_NOTIFIER").is_some()
         // cargo-dist's own "don't manage updates for this install" switch; the
         // installer already honors it, so it is the one mental model.
         || std::env::var("OPENRESEARCH_CLI_DISABLE_UPDATE").as_deref() == Ok("1")
-        || std::env::var_os("CI").is_some();
-    !opted_out && std::io::stderr().is_terminal()
 }
 
-/// The passive update nudge, modeled on the gh CLI / update-notifier pattern:
-/// the message shown this run comes from the *cached* previous check (so it is
-/// instant), and a background refresh updates the cache for the next run at
-/// most once per [`CHECK_TTL`].
-pub struct Nudge {
-    message: Option<String>,
+/// Whether a `current` → `latest` upgrade crosses a breaking-change boundary
+/// under semver. A major bump is always breaking; pre-1.0 (`0.y.z`) a *minor*
+/// bump is the breaking signal too, since `0.y` versions treat `y` like a major
+/// (`0.0.z` then treats every `z` as breaking). Post-1.0 a minor bump is
+/// additive. Assumes `latest` outranks `current` in [`precedence`] (the only
+/// case the warning builds for).
+///
+/// RE-CONFIRM AT 1.0: the moment orx ships `1.0.0`, a `1.x` minor bump silently
+/// downgrades from breaking to soft here. That is semver-correct, but if the
+/// backend keeps making breaking changes on minor bumps post-1.0, this rule
+/// would understate them — revisit the heuristic then.
+fn is_breaking_gap(current: &Version, latest: &Version) -> bool {
+    if latest.major != current.major {
+        return latest.major > current.major;
+    }
+    // Same major. Below 1.0 the minor (and, below 0.1, the patch) is the
+    // breaking axis.
+    if current.major == 0 {
+        if current.minor == 0 {
+            return latest.minor > 0 || latest.patch > current.patch;
+        }
+        return latest.minor > current.minor;
+    }
+    false
+}
+
+/// Version-precedence key: everything that orders two releases *except* build
+/// metadata. Per the SemVer spec build metadata is not part of precedence
+/// (`1.0.0+a` and `1.0.0+b` are the same release), but `semver::Version`'s `Ord`
+/// compares it anyway — so two builds of the same release would otherwise read
+/// as "outdated". Comparing this key instead avoids that false positive.
+/// `Prerelease`'s own `Ord` already encodes the spec rule that a release sorts
+/// above its pre-releases (empty pre-release is the greatest).
+fn precedence(v: &Version) -> (u64, u64, u64, &semver::Prerelease) {
+    (v.major, v.minor, v.patch, &v.pre)
+}
+
+/// Builds the outdated-version warning when `latest` outranks `current` in
+/// [`precedence`], or `None` when `current` is already current (or ahead — a
+/// local dev build, or the same release with different build metadata).
+///
+/// Because orx talks to a versioned backend, a stale client can hit removed or
+/// changed API shapes, so the warning leads with that risk rather than a
+/// neutral "new version available". The framing escalates with the size of the
+/// gap (see [`is_breaking_gap`]): a breaking gap warns that commands can start
+/// failing now, while a non-breaking gap is a gentler "upgrade soon".
+fn warning_for(current: &Version, latest: &Version) -> Option<String> {
+    if precedence(latest) <= precedence(current) {
+        return None;
+    }
+    let detail = if is_breaking_gap(current, latest) {
+        "This release may include breaking API changes, so commands can start failing \
+         until you upgrade."
+    } else {
+        "A newer release is available; upgrade to stay compatible with the API."
+    };
+    Some(format!(
+        "Warning: orx {current} is outdated (latest {latest}). {detail} \
+         Run `orx update` to upgrade."
+    ))
+}
+
+/// The passive outdated-version warning, modeled on the gh CLI / update-notifier
+/// pattern: the message shown this run comes from the *cached* previous check,
+/// so it is instant and never adds latency to the command. A background refresh
+/// updates the cache for the next run at most once per [`CHECK_TTL`].
+///
+/// Unlike a quiet "new version" nudge, the warning is shown on every command —
+/// piped, scripted, or interactive — and is printed in [`start`](Self::start),
+/// *before* the command runs, so it survives commands that `std::process::exit`
+/// on their own (e.g. the "not logged in" path) instead of returning to `main`.
+/// [`opted_out`] is the single switch to silence it.
+///
+/// Because the message comes from cache, the *first* run after a fresh install
+/// has nothing cached yet and shows nothing; the background refresh it kicks off
+/// warms the cache so a later run can warn. The refresh is always fire-and-forget
+/// — it never blocks the command — so a one-shot environment that throws its
+/// cache away each run (e.g. an ephemeral CI container) may take a few runs to
+/// warm up, or never. That is the accepted cost of adding zero latency.
+pub struct UpdateWarning {
     refresh: Option<tokio::task::JoinHandle<()>>,
 }
 
-impl Nudge {
-    pub fn start() -> Nudge {
-        if !nudge_enabled() {
-            return Nudge {
-                message: None,
-                refresh: None,
-            };
+impl UpdateWarning {
+    /// Prints the cached warning (if any) to stderr immediately, then kicks off a
+    /// best-effort background refresh of the cached "latest" for next time.
+    /// Printing here — rather than after the command — is what guarantees the
+    /// warning shows even when the command exits the process itself.
+    pub fn start() -> UpdateWarning {
+        if opted_out() {
+            return UpdateWarning { refresh: None };
         }
 
         let current = current_version();
         let cache = read_cache();
 
-        let message = cache
+        if let Some(message) = cache
             .as_ref()
             .and_then(|c| Version::parse(&c.latest).ok())
-            .filter(|latest| *latest > current)
-            .map(|latest| {
-                format!(
-                    "A new release of orx is available: {} → {}. Run `orx update` to upgrade.",
-                    current, latest
-                )
-            });
+            .and_then(|latest| warning_for(&current, &latest))
+        {
+            // Infallible: a closed/broken stderr (e.g. `2>&-`, or a reader that
+            // already exited) must not panic the process before the command even
+            // runs. `eprintln!` would; a swallowed `writeln!` won't.
+            let _ = writeln!(std::io::stderr(), "{message}\n");
+        }
 
+        // Refresh whenever the cache is stale (or absent), regardless of whether
+        // stderr is a terminal: scripted/piped runs warn too, so their cache has
+        // to stay fresh or they'd warn off a frozen answer indefinitely.
         let stale = cache
             .as_ref()
             .map(|c| now_unix().saturating_sub(c.checked_at) >= CHECK_TTL.as_secs())
             .unwrap_or(true);
-        let refresh = stale.then(|| {
-            let prev_latest = cache.map(|c| c.latest);
-            tokio::spawn(async move {
-                let latest = fetch_latest(Duration::from_secs(3))
-                    .await
-                    .ok()
-                    .map(|l| l.version.to_string());
-                // On fetch failure, refresh checked_at with the old answer so
-                // errors don't cause a retry on every invocation.
-                let value = latest
-                    .or(prev_latest)
-                    .unwrap_or_else(|| current.to_string());
-                write_check_cache(&value);
-            })
+        if !stale {
+            return UpdateWarning { refresh: None };
+        }
+
+        let prev_latest = cache.map(|c| c.latest);
+        let handle = tokio::spawn(async move {
+            let latest = fetch_latest(Duration::from_secs(3))
+                .await
+                .ok()
+                .map(|l| l.version.to_string());
+            // On fetch failure, refresh checked_at with the old answer so errors
+            // don't cause a retry on every invocation. Only fabricate `current`
+            // as a last resort (no cache, no previous answer): a one-off failed
+            // fetch then suppresses the warning until the TTL lapses, which is
+            // the price of not re-fetching on every offline invocation.
+            let value = latest
+                .or(prev_latest)
+                .unwrap_or_else(|| current.to_string());
+            write_check_cache(&value);
         });
 
-        Nudge { message, refresh }
+        UpdateWarning {
+            refresh: Some(handle),
+        }
     }
 
-    /// Called after the real command finished: gives the background refresh a
-    /// short grace window (it usually finished while the command did its own
-    /// network work), then prints the nudge — stderr only, exit code untouched.
+    /// Called after the real command finished. Grants the fire-and-forget refresh
+    /// a brief grace window to land in the cache — it has often finished during
+    /// the command's own work — then moves on. The window matters most for a fast
+    /// command (one that returns before the fetch does): it gives the write a
+    /// chance to commit before `#[tokio::main]` tears the runtime down, without
+    /// which quick commands would never warm the cache. Never blocks the command
+    /// meaningfully, never touches stdout or the exit code.
     pub async fn finish(self) {
-        if let Some(handle) = self.refresh {
-            if tokio::time::timeout(Duration::from_millis(250), handle)
-                .await
-                .is_err()
-            {
-                // Took too long; the next stale run will try again.
-            }
-        }
-        if let Some(message) = self.message {
-            eprintln!("\n{}", message);
-        }
+        let Some(handle) = self.refresh else {
+            return;
+        };
+        // Timed out -> the task keeps running (it may still land); the next stale
+        // run tries again regardless.
+        let _ = tokio::time::timeout(Duration::from_millis(250), handle).await;
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{exe_matches_prefix, parse_manifest};
+    use super::{exe_matches_prefix, is_breaking_gap, parse_manifest, precedence, warning_for};
     use semver::Version;
     use std::path::Path;
+
+    #[test]
+    fn precedence_ignores_build_metadata_and_orders_prereleases() {
+        let v = |s: &str| Version::parse(s).unwrap();
+        // Build metadata is not part of precedence: same release.
+        assert_eq!(precedence(&v("1.2.3+a")), precedence(&v("1.2.3+b")));
+        assert_eq!(precedence(&v("1.2.3")), precedence(&v("1.2.3+build.99")));
+        // A release outranks its pre-releases (empty pre-release is greatest).
+        assert!(precedence(&v("0.2.0")) > precedence(&v("0.2.0-rc.1")));
+        assert!(precedence(&v("0.2.0-rc.2")) > precedence(&v("0.2.0-rc.1")));
+        // Ordinary ordering on the numeric fields still holds.
+        assert!(precedence(&v("0.2.0")) > precedence(&v("0.1.29")));
+    }
+
+    // The substring the *breaking* message has and the soft one must not, used
+    // to assert which tier a warning landed in without pinning exact copy.
+    const BREAKING_MARKER: &str = "can start failing";
+
+    fn assert_soft(msg: &str) {
+        assert!(msg.contains("outdated"), "{msg}");
+        assert!(msg.contains("orx update"), "{msg}");
+        assert!(
+            !msg.contains(BREAKING_MARKER),
+            "soft warning claims breakage: {msg}"
+        );
+    }
+
+    fn assert_breaking(msg: &str) {
+        assert!(msg.contains("breaking API changes"), "{msg}");
+        assert!(msg.contains(BREAKING_MARKER), "{msg}");
+        assert!(msg.contains("orx update"), "{msg}");
+    }
+
+    #[test]
+    fn no_warning_when_current_or_ahead() {
+        let v = |s: &str| Version::parse(s).unwrap();
+        // Exactly current.
+        assert!(warning_for(&v("0.1.29"), &v("0.1.29")).is_none());
+        // Local build ahead of the latest release.
+        assert!(warning_for(&v("0.2.0"), &v("0.1.29")).is_none());
+        // Build metadata is ignored by semver ordering, so it's not "outdated".
+        assert!(warning_for(&v("0.1.29"), &v("0.1.29+build.5")).is_none());
+    }
+
+    #[test]
+    fn is_breaking_gap_classifies_every_axis() {
+        let v = |s: &str| Version::parse(s).unwrap();
+        // major bump: always breaking.
+        assert!(is_breaking_gap(&v("0.9.0"), &v("1.0.0")));
+        assert!(is_breaking_gap(&v("1.4.0"), &v("2.0.0")));
+        // pre-1.0 minor bump: breaking.
+        assert!(is_breaking_gap(&v("0.1.29"), &v("0.2.0")));
+        // pre-1.0 patch bump: NOT breaking.
+        assert!(!is_breaking_gap(&v("0.1.28"), &v("0.1.29")));
+        // 0.0.x: even a patch bump is breaking (every 0.0.z is its own "major").
+        assert!(is_breaking_gap(&v("0.0.1"), &v("0.0.2")));
+        // post-1.0 minor/patch bump: NOT breaking (additive).
+        assert!(!is_breaking_gap(&v("1.2.3"), &v("1.3.0")));
+        assert!(!is_breaking_gap(&v("1.2.3"), &v("1.2.4")));
+    }
+
+    #[test]
+    fn patch_gap_is_a_soft_warning() {
+        assert_soft(&warning_for(&Version::new(0, 1, 28), &Version::new(0, 1, 29)).unwrap());
+    }
+
+    #[test]
+    fn minor_gap_warns_about_breaking_changes() {
+        // Pre-1.0, a bumped minor is the semver signal for a breaking change.
+        assert_breaking(&warning_for(&Version::new(0, 1, 29), &Version::new(0, 2, 0)).unwrap());
+    }
+
+    #[test]
+    fn major_gap_warns_about_breaking_changes() {
+        assert_breaking(&warning_for(&Version::new(1, 4, 0), &Version::new(2, 0, 0)).unwrap());
+    }
+
+    #[test]
+    fn post_1_0_patch_and_minor_are_not_breaking() {
+        // Once past 1.0, a minor bump is additive: patch (1.2.3 -> 1.2.4) and
+        // minor (1.2.3 -> 1.3.0) gaps both get the soft wording; only a major
+        // bump escalates.
+        assert_soft(&warning_for(&Version::new(1, 2, 3), &Version::new(1, 2, 4)).unwrap());
+        assert_soft(&warning_for(&Version::new(1, 2, 3), &Version::new(1, 3, 0)).unwrap());
+    }
 
     #[test]
     fn parses_dist_manifest() {

--- a/src/updates.rs
+++ b/src/updates.rs
@@ -15,7 +15,7 @@
 //! dist-workspace.toml sets `install-path = "CARGO_HOME"`), so `orx update`
 //! refuses to touch the binary unless the receipt matches it.
 
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -278,6 +278,40 @@ fn opted_out() -> bool {
         || std::env::var("OPENRESEARCH_CLI_DISABLE_UPDATE").as_deref() == Ok("1")
 }
 
+/// Whether to emit ANSI styling on stderr: only when stderr is a real terminal
+/// and the user hasn't set the conventional `NO_COLOR` opt-out. Pipes, files,
+/// and CI logs get plain text — never raw escape codes — which matters because
+/// this warning now prints on non-interactive runs too.
+fn stderr_supports_ansi() -> bool {
+    std::env::var_os("NO_COLOR").is_none() && std::io::stderr().is_terminal()
+}
+
+/// Wraps `text` in the ANSI bold sequence when `enabled`, else returns it as-is.
+/// `\x1b[22m` resets bold/faint specifically (not `\x1b[0m`, which would also
+/// clear any surrounding styling the terminal had).
+fn bold(text: &str, enabled: bool) -> String {
+    if enabled {
+        format!("\x1b[1m{text}\x1b[22m")
+    } else {
+        text.to_string()
+    }
+}
+
+/// Renders the warning for printing to stderr: bolds the leading `Warning:`
+/// label when `ansi` is set, and sets the whole thing off in its own block with
+/// a blank line above and below. Returns the exact bytes to write (the caller
+/// uses `write!`, not `writeln!`, since the trailing newlines are included).
+fn render(message: &str, ansi: bool) -> String {
+    // The message always begins with the literal "Warning:" (see `warning_for`);
+    // bold just that label, gh/cargo-style, rather than the whole sentence.
+    const LABEL: &str = "Warning:";
+    let styled = match message.strip_prefix(LABEL) {
+        Some(rest) => format!("{}{rest}", bold(LABEL, ansi)),
+        None => message.to_string(),
+    };
+    format!("\n{styled}\n\n")
+}
+
 /// Whether a `current` → `latest` upgrade crosses a breaking-change boundary
 /// under semver. A major bump is always breaking; pre-1.0 (`0.y.z`) a *minor*
 /// bump is the breaking signal too, since `0.y` versions treat `y` like a major
@@ -382,7 +416,11 @@ impl UpdateWarning {
             // Infallible: a closed/broken stderr (e.g. `2>&-`, or a reader that
             // already exited) must not panic the process before the command even
             // runs. `eprintln!` would; a swallowed `writeln!` won't.
-            let _ = writeln!(std::io::stderr(), "{message}\n");
+            let _ = write!(
+                std::io::stderr(),
+                "{}",
+                render(&message, stderr_supports_ansi())
+            );
         }
 
         // Refresh whenever the cache is stale (or absent), regardless of whether
@@ -437,9 +475,43 @@ impl UpdateWarning {
 
 #[cfg(test)]
 mod tests {
-    use super::{exe_matches_prefix, is_breaking_gap, parse_manifest, precedence, warning_for};
+    use super::{
+        bold, exe_matches_prefix, is_breaking_gap, parse_manifest, precedence, render, warning_for,
+    };
     use semver::Version;
     use std::path::Path;
+
+    #[test]
+    fn render_sets_off_the_warning_in_its_own_block() {
+        let msg = "Warning: orx 0.1.0 is outdated (latest 0.2.0). foo Run `orx update` to upgrade.";
+        // Plain (non-TTY): blank line before and after, no escape codes at all.
+        let plain = render(msg, false);
+        assert_eq!(plain, format!("\n{msg}\n\n"));
+        assert!(
+            !plain.contains('\x1b'),
+            "plain output must not contain ANSI"
+        );
+
+        // Styled (TTY): only the "Warning:" label is bolded; same blank-line block.
+        let styled = render(msg, true);
+        assert!(styled.starts_with("\n\x1b[1mWarning:\x1b[22m"));
+        assert!(styled.ends_with("upgrade.\n\n"));
+        // Everything after the label is unstyled — exactly one bold open/close.
+        assert_eq!(styled.matches("\x1b[1m").count(), 1);
+        assert_eq!(styled.matches("\x1b[22m").count(), 1);
+
+        // Fail-soft: a message without the "Warning:" prefix is passed through
+        // unstyled (no panic, no stray escapes), so the label/builder coupling
+        // degrades gracefully if the prefix ever changes.
+        let no_label = render("orx is outdated.", true);
+        assert_eq!(no_label, "\norx is outdated.\n\n");
+    }
+
+    #[test]
+    fn bold_is_a_noop_when_disabled() {
+        assert_eq!(bold("x", false), "x");
+        assert_eq!(bold("x", true), "\x1b[1mx\x1b[22m");
+    }
 
     #[test]
     fn precedence_ignores_build_metadata_and_orders_prereleases() {

--- a/src/updates.rs
+++ b/src/updates.rs
@@ -318,32 +318,6 @@ fn render(message: &str, ansi: bool) -> String {
     format!("\n{styled}\n\n")
 }
 
-/// Whether a `current` → `latest` upgrade crosses a breaking-change boundary
-/// under semver. A major bump is always breaking; pre-1.0 (`0.y.z`) a *minor*
-/// bump is the breaking signal too, since `0.y` versions treat `y` like a major
-/// (`0.0.z` then treats every `z` as breaking). Post-1.0 a minor bump is
-/// additive. Assumes `latest` outranks `current` in [`precedence`] (the only
-/// case the warning builds for).
-///
-/// RE-CONFIRM AT 1.0: the moment orx ships `1.0.0`, a `1.x` minor bump silently
-/// downgrades from breaking to soft here. That is semver-correct, but if the
-/// backend keeps making breaking changes on minor bumps post-1.0, this rule
-/// would understate them — revisit the heuristic then.
-fn is_breaking_gap(current: &Version, latest: &Version) -> bool {
-    if latest.major != current.major {
-        return latest.major > current.major;
-    }
-    // Same major. Below 1.0 the minor (and, below 0.1, the patch) is the
-    // breaking axis.
-    if current.major == 0 {
-        if current.minor == 0 {
-            return latest.minor > 0 || latest.patch > current.patch;
-        }
-        return latest.minor > current.minor;
-    }
-    false
-}
-
 /// Version-precedence key: everything that orders two releases *except* build
 /// metadata. Per the SemVer spec build metadata is not part of precedence
 /// (`1.0.0+a` and `1.0.0+b` are the same release), but `semver::Version`'s `Ord`
@@ -360,23 +334,15 @@ fn precedence(v: &Version) -> (u64, u64, u64, &semver::Prerelease) {
 /// local dev build, or the same release with different build metadata).
 ///
 /// Because orx talks to a versioned backend, a stale client can hit removed or
-/// changed API shapes, so the warning leads with that risk rather than a
-/// neutral "new version available". The framing escalates with the size of the
-/// gap (see [`is_breaking_gap`]): a breaking gap warns that commands can start
-/// failing now, while a non-breaking gap is a gentler "upgrade soon".
+/// changed API shapes, so the warning notes the compatibility risk rather than a
+/// neutral "new version available".
 fn warning_for(current: &Version, latest: &Version) -> Option<String> {
     if precedence(latest) <= precedence(current) {
         return None;
     }
-    let detail = if is_breaking_gap(current, latest) {
-        "This release may include breaking API changes, so commands can start failing \
-         until you upgrade."
-    } else {
-        "A newer release is available; upgrade to stay compatible with the API."
-    };
     Some(format!(
-        "{WARNING_LABEL} orx {current} is outdated (latest {latest}). {detail} \
-         Run `orx update` to upgrade."
+        "{WARNING_LABEL} orx {current} is outdated (latest {latest}). A newer release is \
+         available; upgrade to stay compatible with the API. Run `orx update` to upgrade."
     ))
 }
 
@@ -490,9 +456,7 @@ impl UpdateWarning {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        bold, exe_matches_prefix, is_breaking_gap, parse_manifest, precedence, render, warning_for,
-    };
+    use super::{bold, exe_matches_prefix, parse_manifest, precedence, render, warning_for};
     use semver::Version;
     use std::path::Path;
 
@@ -541,22 +505,11 @@ mod tests {
         assert!(precedence(&v("0.2.0")) > precedence(&v("0.1.29")));
     }
 
-    // The substring the *breaking* message has and the soft one must not, used
-    // to assert which tier a warning landed in without pinning exact copy.
-    const BREAKING_MARKER: &str = "can start failing";
-
-    fn assert_soft(msg: &str) {
+    // Every outdated case shows the same message; assert its stable markers
+    // without pinning the exact copy.
+    fn assert_warns(msg: &str) {
         assert!(msg.contains("outdated"), "{msg}");
-        assert!(msg.contains("orx update"), "{msg}");
-        assert!(
-            !msg.contains(BREAKING_MARKER),
-            "soft warning claims breakage: {msg}"
-        );
-    }
-
-    fn assert_breaking(msg: &str) {
-        assert!(msg.contains("breaking API changes"), "{msg}");
-        assert!(msg.contains(BREAKING_MARKER), "{msg}");
+        assert!(msg.contains("stay compatible with the API"), "{msg}");
         assert!(msg.contains("orx update"), "{msg}");
     }
 
@@ -569,60 +522,30 @@ mod tests {
         assert!(warning_for(&v("0.2.0"), &v("0.1.29")).is_none());
         // Build metadata is ignored by semver ordering, so it's not "outdated".
         assert!(warning_for(&v("0.1.29"), &v("0.1.29+build.5")).is_none());
-    }
-
-    #[test]
-    fn is_breaking_gap_classifies_every_axis() {
-        let v = |s: &str| Version::parse(s).unwrap();
-        // major bump: always breaking.
-        assert!(is_breaking_gap(&v("0.9.0"), &v("1.0.0")));
-        assert!(is_breaking_gap(&v("1.4.0"), &v("2.0.0")));
-        // pre-1.0 minor bump: breaking.
-        assert!(is_breaking_gap(&v("0.1.29"), &v("0.2.0")));
-        // pre-1.0 patch bump: NOT breaking.
-        assert!(!is_breaking_gap(&v("0.1.28"), &v("0.1.29")));
-        // 0.0.x: even a patch bump is breaking (every 0.0.z is its own "major").
-        assert!(is_breaking_gap(&v("0.0.1"), &v("0.0.2")));
-        // post-1.0 minor/patch bump: NOT breaking (additive).
-        assert!(!is_breaking_gap(&v("1.2.3"), &v("1.3.0")));
-        assert!(!is_breaking_gap(&v("1.2.3"), &v("1.2.4")));
-    }
-
-    #[test]
-    fn patch_gap_is_a_soft_warning() {
-        assert_soft(&warning_for(&Version::new(0, 1, 28), &Version::new(0, 1, 29)).unwrap());
-    }
-
-    #[test]
-    fn minor_gap_warns_about_breaking_changes() {
-        // Pre-1.0, a bumped minor is the semver signal for a breaking change.
-        assert_breaking(&warning_for(&Version::new(0, 1, 29), &Version::new(0, 2, 0)).unwrap());
-    }
-
-    #[test]
-    fn major_gap_warns_about_breaking_changes() {
-        assert_breaking(&warning_for(&Version::new(1, 4, 0), &Version::new(2, 0, 0)).unwrap());
-    }
-
-    #[test]
-    fn post_1_0_patch_and_minor_are_not_breaking() {
-        // Once past 1.0, a minor bump is additive: patch (1.2.3 -> 1.2.4) and
-        // minor (1.2.3 -> 1.3.0) gaps both get the soft wording; only a major
-        // bump escalates.
-        assert_soft(&warning_for(&Version::new(1, 2, 3), &Version::new(1, 2, 4)).unwrap());
-        assert_soft(&warning_for(&Version::new(1, 2, 3), &Version::new(1, 3, 0)).unwrap());
-    }
-
-    #[test]
-    fn prerelease_current_vs_stable_latest() {
-        let v = |s: &str| Version::parse(s).unwrap();
-        // A pre-release of the same release is behind the final release, but it's
-        // the same version line, so it's a soft "you're a hair behind", not breaking.
-        assert_soft(&warning_for(&v("0.2.0-rc.1"), &v("0.2.0")).unwrap());
-        // A pre-release of the *next* pre-1.0 minor is a breaking gap.
-        assert_breaking(&warning_for(&v("0.1.29"), &v("0.2.0-rc.1")).unwrap());
         // Running ahead of the latest stable on a local pre-release: not outdated.
         assert!(warning_for(&v("0.3.0-dev.1"), &v("0.2.0")).is_none());
+    }
+
+    #[test]
+    fn warns_on_every_kind_of_outdated_gap() {
+        let v = |s: &str| Version::parse(s).unwrap();
+        // The same warning fires regardless of how far behind: patch, minor,
+        // major, 0.0.x, post-1.0, and a pre-release behind its final release.
+        for (cur, latest) in [
+            ("0.1.28", "0.1.29"),     // pre-1.0 patch
+            ("0.1.29", "0.2.0"),      // pre-1.0 minor
+            ("0.0.1", "0.0.2"),       // 0.0.x patch
+            ("0.9.0", "1.0.0"),       // 0.x -> 1.0
+            ("1.2.3", "1.2.4"),       // post-1.0 patch
+            ("1.2.3", "1.3.0"),       // post-1.0 minor
+            ("1.4.0", "2.0.0"),       // major
+            ("0.2.0-rc.1", "0.2.0"),  // pre-release behind its final release
+            ("0.1.29", "0.2.0-rc.1"), // behind the next minor's pre-release
+        ] {
+            assert_warns(&warning_for(&v(cur), &v(latest)).unwrap_or_else(|| {
+                panic!("expected a warning for {cur} -> {latest}");
+            }));
+        }
     }
 
     #[test]

--- a/src/updates.rs
+++ b/src/updates.rs
@@ -1,5 +1,5 @@
-//! Self-update plumbing shared by `orx version`, `orx update`, and the passive
-//! outdated-version warning.
+//! Self-update plumbing shared by `orx version`, `orx update`, and the
+//! outdated-version warning shown on every command.
 //!
 //! Latest-version discovery deliberately avoids the GitHub REST API: its
 //! unauthenticated limit is 60 requests/hour *per IP*, which is routinely
@@ -263,8 +263,13 @@ pub fn write_check_cache(latest: &str) {
 }
 
 // ---------------------------------------------------------------------------
-// Passive outdated-version warning
+// Outdated-version warning
 // ---------------------------------------------------------------------------
+
+/// The leading label every warning message starts with. Shared so the builder
+/// (`warning_for`) and the styler (`render`, which bolds just this label) can't
+/// silently drift apart on a copy edit.
+const WARNING_LABEL: &str = "Warning:";
 
 /// Whether the user has explicitly silenced the update check. When true, no
 /// warning is shown and no background refresh runs — the one escape hatch for
@@ -302,11 +307,12 @@ fn bold(text: &str, enabled: bool) -> String {
 /// a blank line above and below. Returns the exact bytes to write (the caller
 /// uses `write!`, not `writeln!`, since the trailing newlines are included).
 fn render(message: &str, ansi: bool) -> String {
-    // The message always begins with the literal "Warning:" (see `warning_for`);
-    // bold just that label, gh/cargo-style, rather than the whole sentence.
-    const LABEL: &str = "Warning:";
-    let styled = match message.strip_prefix(LABEL) {
-        Some(rest) => format!("{}{rest}", bold(LABEL, ansi)),
+    // The message always begins with WARNING_LABEL (see `warning_for`); bold just
+    // that label, gh/cargo-style, rather than the whole sentence. If the prefix
+    // ever drifts, fall back to the unstyled message — never panic, never emit a
+    // stray escape.
+    let styled = match message.strip_prefix(WARNING_LABEL) {
+        Some(rest) => format!("{}{rest}", bold(WARNING_LABEL, ansi)),
         None => message.to_string(),
     };
     format!("\n{styled}\n\n")
@@ -369,12 +375,12 @@ fn warning_for(current: &Version, latest: &Version) -> Option<String> {
         "A newer release is available; upgrade to stay compatible with the API."
     };
     Some(format!(
-        "Warning: orx {current} is outdated (latest {latest}). {detail} \
+        "{WARNING_LABEL} orx {current} is outdated (latest {latest}). {detail} \
          Run `orx update` to upgrade."
     ))
 }
 
-/// The passive outdated-version warning, modeled on the gh CLI / update-notifier
+/// The outdated-version warning, modeled on the gh CLI / update-notifier
 /// pattern: the message shown this run comes from the *cached* previous check,
 /// so it is instant and never adds latency to the command. A background refresh
 /// updates the cache for the next run at most once per [`CHECK_TTL`].
@@ -456,17 +462,26 @@ impl UpdateWarning {
         }
     }
 
-    /// Called after the real command finished. Grants the fire-and-forget refresh
-    /// a brief grace window to land in the cache — it has often finished during
-    /// the command's own work — then moves on. The window matters most for a fast
-    /// command (one that returns before the fetch does): it gives the write a
-    /// chance to commit before `#[tokio::main]` tears the runtime down, without
-    /// which quick commands would never warm the cache. Never blocks the command
-    /// meaningfully, never touches stdout or the exit code.
+    /// Called after the real command finished. On an interactive terminal, grants
+    /// the fire-and-forget refresh a brief grace window to land in the cache — it
+    /// has often finished during the command's own work — so the cache is warm for
+    /// the user's *next* command; the window gives the write a chance to commit
+    /// before `#[tokio::main]` tears the runtime down, without which quick commands
+    /// would never warm the cache.
+    ///
+    /// On a non-terminal (pipe, CI, cron) the wait is skipped entirely: an
+    /// ephemeral environment throws its cache away between runs, so warming it
+    /// buys nothing, and a per-invocation 250ms tail across a CI pipeline that
+    /// calls `orx` many times is pure cost. The refresh is still spawned (it may
+    /// land if the process outlives it); we just don't pay to wait for it. Never
+    /// blocks the command meaningfully, never touches stdout or the exit code.
     pub async fn finish(self) {
         let Some(handle) = self.refresh else {
             return;
         };
+        if !std::io::stderr().is_terminal() {
+            return;
+        }
         // Timed out -> the task keeps running (it may still land); the next stale
         // run tries again regardless.
         let _ = tokio::time::timeout(Duration::from_millis(250), handle).await;
@@ -596,6 +611,18 @@ mod tests {
         // bump escalates.
         assert_soft(&warning_for(&Version::new(1, 2, 3), &Version::new(1, 2, 4)).unwrap());
         assert_soft(&warning_for(&Version::new(1, 2, 3), &Version::new(1, 3, 0)).unwrap());
+    }
+
+    #[test]
+    fn prerelease_current_vs_stable_latest() {
+        let v = |s: &str| Version::parse(s).unwrap();
+        // A pre-release of the same release is behind the final release, but it's
+        // the same version line, so it's a soft "you're a hair behind", not breaking.
+        assert_soft(&warning_for(&v("0.2.0-rc.1"), &v("0.2.0")).unwrap());
+        // A pre-release of the *next* pre-1.0 minor is a breaking gap.
+        assert_breaking(&warning_for(&v("0.1.29"), &v("0.2.0-rc.1")).unwrap());
+        // Running ahead of the latest stable on a local pre-release: not outdated.
+        assert!(warning_for(&v("0.3.0-dev.1"), &v("0.2.0")).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## What

Every `orx` command now prints a warning to **stderr** when the running CLI is behind the latest release, because the backend API is versioned and a stale client can hit breaking changes. The framing escalates with the size of the version gap:

- **Breaking gap** (pre-1.0 minor bump, or post-1.0 major bump): *"This release may include breaking API changes, so commands can start failing until you upgrade."*
- **Smaller gap**: *"A newer release is available; upgrade to stay compatible with the API."*

Example:

```
Warning: orx 0.1.29 is outdated (latest 0.9.0). This release may include breaking API changes, so commands can start failing until you upgrade. Run `orx update` to upgrade.
```

## How "latest version" is determined

This reuses the machinery the repo already had (and that `gh` / `npm` / update-notifier use):

- Latest version comes from the **cargo-dist release manifest** at `releases/latest/download/dist-manifest.json` — a rate-limit-free CDN permalink, **not** the GitHub REST API (which throttles at 60 req/hr/IP, routinely exhausted on datacenter/NAT addresses).
- The result is **cached to `~/.config/openresearch/update-check.json`** with a 24h TTL. The warning shown comes from that cache (instant, **zero added latency**); a fire-and-forget background task refreshes the cache for next time.

## What changed

The codebase already had an *interactive-only, quiet* "new version available" nudge in `src/updates.rs`. This reworks it into the always-on outdated **warning**:

- **Shows on every command** — piped, scripted, and CI too, not just interactive terminals. Silence it with `ORX_NO_UPDATE_CHECK`, `NO_UPDATE_NOTIFIER`, or `OPENRESEARCH_CLI_DISABLE_UPDATE=1`.
- **Prints in `start()` before the command runs**, so it shows even for the ~21 commands that `std::process::exit` early (e.g. the "not logged in" path) instead of returning to `main`. (A post-command print would have been silently skipped on exactly those stale-client paths.)
- **Atomic cache write** (temp file + `rename`) so concurrent `orx` processes never read a torn file.
- **Ignores build metadata** in the version comparison — `semver`'s `Ord` compares it, but the spec says it isn't part of precedence, so without this a local `0.1.29+build` build would falsely report itself "outdated".
- **Excludes `version` / `update`**, which manage updates themselves.

## Testing

- `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --locked` — all clean (25 tests).
- New unit tests cover the breaking/soft tiers across every semver axis (pre-1.0 minor, `0.0.x` patch, post-1.0 minor/patch, major), build-metadata, and prerelease ordering.
- Verified at runtime: warning prints **before** the early `process::exit`; stays on stderr (stdout clean); opt-out env var silences it; **no panic** when stderr is closed (`2>&-` → exit 1, not 101); cold-cache run completes in ~8ms with no blocking.

## Note for later

Left as a `RE-CONFIRM AT 1.0` comment in `is_breaking_gap`: once orx ships `1.0.0`, a `1.x` minor bump will downgrade from the breaking wording to the soft wording (semver-correct). Revisit if the backend keeps making breaking changes on minor bumps post-1.0.
