### PR TITLE
Codex harness: inject GitHub token so sandboxed git/gh can authenticate (v0.1.50)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,7 +928,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openresearch-cli"
-version = "0.1.49"
+version = "0.1.50"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openresearch-cli"
-version = "0.1.49"
+version = "0.1.50"
 edition = "2021"
 description = "OpenResearch CLI (orx) — Rust port"
 repository = "https://github.com/alphaXiv/openresearch-cli"

--- a/src/local/harness/codex.rs
+++ b/src/local/harness/codex.rs
@@ -325,6 +325,13 @@ async fn run_turn(ctx: &mut TurnCtx) -> Result<()> {
     };
     cmd.arg(prompt);
     prepare_env(&mut cmd);
+    // The sandbox blocks the keyring `gh` keeps its token in ("stored token is
+    // invalid" from inside the workspace), so resolve it out here and pass it
+    // down; both `gh` and its git credential helper prefer these env vars.
+    if let Some(token) = crate::local::git::resolve_github_token() {
+        cmd.env("GH_TOKEN", &token);
+        cmd.env("GITHUB_TOKEN", token);
+    }
 
     let mut child = cmd
         .spawn()


### PR DESCRIPTION
## Summary

Codex's `workspace-write` Seatbelt sandbox blocks the macOS keyring, so `gh` inside a session reports "stored token is invalid" and git's `gh auth git-credential` helper can't produce credentials — private-repo fetch/push still fail even with the network access #51 granted. This resolves the token in the parent orx process via the existing `resolve_github_token` chain (`GITHUB_TOKEN` env → synced env → `gh auth token`, which all work outside the sandbox) and sets `GH_TOKEN`/`GITHUB_TOKEN` on the codex child; both `gh` and its credential helper prefer these env vars over the keyring.

Verified against codex-cli 0.144 with controlled sandboxed `codex exec` runs: with the env vars set, `git ls-remote` on a private repo succeeds inside the sandbox and the vars pass through to agent shell commands; without them, both `ls-remote` and `gh auth token` fail exactly as reported.

## Test plan

- [x] Sandboxed `codex exec` (workspace-write + network) with `GH_TOKEN`/`GITHUB_TOKEN` in the process env can `git ls-remote` a private repo
- [x] Control: same sandbox without the env vars fails `ls-remote` and `gh auth token` (keyring blocked)
- [x] Codex 0.144 passes the env vars through to agent shell commands (no `shell_environment_policy` filtering)
- [x] `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test --locked` all green
- [ ] End-to-end: orx chat Codex session (Auto mode) on a private-repo project runs `git fetch`/`git push` successfully
- [ ] Resumed Codex session (second turn) still has working git auth
- [ ] Public-repo project with no gh login at all still works (token resolution returns None, behavior unchanged)
- [ ] Bypass-mode session unaffected