### PR TITLE
Sort projects by recency, boot into the last visited project

### DIFF
--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -94,6 +94,7 @@ fn router(state: AppState) -> Router {
                 .patch(update_project)
                 .delete(delete_project),
         )
+        .route("/api/projects/{id}/open", post(open_project))
         .route(
             "/api/projects/{id}/experiments",
             get(list_experiments).post(create_experiment),
@@ -341,6 +342,17 @@ async fn create_project(Json(req): Json<CreateProjectReq>) -> ApiResult {
 
 async fn get_project(Path(id): Path<String>) -> ApiResult {
     let project = Store::open()?
+        .get_local_project(&id)?
+        .ok_or_else(|| not_found("project"))?;
+    Ok(Json(json!({ "project": project })))
+}
+
+/// Mark a project visited: bumps updated_at, which drives the recency sort
+/// and the SSE project.updated diff.
+async fn open_project(Path(id): Path<String>) -> ApiResult {
+    let store = Store::open()?;
+    store.touch_local_project(&id)?;
+    let project = store
         .get_local_project(&id)?
         .ok_or_else(|| not_found("project"))?;
     Ok(Json(json!({ "project": project })))

--- a/src/store.rs
+++ b/src/store.rs
@@ -363,7 +363,7 @@ impl Store {
 
     pub fn list_local_projects(&self) -> Result<Vec<LocalProject>> {
         let mut stmt = self.conn.prepare(&format!(
-            "SELECT {PROJECT_COLS} FROM local_projects ORDER BY created_at ASC"
+            "SELECT {PROJECT_COLS} FROM local_projects ORDER BY updated_at DESC"
         ))?;
         let rows = stmt.query_map([], LocalProject::from_row)?;
         Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
@@ -391,6 +391,16 @@ impl Store {
         self.conn
             .execute("DELETE FROM local_projects WHERE id = ?1", params![id])?;
         tx.commit()?;
+        Ok(())
+    }
+
+    /// Bump updated_at only — records a visit for the recency sort and fires
+    /// the SSE project.updated diff.
+    pub fn touch_local_project(&self, id: &str) -> Result<()> {
+        self.conn.execute(
+            "UPDATE local_projects SET updated_at = ?2 WHERE id = ?1",
+            params![id, now_ms()],
+        )?;
         Ok(())
     }
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -6,6 +6,7 @@ import {
   listExperiments,
   listProjects,
   listRuns,
+  openProject,
   type Experiment,
   type ProjectFiles,
   type Project,
@@ -135,6 +136,9 @@ export default function App() {
   // Per-project data. Harness agents spawn lazily on the first chat message.
   useEffect(() => {
     if (!projectId) return;
+    // Record the visit; the resulting project.updated SSE event refreshes the
+    // list's recency order.
+    openProject(projectId).catch(() => {});
     setExperiments([]);
     setRuns([]);
     setFiles(null);

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -95,6 +95,10 @@ export const createProject = (body: NewProject) =>
 export const updateProject = (projectId: string, body: { runCommand?: string; name?: string }) =>
   patch<{ project: Project }>(`/api/projects/${projectId}`, body).then((r) => r.project);
 
+/** Record a visit: bumps the project's updatedAt, which drives the recency sort. */
+export const openProject = (projectId: string) =>
+  post<{ project: Project }>(`/api/projects/${projectId}/open`).then((r) => r.project);
+
 export const deleteProject = (projectId: string) =>
   fetch(`/api/projects/${projectId}`, { method: "DELETE" }).then(async (r) => {
     if (!r.ok) {

--- a/ui/src/components/ProjectsHome.tsx
+++ b/ui/src/components/ProjectsHome.tsx
@@ -50,7 +50,7 @@ export function ProjectsHome({
           {projects.length === 0 ? (
             <div className="changes-note">No projects yet — create one to get started.</div>
           ) : (
-            projects.map((p) => (
+            [...projects].sort((a, b) => b.updatedAt - a.updatedAt).map((p) => (
               <div
                 key={p.id}
                 className="project-card"


### PR DESCRIPTION
## Summary

The projects page listed projects oldest-created first, and startup always opened the oldest project. Opening a project now records a visit (`POST /api/projects/{id}/open` bumps `updated_at`), the store lists projects `updated_at DESC`, and the UI sorts by `updatedAt` — so the projects page shows most-recent first and the app boots straight into the last project you were in. The bump also fires the existing `project.updated` SSE diff, so an open projects list re-sorts live.

## Test plan

- [ ] With several projects, open the projects page: order is most-recently-visited first (not creation order)
- [ ] Open an older project, go back home: it's now at the top
- [ ] Restart `orx up` / reload the browser: the app opens the project you last had open
- [ ] Rename a project (settings PATCH): it also moves to the top (updated ⇒ recent)
- [ ] Create a new project: it lands on top and opens
- [ ] Delete a project: list still renders and sorts correctly
- [ ] Second browser window on the projects page re-sorts live (SSE) when a project is opened in the first
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --locked`, `tsc --noEmit` all pass