### PR TITLE
fix: append ellipsis to truncated chat session titles

### DIFF
--- a/src/local/chat/mod.rs
+++ b/src/local/chat/mod.rs
@@ -430,8 +430,12 @@ impl ChatHost {
         }
         let saved_images = save_images(&images)?;
         if session.title.is_none() {
-            let title: String = text.lines().next().unwrap_or("").chars().take(64).collect();
-            let mut title = title.trim().to_string();
+            let first_line = text.lines().next().unwrap_or("").trim();
+            let mut title: String = first_line.chars().take(64).collect();
+            if first_line.chars().count() > 64 {
+                title = title.trim_end().to_string();
+                title.push('…');
+            }
             if title.is_empty() && !saved_images.is_empty() {
                 title = "Image".into();
             }


### PR DESCRIPTION
## Summary

Chat session titles are auto-generated from the first 64 chars of the first message, hard-cut with no indicator — long prompts showed up chopped mid-word (e.g. `Reproduce "Towards Mechanistically Understandi`). Now a `…` is appended when the first line actually exceeds 64 chars (trailing whitespace trimmed first); shorter titles are unchanged.

Existing sessions keep their already-cut stored titles — only newly titled sessions get the ellipsis.

## Test plan

- [ ] Start a chat whose first message is longer than 64 chars → sidebar + header title ends with `…`
- [ ] Start a chat with a short first message → title unchanged, no `…`
- [ ] First message exactly 64 chars → no `…`
- [ ] First line ends in spaces around the cut point → no `word …` gap before the ellipsis
- [ ] Image-only first message → title still falls back to "Image"
- [x] `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test --locked` all green