### PR TITLE
Codex chat: migrate to app-server protocol (PR1 — transport swap)

### DIFF
--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -47,9 +47,10 @@ pub async fn run(args: UpArgs) -> Result<()> {
     // Harnesses spawn lazily on the first message to one of their sessions;
     // no eager agent bring-up. (--no-agent is now a no-op kept for compat.)
     let agent = Arc::new(AgentHost::new(args.model.clone()));
+    let codex = Arc::new(local::codex::CodexHost::new());
     let state = AppState {
         agent: agent.clone(),
-        chat: Arc::new(ChatHost::new(agent.clone())),
+        chat: Arc::new(ChatHost::new(agent.clone(), codex.clone())),
         harnesses: Arc::new(tokio::sync::Mutex::new(None)),
     };
 
@@ -74,6 +75,7 @@ pub async fn run(args: UpArgs) -> Result<()> {
         _ = tokio::signal::ctrl_c() => eprintln!("orx up: shutting down"),
     }
     agent.shutdown().await;
+    codex.shutdown().await;
     Ok(())
 }
 

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -481,6 +481,7 @@ async fn delete_project(State(state): State<AppState>, Path(id): Path<String>) -
     for session in store.list_chat_sessions_by_project(&id)? {
         let _ = state.chat.interrupt(&session.id).await;
         state.chat.opencode.kill_session(&session.id).await;
+        state.chat.codex.kill_session(&session.id).await;
         local::chat::cleanup_session_worktree(&project, &session.id);
     }
     store.delete_local_project(&id)?;

--- a/src/local/chat/mod.rs
+++ b/src/local/chat/mod.rs
@@ -928,7 +928,7 @@ impl TurnCtx {
                 Arc::new(crate::local::codex::CodexHost::new()),
             )),
             session_id: "test-session".into(),
-            harness: "codex".into(),
+            harness: "test".into(),
             native_session_id: None,
             model: None,
             permission_mode: None,

--- a/src/local/chat/mod.rs
+++ b/src/local/chat/mod.rs
@@ -256,6 +256,8 @@ fn stored_to_wire(m: &StoredChatMessage) -> WireMessage {
 pub struct ChatHost {
     /// Lazy opencode serve manager (only the opencode adapter spawns it).
     pub opencode: Arc<AgentHost>,
+    /// Lazy codex app-server manager (only the codex adapter spawns it).
+    pub codex: Arc<crate::local::codex::CodexHost>,
     http: reqwest::Client,
     events: broadcast::Sender<(&'static str, Value)>,
     /// Sessions with a turn in flight. A key present means busy; the value is
@@ -338,10 +340,11 @@ impl Drop for TurnGuard {
 }
 
 impl ChatHost {
-    pub fn new(opencode: Arc<AgentHost>) -> Self {
+    pub fn new(opencode: Arc<AgentHost>, codex: Arc<crate::local::codex::CodexHost>) -> Self {
         let (events, _) = broadcast::channel(256);
         Self {
             opencode,
+            codex,
             http: reqwest::Client::new(),
             events,
             turns: Mutex::new(HashMap::new()),
@@ -588,6 +591,11 @@ impl ChatHost {
                         let url = format!("http://127.0.0.1:{port}/session/{nid}/abort");
                         let _ = self.http.post(url).body("{}").send().await;
                     }
+                } else if session.harness == "codex" {
+                    // Native turn/interrupt so the app-server stops generating
+                    // (and settles the turn as "interrupted" in its rollout)
+                    // instead of only losing its orx-side listener.
+                    self.codex.interrupt_session(session_id).await;
                 }
             }
         }
@@ -718,6 +726,7 @@ impl ChatHost {
         // A live opencode serve child would keep running in (and lock) the
         // session's worktree.
         self.opencode.kill_session(session_id).await;
+        self.codex.kill_session(session_id).await;
         // Drop the session's respond lock so the map doesn't retain an entry for
         // a session that no longer exists.
         self.respond_locks.lock().await.remove(session_id);
@@ -906,6 +915,46 @@ pub struct TurnCtx {
 impl TurnCtx {
     pub fn http(&self) -> &reqwest::Client {
         &self.host.http
+    }
+
+    /// Bare in-memory ctx for harness unit tests: parts accumulate on
+    /// `assistant`, nothing is flushed or persisted (don't call `flush` /
+    /// `set_native_session_id` on it — those touch the store).
+    #[cfg(test)]
+    pub fn test_stub() -> Self {
+        Self {
+            host: Arc::new(ChatHost::new(
+                Arc::new(AgentHost::new(None)),
+                Arc::new(crate::local::codex::CodexHost::new()),
+            )),
+            session_id: "test-session".into(),
+            harness: "codex".into(),
+            native_session_id: None,
+            model: None,
+            permission_mode: None,
+            reasoning_level: None,
+            project: crate::local::model::LocalProject {
+                id: "test-project".into(),
+                name: "Test".into(),
+                slug: "test".into(),
+                github_owner: "owner".into(),
+                github_repo: "repo".into(),
+                baseline_branch: "main".into(),
+                repo_path: "/tmp/test-repo".into(),
+                run_command: None,
+                paper_id: None,
+                created_at: 0,
+                updated_at: 0,
+            },
+            text: String::new(),
+            assistant: WireMessage {
+                id: "test-msg".into(),
+                role: "assistant".into(),
+                parts: Vec::new(),
+                created_at: 0,
+            },
+            last_flush: Instant::now(),
+        }
     }
 
     /// Record the harness's own session id (CLIs mint/rotate them per turn).

--- a/src/local/codex.rs
+++ b/src/local/codex.rs
@@ -33,6 +33,8 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(150);
 /// Interrupts are best-effort and sit on the user-facing interrupt/delete
 /// paths — never let a wedged child hold those hostage.
 const INTERRUPT_TIMEOUT: Duration = Duration::from_secs(5);
+/// A healthy app-server answers `initialize` immediately.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// One inbound line, classified. JSON-RPC over one stream: a message with both
 /// `id` and `method` is a server→client *request* (approvals — must be
@@ -127,7 +129,8 @@ pub struct CodexClient {
     /// Ids of server→client requests we have not answered yet, as raw JSON
     /// text (ids are echoed verbatim). Guards `respond` against stale answers.
     unanswered: std::sync::Mutex<HashSet<String>>,
-    /// The in-flight turn's id (from `turn/started`), for `turn/interrupt`.
+    /// The in-flight turn's id (from the `turn/start` response), for
+    /// `turn/interrupt`.
     active_turn: std::sync::Mutex<Option<String>>,
     /// The thread this child has started/resumed — a fresh child (after crash
     /// or restart) must `thread/resume` before its next `turn/start`.
@@ -317,7 +320,9 @@ async fn read_loop(client: Arc<CodexClient>, stdout: tokio::process::ChildStdout
     }
 }
 
-/// Spawn `codex app-server` and complete the `initialize` handshake.
+/// Spawn `codex app-server` (no handshake yet — see `CodexHost::ensure`, which
+/// registers the client *before* the handshake so every kill path can reach
+/// the child even if the spawning turn task is aborted mid-handshake).
 async fn spawn_client() -> Result<Arc<CodexClient>> {
     let bin = find_codex_required()?;
     let mut cmd = Command::new(&bin);
@@ -370,8 +375,13 @@ async fn spawn_client() -> Result<Arc<CodexClient>> {
         resumed_thread: std::sync::Mutex::new(None),
     });
     tokio::spawn(read_loop(client.clone(), stdout));
+    Ok(client)
+}
 
-    let handshake = client.request(
+/// The `initialize` → `initialized` handshake. Split from `spawn_client` so
+/// the host can register the client between the two (abort-safe teardown).
+async fn handshake(client: &CodexClient) -> Result<()> {
+    let init = client.request(
         "initialize",
         json!({ "clientInfo": {
             "name": "orx",
@@ -379,24 +389,18 @@ async fn spawn_client() -> Result<Arc<CodexClient>> {
             "version": env!("CARGO_PKG_VERSION"),
         }}),
     );
-    match tokio::time::timeout(Duration::from_secs(10), handshake).await {
+    match tokio::time::timeout(HANDSHAKE_TIMEOUT, init).await {
         Ok(Ok(_)) => {}
-        Ok(Err(e)) => {
-            let _ = client.child.lock().await.kill().await;
-            return Err(e);
-        }
+        Ok(Err(e)) => return Err(e),
         Err(_) => {
-            let _ = client.child.lock().await.kill().await;
             return Err(anyhow!(
-                "codex app-server did not answer initialize within 10s; see {}",
+                "codex app-server did not answer initialize within {}s; see {}",
+                HANDSHAKE_TIMEOUT.as_secs(),
                 crate::store::data_dir().join("agent-codex.log").display()
             ));
         }
     }
-    client
-        .write_line(&json!({ "method": "initialized" }))
-        .await?;
-    Ok(client)
+    client.write_line(&json!({ "method": "initialized" })).await
 }
 
 /// The `orx up` codex host: one `codex app-server` child per chat session,
@@ -425,7 +429,15 @@ impl CodexHost {
     /// Spawn (or reuse) this session's app-server child. Idempotent while the
     /// child is alive; a dead child is replaced (its thread is re-resumed by
     /// the caller — `resumed_thread` starts empty on the replacement).
-    pub async fn ensure(&self, session_id: &str) -> Result<Arc<CodexClient>> {
+    ///
+    /// The spawn + handshake + registration run in a *detached* task: the
+    /// calling turn task is abortable (interrupt / delete), and an aborted
+    /// future would drop its `Arc` while the reader task keeps the child alive
+    /// — an unregistered client would be unreachable by every kill path and
+    /// leak the process for the rest of `orx up`'s life. Detached, the
+    /// bring-up always runs to completion: the client ends up registered
+    /// (killable via kill_session/shutdown) or killed on handshake failure.
+    pub async fn ensure(self: &Arc<Self>, session_id: &str) -> Result<Arc<CodexClient>> {
         let _spawning = self.spawn_lock.lock().await;
         {
             let mut guard = self.inner.lock().await;
@@ -436,12 +448,37 @@ impl CodexHost {
                 guard.remove(session_id);
             }
         }
-        let client = spawn_client().await?;
-        self.inner
-            .lock()
-            .await
-            .insert(session_id.to_string(), client.clone());
-        Ok(client)
+        let host = self.clone();
+        let session = session_id.to_string();
+        tokio::spawn(async move {
+            let client = spawn_client().await?;
+            // Never displace a live entry: if an abandoned bring-up's insert
+            // races a successor's (spawn_lock was released by the abort), the
+            // loser kills its own child and defers to the live one.
+            {
+                let mut guard = host.inner.lock().await;
+                if let Some(existing) = guard.get(&session) {
+                    if matches!(existing.child.lock().await.try_wait(), Ok(None)) {
+                        let existing = existing.clone();
+                        drop(guard);
+                        let _ = client.child.lock().await.kill().await;
+                        return Ok(existing);
+                    }
+                }
+                guard.insert(session.clone(), client.clone());
+            }
+            if let Err(e) = handshake(&client).await {
+                let _ = client.child.lock().await.kill().await;
+                let mut guard = host.inner.lock().await;
+                if guard.get(&session).is_some_and(|c| Arc::ptr_eq(c, &client)) {
+                    guard.remove(&session);
+                }
+                return Err(e);
+            }
+            Ok(client)
+        })
+        .await
+        .map_err(|e| anyhow!("codex app-server bring-up task failed: {e}"))?
     }
 
     /// The session's live client, if any (for inline replies / interrupts).

--- a/src/local/codex.rs
+++ b/src/local/codex.rs
@@ -1,0 +1,508 @@
+//! Codex app-server host — one long-lived `codex app-server` child per chat
+//! session, speaking newline-delimited JSON-RPC 2.0 over stdio (the protocol
+//! the Codex TUI/IDE use; `jsonrpc` field omitted on the wire, requests flow
+//! in BOTH directions — the server sends us approval requests we must answer
+//! by id). Mirrors `AgentHost` (opencode.rs): spawn on demand, reap on read,
+//! kill on session delete / shutdown.
+//!
+//! Wire shapes were pinned against codex-cli 0.144.0 via
+//! `codex app-server generate-json-schema` plus a live spike (see the fixture
+//! transcript in `harness/codex.rs` tests): notifications and server requests
+//! carry camelCase params; approval replies are `{"decision": "accept" |
+//! "acceptForSession" | "decline" | "cancel"}` (wrapped, not bare); thread ids
+//! are plain UUIDs persisted as rollout files under `~/.codex/sessions`, so
+//! `thread/resume {threadId}` survives an `orx up` restart.
+
+use std::collections::HashMap;
+use std::process::Stdio;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, Command};
+use tokio::sync::{mpsc, oneshot, Mutex};
+
+use crate::error::{anyhow, Result};
+use crate::local::harness::codex::{ensure_orx_data_dir, find_codex};
+
+/// One inbound line, classified. JSON-RPC over one stream: a message with both
+/// `id` and `method` is a server→client *request* (approvals — must be
+/// answered); `id` alone is a response to one of our requests; `method` alone
+/// is a notification.
+#[derive(Debug, PartialEq)]
+pub enum Line {
+    Request {
+        id: Value,
+        method: String,
+        params: Value,
+    },
+    Response {
+        id: i64,
+        result: Result<Value, String>,
+    },
+    Notification {
+        method: String,
+        params: Value,
+    },
+    Junk,
+}
+
+/// Classify one wire line. Pure — the reader task and the tests share it.
+pub fn classify_line(line: &str) -> Line {
+    let Ok(msg) = serde_json::from_str::<Value>(line) else {
+        return Line::Junk;
+    };
+    let method = msg
+        .get("method")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let id = msg.get("id");
+    match (id, method) {
+        (Some(id), Some(method)) => Line::Request {
+            // Echoed back verbatim in the reply — never assume integer.
+            id: id.clone(),
+            method,
+            params: msg.get("params").cloned().unwrap_or(Value::Null),
+        },
+        (Some(id), None) => {
+            let Some(id) = id.as_i64() else {
+                return Line::Junk; // we only ever send integer ids
+            };
+            let result = match msg.get("error") {
+                Some(err) => Err(err
+                    .get("message")
+                    .and_then(Value::as_str)
+                    .unwrap_or("codex app-server error")
+                    .to_string()),
+                None => Ok(msg.get("result").cloned().unwrap_or(Value::Null)),
+            };
+            Line::Response { id, result }
+        }
+        (None, Some(method)) => Line::Notification {
+            method,
+            params: msg.get("params").cloned().unwrap_or(Value::Null),
+        },
+        (None, None) => Line::Junk,
+    }
+}
+
+/// One event delivered to the session's in-flight turn.
+#[derive(Debug)]
+pub enum TurnEvent {
+    Notification {
+        method: String,
+        params: Value,
+    },
+    /// A server→client request (approval). The turn loop decides the reply
+    /// (surface a card / auto-answer) and sends it via [`CodexClient::respond`].
+    Request {
+        id: Value,
+        method: String,
+        params: Value,
+    },
+    /// Child died (EOF on stdout). The turn cannot continue.
+    Closed,
+}
+
+/// The in-flight turn's ids, for `turn/interrupt`.
+#[derive(Clone, Default)]
+struct ActiveTurn {
+    thread_id: Option<String>,
+    turn_id: Option<String>,
+}
+
+/// A live JSON-RPC connection to one session's `codex app-server` child.
+pub struct CodexClient {
+    child: Mutex<Child>,
+    stdin: Mutex<ChildStdin>,
+    next_id: AtomicI64,
+    /// Our outstanding requests. Sync mutex: touched from the reader task and
+    /// from `request()`, held only for map ops, never across an await.
+    pending: std::sync::Mutex<HashMap<i64, oneshot::Sender<Result<Value, String>>>>,
+    /// The session's in-flight turn, if any (one per session-child). The
+    /// registration guard drops synchronously on task abort, hence sync mutex.
+    turn: std::sync::Mutex<Option<mpsc::UnboundedSender<TurnEvent>>>,
+    /// Ids of server→client requests we have not answered yet, as raw JSON
+    /// text (ids are echoed verbatim). Guards `respond` against stale answers.
+    unanswered: std::sync::Mutex<HashMap<String, ()>>,
+    active: std::sync::Mutex<ActiveTurn>,
+    /// The thread this child has started/resumed — a fresh child (after crash
+    /// or restart) must `thread/resume` before its next `turn/start`.
+    resumed_thread: std::sync::Mutex<Option<String>>,
+}
+
+impl CodexClient {
+    /// Send a client→server request and await its response.
+    pub async fn request(&self, method: &str, params: Value) -> Result<Value> {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = oneshot::channel();
+        self.pending.lock().unwrap().insert(id, tx);
+        let sent = self
+            .write_line(&json!({ "id": id, "method": method, "params": params }))
+            .await;
+        if let Err(e) = sent {
+            self.pending.lock().unwrap().remove(&id);
+            return Err(e);
+        }
+        // Generous ceiling: thread/start can wait on the user's MCP servers.
+        match tokio::time::timeout(Duration::from_secs(150), rx).await {
+            Ok(Ok(Ok(result))) => Ok(result),
+            Ok(Ok(Err(err))) => Err(anyhow!("codex {method} failed: {err}")),
+            Ok(Err(_)) => Err(anyhow!("codex app-server closed during {method}")),
+            Err(_) => {
+                self.pending.lock().unwrap().remove(&id);
+                Err(anyhow!("codex app-server did not answer {method}"))
+            }
+        }
+    }
+
+    /// Send a notification (no id, no reply).
+    pub async fn notify(&self, method: &str, params: Option<Value>) -> Result<()> {
+        let mut msg = json!({ "method": method });
+        if let Some(params) = params {
+            msg["params"] = params;
+        }
+        self.write_line(&msg).await
+    }
+
+    /// Answer a server→client request (approval). Errors if `id` isn't
+    /// pending — the stale-answer guard (child restarted, turn ended).
+    pub async fn respond(&self, id: &Value, result: Value) -> Result<()> {
+        if self
+            .unanswered
+            .lock()
+            .unwrap()
+            .remove(&id.to_string())
+            .is_none()
+        {
+            return Err(anyhow!("this approval is no longer pending"));
+        }
+        self.write_line(&json!({ "id": id, "result": result }))
+            .await
+    }
+
+    async fn write_line(&self, msg: &Value) -> Result<()> {
+        let mut stdin = self.stdin.lock().await;
+        stdin
+            .write_all(format!("{msg}\n").as_bytes())
+            .await
+            .map_err(|e| anyhow!("codex app-server stdin: {e}"))?;
+        stdin
+            .flush()
+            .await
+            .map_err(|e| anyhow!("codex app-server stdin: {e}"))?;
+        Ok(())
+    }
+
+    /// Register the session's turn event sink. The returned guard deregisters
+    /// on drop (including task abort mid-turn).
+    pub fn register_turn(self: &Arc<Self>, tx: mpsc::UnboundedSender<TurnEvent>) -> TurnRoute {
+        *self.turn.lock().unwrap() = Some(tx);
+        TurnRoute {
+            client: self.clone(),
+        }
+    }
+
+    /// The thread this child has already started/resumed, if any.
+    pub fn resumed_thread(&self) -> Option<String> {
+        self.resumed_thread.lock().unwrap().clone()
+    }
+
+    pub fn set_resumed_thread(&self, thread_id: &str) {
+        *self.resumed_thread.lock().unwrap() = Some(thread_id.to_string());
+        self.active.lock().unwrap().thread_id = Some(thread_id.to_string());
+    }
+
+    pub fn set_active_turn(&self, turn_id: &str) {
+        self.active.lock().unwrap().turn_id = Some(turn_id.to_string());
+    }
+
+    /// Best-effort native interrupt of the in-flight turn.
+    pub async fn interrupt_active_turn(&self) {
+        let ActiveTurn { thread_id, turn_id } = self.active.lock().unwrap().clone();
+        if let (Some(thread_id), Some(turn_id)) = (thread_id, turn_id) {
+            let _ = self
+                .request(
+                    "turn/interrupt",
+                    json!({ "threadId": thread_id, "turnId": turn_id }),
+                )
+                .await;
+        }
+    }
+}
+
+/// RAII turn registration — dropping (normal exit or task abort) detaches the
+/// event sink so a dangling turn can't receive another turn's events.
+pub struct TurnRoute {
+    client: Arc<CodexClient>,
+}
+
+impl Drop for TurnRoute {
+    fn drop(&mut self) {
+        *self.client.turn.lock().unwrap() = None;
+        self.client.active.lock().unwrap().turn_id = None;
+    }
+}
+
+/// Reader task: pump child stdout, route each line. On EOF every pending
+/// request fails and the live turn (if any) gets [`TurnEvent::Closed`].
+async fn read_loop(client: Arc<CodexClient>, stdout: tokio::process::ChildStdout) {
+    let mut lines = BufReader::new(stdout).lines();
+    while let Ok(Some(line)) = lines.next_line().await {
+        match classify_line(&line) {
+            Line::Response { id, result } => {
+                if let Some(tx) = client.pending.lock().unwrap().remove(&id) {
+                    let _ = tx.send(result);
+                }
+            }
+            Line::Request { id, method, params } => {
+                client.unanswered.lock().unwrap().insert(id.to_string(), ());
+                let routed = {
+                    let turn = client.turn.lock().unwrap();
+                    turn.as_ref()
+                        .map(|tx| {
+                            tx.send(TurnEvent::Request {
+                                id: id.clone(),
+                                method: method.clone(),
+                                params: params.clone(),
+                            })
+                            .is_ok()
+                        })
+                        .unwrap_or(false)
+                };
+                if !routed {
+                    // No turn is listening (raced an abort). Never leave the
+                    // server hanging on a request nobody will answer.
+                    let _ = client.respond(&id, json!({ "decision": "decline" })).await;
+                }
+            }
+            Line::Notification { method, params } => {
+                let turn = client.turn.lock().unwrap();
+                if let Some(tx) = turn.as_ref() {
+                    let _ = tx.send(TurnEvent::Notification { method, params });
+                }
+            }
+            Line::Junk => {}
+        }
+    }
+    // EOF: the child is gone. Fail everything that is still waiting.
+    for (_, tx) in client.pending.lock().unwrap().drain() {
+        let _ = tx.send(Err("codex app-server exited".into()));
+    }
+    client.unanswered.lock().unwrap().clear();
+    if let Some(tx) = client.turn.lock().unwrap().as_ref() {
+        let _ = tx.send(TurnEvent::Closed);
+    }
+}
+
+/// Spawn `codex app-server` and complete the `initialize` handshake.
+async fn spawn_client() -> Result<Arc<CodexClient>> {
+    let bin = find_codex().ok_or_else(|| {
+        anyhow!("codex not found on PATH — install Codex and run `codex login` first")
+    })?;
+    let mut cmd = Command::new(&bin);
+    cmd.arg("app-server")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::from(crate::local::chat::harness_log("codex")?))
+        .kill_on_drop(true);
+    crate::local::chat::prepare_env(&mut cmd);
+    // Pin the child's store to the same canonicalized dir the sandbox policy
+    // grants (see harness/codex.rs `ensure_orx_data_dir`) — after prepare_env
+    // so the pin beats a dashboard-synced ORX_DATA_DIR. Unconditional: the
+    // child is shared by every permission mode, so unlike the old per-turn
+    // exec pin this also applies under Bypass (more coherent — agent store ==
+    // served store in every mode).
+    if let Some(dir) = ensure_orx_data_dir() {
+        cmd.env("ORX_DATA_DIR", &dir);
+    }
+    // The sandbox blocks the keyring `gh` keeps its token in; resolve it out
+    // here and pass it down. Resolved once per child, not per turn.
+    if let Some(token) = crate::local::git::resolve_github_token() {
+        cmd.env("GH_TOKEN", &token);
+        cmd.env("GITHUB_TOKEN", token);
+    }
+    // Own process group: a terminal SIGINT reaches orx up alone, which then
+    // tears the child down deliberately (kill_on_drop / shutdown()).
+    #[cfg(unix)]
+    cmd.process_group(0);
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| anyhow!("Could not spawn {} app-server: {}", bin.display(), e))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow!("codex app-server: no stdout"))?;
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow!("codex app-server: no stdin"))?;
+
+    let client = Arc::new(CodexClient {
+        child: Mutex::new(child),
+        stdin: Mutex::new(stdin),
+        next_id: AtomicI64::new(1),
+        pending: std::sync::Mutex::new(HashMap::new()),
+        turn: std::sync::Mutex::new(None),
+        unanswered: std::sync::Mutex::new(HashMap::new()),
+        active: std::sync::Mutex::new(ActiveTurn::default()),
+        resumed_thread: std::sync::Mutex::new(None),
+    });
+    tokio::spawn(read_loop(client.clone(), stdout));
+
+    let handshake = client.request(
+        "initialize",
+        json!({ "clientInfo": {
+            "name": "orx",
+            "title": "OpenResearch",
+            "version": env!("CARGO_PKG_VERSION"),
+        }}),
+    );
+    match tokio::time::timeout(Duration::from_secs(10), handshake).await {
+        Ok(Ok(_)) => {}
+        Ok(Err(e)) => {
+            let _ = client.child.lock().await.kill().await;
+            return Err(e);
+        }
+        Err(_) => {
+            let _ = client.child.lock().await.kill().await;
+            return Err(anyhow!(
+                "codex app-server did not answer initialize within 10s; see {}",
+                crate::store::data_dir().join("agent-codex.log").display()
+            ));
+        }
+    }
+    client.notify("initialized", None).await?;
+    Ok(client)
+}
+
+/// The `orx up` codex host: one `codex app-server` child per chat session,
+/// keyed by the orx session id. Share as `Arc<CodexHost>` in axum state.
+pub struct CodexHost {
+    /// Serializes ensure() spawns (a spawn is quick, and one at a time keeps
+    /// the handshake traffic sane). `inner` is never held across a spawn.
+    spawn_lock: Mutex<()>,
+    inner: Mutex<HashMap<String, Arc<CodexClient>>>,
+}
+
+impl Default for CodexHost {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CodexHost {
+    pub fn new() -> Self {
+        Self {
+            spawn_lock: Mutex::new(()),
+            inner: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Spawn (or reuse) this session's app-server child. Idempotent while the
+    /// child is alive; a dead child is replaced (its thread is re-resumed by
+    /// the caller — `resumed_thread` starts empty on the replacement).
+    pub async fn ensure(&self, session_id: &str) -> Result<Arc<CodexClient>> {
+        let _spawning = self.spawn_lock.lock().await;
+        {
+            let mut guard = self.inner.lock().await;
+            if let Some(client) = guard.get(session_id) {
+                if matches!(client.child.lock().await.try_wait(), Ok(None)) {
+                    return Ok(client.clone());
+                }
+                guard.remove(session_id);
+            }
+        }
+        let client = spawn_client().await?;
+        self.inner
+            .lock()
+            .await
+            .insert(session_id.to_string(), client.clone());
+        Ok(client)
+    }
+
+    /// The session's live client, if any (for inline replies / interrupts).
+    pub async fn client_for(&self, session_id: &str) -> Option<Arc<CodexClient>> {
+        let mut guard = self.inner.lock().await;
+        let client = guard.get(session_id)?;
+        if matches!(client.child.lock().await.try_wait(), Ok(None)) {
+            Some(client.clone())
+        } else {
+            guard.remove(session_id);
+            None
+        }
+    }
+
+    /// Natively interrupt the session's in-flight turn (best-effort).
+    pub async fn interrupt_session(&self, session_id: &str) {
+        if let Some(client) = self.client_for(session_id).await {
+            client.interrupt_active_turn().await;
+        }
+    }
+
+    /// Kill and reap one session's child (on session delete).
+    pub async fn kill_session(&self, session_id: &str) {
+        if let Some(client) = self.inner.lock().await.remove(session_id) {
+            let _ = client.child.lock().await.kill().await;
+        }
+    }
+
+    /// Kill and reap every child (also happens via kill_on_drop on exit).
+    pub async fn shutdown(&self) {
+        for (_, client) in self.inner.lock().await.drain() {
+            let _ = client.child.lock().await.kill().await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_discriminates_the_three_wire_shapes() {
+        // Server→client request: id + method. Id kept as raw Value.
+        assert_eq!(
+            classify_line(
+                r#"{"id":0,"method":"item/commandExecution/requestApproval","params":{"threadId":"t"}}"#
+            ),
+            Line::Request {
+                id: json!(0),
+                method: "item/commandExecution/requestApproval".into(),
+                params: json!({"threadId": "t"}),
+            }
+        );
+        // Response to one of our requests: id only.
+        assert_eq!(
+            classify_line(r#"{"id":2,"result":{"thread":{"id":"abc"}}}"#),
+            Line::Response {
+                id: 2,
+                result: Ok(json!({"thread":{"id":"abc"}}))
+            }
+        );
+        // Error response carries the message.
+        assert_eq!(
+            classify_line(r#"{"id":3,"error":{"code":-32600,"message":"bad"}}"#),
+            Line::Response {
+                id: 3,
+                result: Err("bad".into())
+            }
+        );
+        // Notification: method only.
+        assert_eq!(
+            classify_line(r#"{"method":"turn/completed","params":{"threadId":"t"}}"#),
+            Line::Notification {
+                method: "turn/completed".into(),
+                params: json!({"threadId":"t"})
+            }
+        );
+        // Junk never panics.
+        assert_eq!(classify_line("not json"), Line::Junk);
+        assert_eq!(classify_line("{}"), Line::Junk);
+        // Non-integer response id (we only send integers) is junk, not a panic.
+        assert_eq!(classify_line(r#"{"id":"weird","result":{}}"#), Line::Junk);
+    }
+}

--- a/src/local/codex.rs
+++ b/src/local/codex.rs
@@ -430,13 +430,16 @@ impl CodexHost {
     /// child is alive; a dead child is replaced (its thread is re-resumed by
     /// the caller — `resumed_thread` starts empty on the replacement).
     ///
-    /// The spawn + handshake + registration run in a *detached* task: the
+    /// The spawn + registration + handshake run in a *detached* task: the
     /// calling turn task is abortable (interrupt / delete), and an aborted
     /// future would drop its `Arc` while the reader task keeps the child alive
     /// — an unregistered client would be unreachable by every kill path and
     /// leak the process for the rest of `orx up`'s life. Detached, the
     /// bring-up always runs to completion: the client ends up registered
     /// (killable via kill_session/shutdown) or killed on handshake failure.
+    /// One consequence of registering before the handshake: a reuse hit may
+    /// briefly hand out a still-mid-handshake client; its requests fail
+    /// cleanly (server "not initialized" / closed) and the next turn recovers.
     pub async fn ensure(self: &Arc<Self>, session_id: &str) -> Result<Arc<CodexClient>> {
         let _spawning = self.spawn_lock.lock().await;
         {

--- a/src/local/codex.rs
+++ b/src/local/codex.rs
@@ -13,7 +13,7 @@
 //! are plain UUIDs persisted as rollout files under `~/.codex/sessions`, so
 //! `thread/resume {threadId}` survives an `orx up` restart.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
@@ -25,7 +25,14 @@ use tokio::process::{Child, ChildStdin, Command};
 use tokio::sync::{mpsc, oneshot, Mutex};
 
 use crate::error::{anyhow, Result};
-use crate::local::harness::codex::{ensure_orx_data_dir, find_codex};
+use crate::local::harness::codex::{ensure_orx_data_dir, find_codex_required};
+
+/// Ceiling on a request's response wait — generous because `thread/start`
+/// blocks on the user's own MCP servers coming up.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(150);
+/// Interrupts are best-effort and sit on the user-facing interrupt/delete
+/// paths — never let a wedged child hold those hostage.
+const INTERRUPT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// One inbound line, classified. JSON-RPC over one stream: a message with both
 /// `id` and `method` is a server→client *request* (approvals — must be
@@ -106,13 +113,6 @@ pub enum TurnEvent {
     Closed,
 }
 
-/// The in-flight turn's ids, for `turn/interrupt`.
-#[derive(Clone, Default)]
-struct ActiveTurn {
-    thread_id: Option<String>,
-    turn_id: Option<String>,
-}
-
 /// A live JSON-RPC connection to one session's `codex app-server` child.
 pub struct CodexClient {
     child: Mutex<Child>,
@@ -126,16 +126,21 @@ pub struct CodexClient {
     turn: std::sync::Mutex<Option<mpsc::UnboundedSender<TurnEvent>>>,
     /// Ids of server→client requests we have not answered yet, as raw JSON
     /// text (ids are echoed verbatim). Guards `respond` against stale answers.
-    unanswered: std::sync::Mutex<HashMap<String, ()>>,
-    active: std::sync::Mutex<ActiveTurn>,
+    unanswered: std::sync::Mutex<HashSet<String>>,
+    /// The in-flight turn's id (from `turn/started`), for `turn/interrupt`.
+    active_turn: std::sync::Mutex<Option<String>>,
     /// The thread this child has started/resumed — a fresh child (after crash
     /// or restart) must `thread/resume` before its next `turn/start`.
     resumed_thread: std::sync::Mutex<Option<String>>,
 }
 
 impl CodexClient {
-    /// Send a client→server request and await its response.
-    pub async fn request(&self, method: &str, params: Value) -> Result<Value> {
+    /// Send a client→server request; `Ok(Err(msg))` is a *server-reported*
+    /// JSON-RPC error, `Err(..)` a transport failure (child gone / timeout).
+    /// Callers that must tell "codex said no" apart from "codex didn't answer"
+    /// (e.g. the thread/resume fallback) use this; everyone else wants
+    /// [`Self::request`].
+    pub async fn try_request(&self, method: &str, params: Value) -> Result<Result<Value, String>> {
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let (tx, rx) = oneshot::channel();
         self.pending.lock().unwrap().insert(id, tx);
@@ -146,41 +151,41 @@ impl CodexClient {
             self.pending.lock().unwrap().remove(&id);
             return Err(e);
         }
-        // Generous ceiling: thread/start can wait on the user's MCP servers.
-        match tokio::time::timeout(Duration::from_secs(150), rx).await {
-            Ok(Ok(Ok(result))) => Ok(result),
-            Ok(Ok(Err(err))) => Err(anyhow!("codex {method} failed: {err}")),
+        match tokio::time::timeout(REQUEST_TIMEOUT, rx).await {
+            Ok(Ok(result)) => Ok(result),
             Ok(Err(_)) => Err(anyhow!("codex app-server closed during {method}")),
             Err(_) => {
                 self.pending.lock().unwrap().remove(&id);
-                Err(anyhow!("codex app-server did not answer {method}"))
+                Err(anyhow!(
+                    "codex app-server did not answer {method} within {}s",
+                    REQUEST_TIMEOUT.as_secs()
+                ))
             }
         }
     }
 
-    /// Send a notification (no id, no reply).
-    pub async fn notify(&self, method: &str, params: Option<Value>) -> Result<()> {
-        let mut msg = json!({ "method": method });
-        if let Some(params) = params {
-            msg["params"] = params;
+    /// [`Self::try_request`] with server errors collapsed into `Err`.
+    pub async fn request(&self, method: &str, params: Value) -> Result<Value> {
+        match self.try_request(method, params).await? {
+            Ok(result) => Ok(result),
+            Err(err) => Err(anyhow!("codex {method} failed: {err}")),
         }
-        self.write_line(&msg).await
     }
 
     /// Answer a server→client request (approval). Errors if `id` isn't
     /// pending — the stale-answer guard (child restarted, turn ended).
     pub async fn respond(&self, id: &Value, result: Value) -> Result<()> {
-        if self
-            .unanswered
-            .lock()
-            .unwrap()
-            .remove(&id.to_string())
-            .is_none()
-        {
+        if !self.unanswered.lock().unwrap().remove(&id.to_string()) {
             return Err(anyhow!("this approval is no longer pending"));
         }
         self.write_line(&json!({ "id": id, "result": result }))
             .await
+    }
+
+    /// Decline a server→client request — the fail-safe answer whenever no one
+    /// can (or should) decide, so the server is never left blocked on us.
+    pub async fn respond_decline(&self, id: &Value) -> Result<()> {
+        self.respond(id, json!({ "decision": "decline" })).await
     }
 
     async fn write_line(&self, msg: &Value) -> Result<()> {
@@ -199,9 +204,10 @@ impl CodexClient {
     /// Register the session's turn event sink. The returned guard deregisters
     /// on drop (including task abort mid-turn).
     pub fn register_turn(self: &Arc<Self>, tx: mpsc::UnboundedSender<TurnEvent>) -> TurnRoute {
-        *self.turn.lock().unwrap() = Some(tx);
+        *self.turn.lock().unwrap() = Some(tx.clone());
         TurnRoute {
             client: self.clone(),
+            tx,
         }
     }
 
@@ -212,37 +218,49 @@ impl CodexClient {
 
     pub fn set_resumed_thread(&self, thread_id: &str) {
         *self.resumed_thread.lock().unwrap() = Some(thread_id.to_string());
-        self.active.lock().unwrap().thread_id = Some(thread_id.to_string());
     }
 
     pub fn set_active_turn(&self, turn_id: &str) {
-        self.active.lock().unwrap().turn_id = Some(turn_id.to_string());
+        *self.active_turn.lock().unwrap() = Some(turn_id.to_string());
     }
 
-    /// Best-effort native interrupt of the in-flight turn.
+    /// Best-effort native interrupt of the in-flight turn. Bounded: this sits
+    /// on the user-facing interrupt/delete paths, and a wedged child (stdin
+    /// full, not answering) must not hold them for the full request timeout.
     pub async fn interrupt_active_turn(&self) {
-        let ActiveTurn { thread_id, turn_id } = self.active.lock().unwrap().clone();
+        let thread_id = self.resumed_thread();
+        let turn_id = self.active_turn.lock().unwrap().clone();
         if let (Some(thread_id), Some(turn_id)) = (thread_id, turn_id) {
-            let _ = self
-                .request(
+            let _ = tokio::time::timeout(
+                INTERRUPT_TIMEOUT,
+                self.request(
                     "turn/interrupt",
                     json!({ "threadId": thread_id, "turnId": turn_id }),
-                )
-                .await;
+                ),
+            )
+            .await;
         }
     }
 }
 
 /// RAII turn registration — dropping (normal exit or task abort) detaches the
-/// event sink so a dangling turn can't receive another turn's events.
+/// event sink so a dangling turn can't receive another turn's events. An
+/// aborted task's guard drops *asynchronously*, possibly after a successor
+/// turn has already registered — so drop only detaches its *own* channel,
+/// never a successor's.
 pub struct TurnRoute {
     client: Arc<CodexClient>,
+    tx: mpsc::UnboundedSender<TurnEvent>,
 }
 
 impl Drop for TurnRoute {
     fn drop(&mut self) {
-        *self.client.turn.lock().unwrap() = None;
-        self.client.active.lock().unwrap().turn_id = None;
+        let mut turn = self.client.turn.lock().unwrap();
+        if turn.as_ref().is_some_and(|t| t.same_channel(&self.tx)) {
+            *turn = None;
+            drop(turn);
+            *self.client.active_turn.lock().unwrap() = None;
+        }
     }
 }
 
@@ -258,24 +276,22 @@ async fn read_loop(client: Arc<CodexClient>, stdout: tokio::process::ChildStdout
                 }
             }
             Line::Request { id, method, params } => {
-                client.unanswered.lock().unwrap().insert(id.to_string(), ());
+                client.unanswered.lock().unwrap().insert(id.to_string());
                 let routed = {
                     let turn = client.turn.lock().unwrap();
-                    turn.as_ref()
-                        .map(|tx| {
-                            tx.send(TurnEvent::Request {
-                                id: id.clone(),
-                                method: method.clone(),
-                                params: params.clone(),
-                            })
-                            .is_ok()
+                    turn.as_ref().is_some_and(|tx| {
+                        tx.send(TurnEvent::Request {
+                            id: id.clone(),
+                            method,
+                            params,
                         })
-                        .unwrap_or(false)
+                        .is_ok()
+                    })
                 };
                 if !routed {
                     // No turn is listening (raced an abort). Never leave the
                     // server hanging on a request nobody will answer.
-                    let _ = client.respond(&id, json!({ "decision": "decline" })).await;
+                    let _ = client.respond_decline(&id).await;
                 }
             }
             Line::Notification { method, params } => {
@@ -287,7 +303,11 @@ async fn read_loop(client: Arc<CodexClient>, stdout: tokio::process::ChildStdout
             Line::Junk => {}
         }
     }
-    // EOF: the child is gone. Fail everything that is still waiting.
+    // EOF or read error: the connection is unusable either way. Kill the child
+    // if it is somehow still alive (a half-dead child left in the registry
+    // would eat a request timeout per turn until restart), then fail everything
+    // still waiting.
+    let _ = client.child.lock().await.kill().await;
     for (_, tx) in client.pending.lock().unwrap().drain() {
         let _ = tx.send(Err("codex app-server exited".into()));
     }
@@ -299,9 +319,7 @@ async fn read_loop(client: Arc<CodexClient>, stdout: tokio::process::ChildStdout
 
 /// Spawn `codex app-server` and complete the `initialize` handshake.
 async fn spawn_client() -> Result<Arc<CodexClient>> {
-    let bin = find_codex().ok_or_else(|| {
-        anyhow!("codex not found on PATH — install Codex and run `codex login` first")
-    })?;
+    let bin = find_codex_required()?;
     let mut cmd = Command::new(&bin);
     cmd.arg("app-server")
         .stdin(Stdio::piped())
@@ -347,8 +365,8 @@ async fn spawn_client() -> Result<Arc<CodexClient>> {
         next_id: AtomicI64::new(1),
         pending: std::sync::Mutex::new(HashMap::new()),
         turn: std::sync::Mutex::new(None),
-        unanswered: std::sync::Mutex::new(HashMap::new()),
-        active: std::sync::Mutex::new(ActiveTurn::default()),
+        unanswered: std::sync::Mutex::new(HashSet::new()),
+        active_turn: std::sync::Mutex::new(None),
         resumed_thread: std::sync::Mutex::new(None),
     });
     tokio::spawn(read_loop(client.clone(), stdout));
@@ -375,7 +393,9 @@ async fn spawn_client() -> Result<Arc<CodexClient>> {
             ));
         }
     }
-    client.notify("initialized", None).await?;
+    client
+        .write_line(&json!({ "method": "initialized" }))
+        .await?;
     Ok(client)
 }
 
@@ -436,7 +456,7 @@ impl CodexHost {
         }
     }
 
-    /// Natively interrupt the session's in-flight turn (best-effort).
+    /// Natively interrupt the session's in-flight turn (best-effort, bounded).
     pub async fn interrupt_session(&self, session_id: &str) {
         if let Some(client) = self.client_for(session_id).await {
             client.interrupt_active_turn().await;
@@ -464,15 +484,21 @@ mod tests {
 
     #[test]
     fn classify_discriminates_the_three_wire_shapes() {
-        // Server→client request: id + method. Id kept as raw Value.
+        // Server→client request: id + method. Id kept as raw Value. (Fixture
+        // captured live from the 0.144 spike, trimmed.)
         assert_eq!(
             classify_line(
-                r#"{"id":0,"method":"item/commandExecution/requestApproval","params":{"threadId":"t"}}"#
+                r#"{"method":"item/commandExecution/requestApproval","id":0,"params":{"threadId":"t1","turnId":"turn1","itemId":"call_1","startedAtMs":1,"reason":"Allow writing the requested probe file outside the workspace?","command":"/bin/zsh -lc 'touch /outside/probe.txt'","cwd":"/ws"}}"#
             ),
             Line::Request {
                 id: json!(0),
                 method: "item/commandExecution/requestApproval".into(),
-                params: json!({"threadId": "t"}),
+                params: json!({
+                    "threadId": "t1", "turnId": "turn1", "itemId": "call_1",
+                    "startedAtMs": 1,
+                    "reason": "Allow writing the requested probe file outside the workspace?",
+                    "command": "/bin/zsh -lc 'touch /outside/probe.txt'", "cwd": "/ws",
+                }),
             }
         );
         // Response to one of our requests: id only.

--- a/src/local/harness/codex.rs
+++ b/src/local/harness/codex.rs
@@ -558,7 +558,7 @@ async fn run_turn_app_server(ctx: &mut TurnCtx) -> Result<()> {
                 // propagates as the turn's error (the `?` above) — a resumable
                 // thread must never be discarded over a timeout/hiccup.
                 Err(err) => {
-                    eprintln!("codex thread/resume rejected ({err}); starting a fresh thread");
+                    eprintln!("orx up: codex thread/resume rejected ({err}); starting a fresh thread");
                     start_thread(ctx, &client, thread_setup).await?
                 }
             }

--- a/src/local/harness/codex.rs
+++ b/src/local/harness/codex.rs
@@ -116,8 +116,9 @@ impl Harness for Codex {
         info.agent_ready = info.installed && info.authenticated;
         if info.agent_ready {
             info = info.with_models(&CODEX_MODELS);
-            // Old CLIs still work via the legacy exec path, but without the
-            // app-server wins (permission prompts on sandbox escalations).
+            // Old CLIs still work via the legacy exec path, but miss the
+            // app-server wins (thread resume; the approval channel the
+            // follow-up builds on).
             let too_old = info
                 .version
                 .as_deref()
@@ -188,20 +189,23 @@ impl Harness for Codex {
 /// live spike). Older CLIs take the exec fallback below.
 const MIN_APP_SERVER_VERSION: (u64, u64, u64) = (0, 144, 0);
 
-/// `codex --version` output → (major, minor, patch). Accepts "codex-cli
-/// 0.144.0" and bare "0.144.0"; a `-suffix` on the patch is tolerated.
+/// `codex --version` output → (major, minor, patch). The first token that
+/// parses wins, so "codex-cli 0.144.0", bare "0.144.0", and a future
+/// "codex-cli 0.150.0 (abc123)" all resolve; a `-suffix` on the patch is
+/// tolerated.
 fn parse_codex_version(version: &str) -> Option<(u64, u64, u64)> {
-    let token = version.split_whitespace().last()?;
-    let mut parts = token.splitn(3, '.');
-    let major = parts.next()?.parse().ok()?;
-    let minor = parts.next()?.parse().ok()?;
-    let patch = parts.next()?;
-    let patch = patch
-        .split(|c: char| !c.is_ascii_digit())
-        .next()?
-        .parse()
-        .ok()?;
-    Some((major, minor, patch))
+    version.split_whitespace().find_map(|token| {
+        let mut parts = token.splitn(3, '.');
+        let major = parts.next()?.parse().ok()?;
+        let minor = parts.next()?.parse().ok()?;
+        let patch = parts
+            .next()?
+            .split(|c: char| !c.is_ascii_digit())
+            .next()?
+            .parse()
+            .ok()?;
+        Some((major, minor, patch))
+    })
 }
 
 /// Whether the installed codex speaks the validated app-server protocol.
@@ -243,8 +247,8 @@ fn codex_policies(mode: Option<PermissionMode>) -> (&'static str, &'static str) 
 /// `.git` as writable roots (see `ensure_orx_data_dir` / `shared_git_dir`),
 /// and network on (the agent's job is driving the orx API and git). Like the
 /// exec `-c` override, this is a full policy replacement for the turn — a
-/// user's own config.toml `writableRoots` don't survive it (no append form
-/// exists on either transport).
+/// user's own config.toml `sandbox_workspace_write.writable_roots` don't
+/// survive it (no append form exists on either transport).
 async fn sandbox_policy_json(mode: Option<PermissionMode>, workspace: &Path) -> Value {
     match mode.unwrap_or(PermissionMode::Auto) {
         PermissionMode::Bypass => serde_json::json!({ "type": "dangerFullAccess" }),
@@ -265,14 +269,15 @@ async fn sandbox_policy_json(mode: Option<PermissionMode>, workspace: &Path) -> 
     }
 }
 
-/// One app-server notification → transcript state. Pure (fixture-tested):
-/// touches only `ctx.assistant.parts` via the TurnCtx helpers. Returns the
-/// turn's terminal state when this event ends it.
+/// How a turn ended, from `turn/completed`.
 enum TurnEnd {
     Done,
     Failed(String),
 }
 
+/// One app-server notification → transcript state. Pure (fixture-tested):
+/// touches only `ctx.assistant.parts` via the TurnCtx helpers. Returns the
+/// turn's terminal state when this event ends it.
 fn apply_notification(ctx: &mut TurnCtx, method: &str, params: &Value) -> Option<TurnEnd> {
     match method {
         "item/started" | "item/completed" => {
@@ -352,7 +357,7 @@ fn append_delta(ctx: &mut TurnCtx, params: &Value, make: impl FnOnce(String) -> 
     ) else {
         return;
     };
-    if ctx.assistant.parts.iter().all(|p| p.id != item_id) {
+    if !part_exists(ctx, item_id) {
         ctx.upsert_part(make(item_id.to_string()));
     }
     ctx.append_part_text(item_id, delta);
@@ -552,7 +557,10 @@ async fn run_turn_app_server(ctx: &mut TurnCtx) -> Result<()> {
                 // is lost either way. A transport failure, by contrast,
                 // propagates as the turn's error (the `?` above) — a resumable
                 // thread must never be discarded over a timeout/hiccup.
-                Err(_) => start_thread(ctx, &client, thread_setup).await?,
+                Err(err) => {
+                    eprintln!("codex thread/resume rejected ({err}); starting a fresh thread");
+                    start_thread(ctx, &client, thread_setup).await?
+                }
             }
         }
         None => start_thread(ctx, &client, thread_setup).await?,
@@ -586,21 +594,17 @@ async fn run_turn_app_server(ctx: &mut TurnCtx) -> Result<()> {
         .and_then(|t| t.get("id"))
         .and_then(Value::as_str)
         .map(str::to_string);
+    // Arm the native interrupt now rather than on `turn/started` — an
+    // interrupt landing before that notification would otherwise no-op.
+    if let Some(turn_id) = turn_id.as_deref() {
+        client.set_active_turn(turn_id);
+    }
 
     while let Some(event) = rx.recv().await {
         match event {
             TurnEvent::Notification { method, params } => {
                 if event_turn_mismatch(turn_id.as_deref(), &params) {
                     continue;
-                }
-                if method == "turn/started" {
-                    if let Some(turn_id) = params
-                        .get("turn")
-                        .and_then(|t| t.get("id"))
-                        .and_then(Value::as_str)
-                    {
-                        client.set_active_turn(turn_id);
-                    }
                 }
                 match apply_notification(ctx, &method, &params) {
                     Some(TurnEnd::Done) => {
@@ -625,7 +629,9 @@ async fn run_turn_app_server(ctx: &mut TurnCtx) -> Result<()> {
                 // approvalPolicy is `never` on every mode, so no approval
                 // should arrive; decline defensively rather than leave the
                 // server blocked on an unanswered request. The follow-up
-                // surfaces these as permission cards.
+                // surfaces these as permission cards — and must keep declining
+                // stale-turn requests (params carry turnId; `event_turn_mismatch`
+                // works on them unchanged) instead of surfacing them.
                 let _ = client.respond_decline(&id).await;
             }
             TurnEvent::Closed => {
@@ -678,24 +684,7 @@ async fn start_thread(ctx: &mut TurnCtx, client: &CodexClient, params: Value) ->
     Ok(thread_id)
 }
 
-// --- legacy exec path (codex < 0.144, and ORX_CODEX_EXEC=1) -------------------
-
-/// Session mode → Codex `exec` sandbox policy. `codex exec` can't prompt for
-/// approval, so the sandbox *is* the permission boundary. `Bypass` is the one
-/// mode that also drops the sandbox entirely (`--dangerously-...`); the rest run
-/// sandboxed with approvals set to `never` (nothing to escalate to). Returns
-/// `None` for `Bypass` to signal "use the bypass flag instead of `-s`".
-fn codex_sandbox(mode: Option<PermissionMode>) -> Option<&'static str> {
-    match mode.unwrap_or(PermissionMode::Auto) {
-        PermissionMode::Plan => Some("read-only"),
-        // AcceptEdits/Ask have no distinct exec semantics — treat as the
-        // balanced default so a session that carries them still runs sanely.
-        PermissionMode::Auto | PermissionMode::AcceptEdits | PermissionMode::Ask => {
-            Some("workspace-write")
-        }
-        PermissionMode::Bypass => None,
-    }
-}
+// --- shared by both transports -------------------------------------------
 
 /// The workspace's git dir (`git rev-parse --git-common-dir`), canonicalized.
 /// Codex's `workspace-write` sandbox denies every git metadata write: it marks
@@ -750,6 +739,48 @@ pub(crate) fn ensure_orx_data_dir() -> Option<PathBuf> {
     dir.canonicalize().ok()
 }
 
+/// Session reasoning id → Codex `model_reasoning_effort` value. The composer only
+/// offers ids from `CODEX_REASONING_LEVELS`; an unrecognized/absent value omits
+/// the override and lets Codex apply its configured default.
+fn codex_reasoning(level: Option<&str>) -> Option<&str> {
+    let level = level?;
+    CODEX_REASONING_LEVELS
+        .iter()
+        .any(|(id, _)| *id == level)
+        .then_some(level)
+}
+
+fn command_string(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Array(parts) => parts
+            .iter()
+            .filter_map(Value::as_str)
+            .collect::<Vec<_>>()
+            .join(" "),
+        _ => String::new(),
+    }
+}
+
+// --- legacy exec path (codex < 0.144, and ORX_CODEX_EXEC=1) -------------------
+
+/// Session mode → Codex `exec` sandbox policy. `codex exec` can't prompt for
+/// approval, so the sandbox *is* the permission boundary. `Bypass` is the one
+/// mode that also drops the sandbox entirely (`--dangerously-...`); the rest run
+/// sandboxed with approvals set to `never` (nothing to escalate to). Returns
+/// `None` for `Bypass` to signal "use the bypass flag instead of `-s`".
+fn codex_sandbox(mode: Option<PermissionMode>) -> Option<&'static str> {
+    match mode.unwrap_or(PermissionMode::Auto) {
+        PermissionMode::Plan => Some("read-only"),
+        // AcceptEdits/Ask have no distinct exec semantics — treat as the
+        // balanced default so a session that carries them still runs sanely.
+        PermissionMode::Auto | PermissionMode::AcceptEdits | PermissionMode::Ask => {
+            Some("workspace-write")
+        }
+        PermissionMode::Bypass => None,
+    }
+}
+
 /// The `-c` value granting `roots` as sandbox writable roots, e.g.
 /// `sandbox_workspace_write.writable_roots=["/a", "/b"]`. `None` when there
 /// are no roots (omit the flag: `-c ...=[]` would still *replace* the user's
@@ -773,29 +804,6 @@ fn toml_string(path: &Path) -> String {
     serde_json::to_string(&path.to_string_lossy())
         .unwrap_or_else(|_| String::from("\"\""))
         .replace('\u{7f}', "\\u007F")
-}
-
-/// Session reasoning id → Codex `model_reasoning_effort` value. The composer only
-/// offers ids from `CODEX_REASONING_LEVELS`; an unrecognized/absent value omits
-/// the override and lets Codex apply its configured default.
-fn codex_reasoning(level: Option<&str>) -> Option<&str> {
-    let level = level?;
-    CODEX_REASONING_LEVELS
-        .iter()
-        .any(|(id, _)| *id == level)
-        .then_some(level)
-}
-
-fn command_string(v: &Value) -> String {
-    match v {
-        Value::String(s) => s.clone(),
-        Value::Array(parts) => parts
-            .iter()
-            .filter_map(Value::as_str)
-            .collect::<Vec<_>>()
-            .join(" "),
-        _ => String::new(),
-    }
 }
 
 async fn run_turn_exec(ctx: &mut TurnCtx) -> Result<()> {
@@ -1159,8 +1167,7 @@ mod tests {
             match crate::local::codex::classify_line(line) {
                 crate::local::codex::Line::Notification { method, params } => {
                     assert!(
-                        !event_turn_mismatch(Some("turn1"), &params)
-                            || params.get("turnId").is_none(),
+                        !event_turn_mismatch(Some("turn1"), &params),
                         "fixture events all belong to turn1"
                     );
                     if let Some(end) = apply_notification(&mut ctx, &method, &params) {
@@ -1255,6 +1262,25 @@ mod tests {
         );
         let state = ctx.assistant.parts[0].state.as_ref().unwrap();
         assert_eq!(state.output.as_deref(), Some("final"));
+    }
+
+    /// The Failed-dedup guard matches exactly how `push_error` stores errors
+    /// (status "error" + the `error` field), and nothing else.
+    #[test]
+    fn has_error_part_matches_pushed_errors_only() {
+        let mut ctx = TurnCtx::test_stub();
+        assert!(!has_error_part(&ctx, "boom"));
+        ctx.push_error("boom".to_string());
+        assert!(has_error_part(&ctx, "boom"));
+        assert!(!has_error_part(&ctx, "other"));
+        // A failed *command* part is not an error part — its state.error is
+        // None, so identical text can't false-match.
+        apply_notification(
+            &mut ctx,
+            "item/completed",
+            &serde_json::json!({"item":{"type":"commandExecution","id":"c1","command":"x","status":"failed"}}),
+        );
+        assert!(!has_error_part(&ctx, "x"));
     }
 
     #[test]

--- a/src/local/harness/codex.rs
+++ b/src/local/harness/codex.rs
@@ -200,6 +200,34 @@ fn absolute_git_dir(workspace: &Path, dir: &Path) -> Option<PathBuf> {
     workspace.join(dir).canonicalize().ok()
 }
 
+/// The orx data dir as a sandbox writable root. The `orx` CLI the agent
+/// drives opens the SQLite store read-write (plus journal/WAL sidecars)
+/// directly at `store::data_dir()`, which sits under `~/.local/share` —
+/// outside every workspace — so `workspace-write` denies the open and every
+/// store-touching command dies with "unable to open database file". Created
+/// here (host side, unsandboxed) so canonicalize can't fail before first use;
+/// canonicalized for the same reason as `shared_git_dir`.
+fn orx_data_dir() -> Option<PathBuf> {
+    let dir = crate::store::data_dir();
+    std::fs::create_dir_all(&dir).ok()?;
+    dir.canonicalize().ok()
+}
+
+/// The `-c` value granting `roots` as sandbox writable roots, e.g.
+/// `sandbox_workspace_write.writable_roots=["/a", "/b"]`. `None` when there
+/// are no roots (omit the flag: `-c ...=[]` would still *replace* the user's
+/// configured roots with nothing).
+fn writable_roots_override(roots: &[PathBuf]) -> Option<String> {
+    if roots.is_empty() {
+        return None;
+    }
+    let list: Vec<String> = roots.iter().map(|p| toml_string(p)).collect();
+    Some(format!(
+        "sandbox_workspace_write.writable_roots=[{}]",
+        list.join(", ")
+    ))
+}
+
 /// A path as a TOML basic-string literal, for `-c key="value"` overrides.
 /// serde_json's escaping emits only sequences TOML also accepts (`\"`, `\\`,
 /// control chars as `\uXXXX`) and leaves `/` literal — except DEL (0x7F),
@@ -276,13 +304,17 @@ async fn run_turn(ctx: &mut TurnCtx) -> Result<()> {
                 "approval_policy=\"never\"",
             ]);
             // workspace-write out of the box is too tight for the orx
-            // workflow in two ways (both verified via `codex sandbox` against
-            // codex-cli 0.144; in the TUI both denials escalate to approval
+            // workflow in three ways (all verified via `codex sandbox` against
+            // codex-cli 0.144; in the TUI these denials escalate to approval
             // prompts, which `codex exec` doesn't have):
             //   * Network is blocked by default — DNS doesn't even resolve, so
             //     `git fetch`/`push`, package installs, and the `orx` CLI's
             //     localhost API calls all die. The agent's job is launching
             //     experiments over that API; Auto must keep the network open.
+            //   * The orx store isn't writable — the SQLite DB lives in the
+            //     data dir under `~/.local/share`, outside the workspace, so
+            //     every `orx` command that touches it fails with "unable to
+            //     open database file"; grant the data dir (see `orx_data_dir`).
             //   * Git metadata isn't writable — codex protects `.git` inside
             //     the workspace, and a worktree's real metadata (the hub
             //     clone's `.git`) sits outside it — so `git fetch`/`commit`
@@ -292,14 +324,11 @@ async fn run_turn(ctx: &mut TurnCtx) -> Result<()> {
             //     --add-dir` is unverified on the resume path).
             if policy == "workspace-write" {
                 cmd.args(["-c", "sandbox_workspace_write.network_access=true"]);
-                if let Some(git_dir) = shared_git_dir(&repo).await {
-                    cmd.args([
-                        "-c",
-                        &format!(
-                            "sandbox_workspace_write.writable_roots=[{}]",
-                            toml_string(&git_dir)
-                        ),
-                    ]);
+                let mut roots = Vec::new();
+                roots.extend(orx_data_dir());
+                roots.extend(shared_git_dir(&repo).await);
+                if let Some(override_arg) = writable_roots_override(&roots) {
+                    cmd.args(["-c", &override_arg]);
                 }
             }
         }
@@ -570,6 +599,17 @@ mod tests {
         assert_eq!(toml_string(Path::new(r#"/a/"q""#)), r#""/a/\"q\"""#);
         // DEL is the one char serde_json leaves raw that TOML rejects.
         assert_eq!(toml_string(Path::new("/a/\u{7f}b")), r#""/a/\u007Fb""#);
+    }
+
+    #[test]
+    fn writable_roots_override_joins_and_omits_empty() {
+        assert_eq!(
+            writable_roots_override(&[PathBuf::from("/data dir"), PathBuf::from("/hub/.git")]),
+            Some(r#"sandbox_workspace_write.writable_roots=["/data dir", "/hub/.git"]"#.into())
+        );
+        // No roots → no flag at all; `=[]` would clobber the user's own
+        // config.toml roots for the turn.
+        assert_eq!(writable_roots_override(&[]), None);
     }
 
     #[test]

--- a/src/local/harness/codex.rs
+++ b/src/local/harness/codex.rs
@@ -121,9 +121,9 @@ impl Harness for Codex {
         // launches that are the point. (Codex has a real first-class Plan mode,
         // but only over `app-server`/the TUI — `codex exec` doesn't honor it;
         // verified `-c collaboration_mode="plan"` is accepted but ignored.)
-        //   * Auto  — workspace-write, plus network and the hub clone's
-        //     `.git` (see `run_turn`), since exec can't approve its way past
-        //     either denial the way the TUI can.
+        //   * Auto  — workspace-write, plus network, the orx data dir, and
+        //     the hub clone's `.git` (see `run_turn`), since exec can't
+        //     approve its way past any of those denials the way the TUI can.
         //   * Bypass— full access (`--dangerously-bypass-approvals-and-sandbox`).
         HarnessOptions::none()
             .with_permission_modes(
@@ -294,13 +294,15 @@ async fn run_turn(ctx: &mut TurnCtx) -> Result<()> {
     // Permission mode → sandbox policy. `codex exec` can't prompt, so the
     // sandbox is the approval boundary: non-bypass modes run sandboxed with
     // approvals disabled (nothing to escalate to), `Bypass` drops both.
-    let mut data_dir_pin: Option<PathBuf> = None;
     //
     // Set the policy via `-c sandbox_mode=` rather than `-s`: the `exec resume`
     // subcommand rejects `-s` ("unexpected argument"), but accepts `-c` on both
     // the fresh and resume paths (verified against codex-cli 0.143), so one form
     // works for the whole session lifecycle.
-    match codex_sandbox(ctx.permission_mode) {
+    //
+    // Yields the data dir granted as a writable root (if any), so the child's
+    // store can be pinned to it below, after `prepare_env`.
+    let data_dir_pin = match codex_sandbox(ctx.permission_mode) {
         Some(policy) => {
             cmd.args([
                 "-c",
@@ -330,19 +332,24 @@ async fn run_turn(ctx: &mut TurnCtx) -> Result<()> {
             // --add-dir` is unverified on the resume path).
             if policy == "workspace-write" {
                 cmd.args(["-c", "sandbox_workspace_write.network_access=true"]);
-                data_dir_pin = ensure_orx_data_dir();
-                let mut roots = Vec::new();
-                roots.extend(data_dir_pin.clone());
-                roots.extend(shared_git_dir(&repo).await);
+                let data_dir = ensure_orx_data_dir();
+                let roots: Vec<PathBuf> = [data_dir.clone(), shared_git_dir(&repo).await]
+                    .into_iter()
+                    .flatten()
+                    .collect();
                 if let Some(override_arg) = writable_roots_override(&roots) {
                     cmd.args(["-c", &override_arg]);
                 }
+                data_dir
+            } else {
+                None
             }
         }
         None => {
             cmd.arg("--dangerously-bypass-approvals-and-sandbox");
+            None
         }
-    }
+    };
     // Reasoning level → Codex's own `model_reasoning_effort` config override.
     if let Some(effort) = codex_reasoning(ctx.reasoning_level.as_deref()) {
         cmd.args(["-c", &format!("model_reasoning_effort=\"{effort}\"")]);
@@ -368,6 +375,8 @@ async fn run_turn(ctx: &mut TurnCtx) -> Result<()> {
     // relative `ORX_DATA_DIR` resolves against the child's cwd, not ours.
     // Must come after `prepare_env`: later `cmd.env` calls win, and the
     // synced-env injection guards on the *process* env, not the cmd's map.
+    // (Unsandboxed Bypass has no grant to stay coherent with, so no pin — a
+    // synced `ORX_DATA_DIR` still wins there.)
     if let Some(dir) = &data_dir_pin {
         cmd.env("ORX_DATA_DIR", dir);
     }

--- a/src/local/harness/codex.rs
+++ b/src/local/harness/codex.rs
@@ -35,6 +35,7 @@ use super::options::{HarnessOptions, PermissionMode};
 use super::Harness;
 use crate::error::{anyhow, Result};
 use crate::local::chat::{prepare_env, TurnCtx, WirePart, WireToolState};
+use crate::local::codex::{CodexClient, TurnEvent};
 use crate::local::opencode::ensure_playbook;
 
 // The 5.6 variants (Sol = frontier, Terra = balanced, Luna = fast) plus 5.5;
@@ -59,6 +60,14 @@ pub struct Codex;
 /// find its `codex-code-mode-host` helper next to the real binary).
 pub fn find_codex() -> Option<PathBuf> {
     find_on_path("codex").map(resolve_symlinks)
+}
+
+/// `find_codex` with the install hint baked in (the `find_opencode` precedent)
+/// — shared by both transports' spawn paths.
+pub(crate) fn find_codex_required() -> Result<PathBuf> {
+    find_codex().ok_or_else(|| {
+        anyhow!("codex not found on PATH — install Codex and run `codex login` first")
+    })
 }
 
 #[async_trait]
@@ -116,7 +125,7 @@ impl Harness for Codex {
                 .is_some_and(|v| v < MIN_APP_SERVER_VERSION);
             if too_old {
                 info.agent_note = Some(
-                    "Update Codex to 0.144+ for permission prompts; older versions use the legacy exec path.".to_string(),
+                    "This Codex version chats via the legacy exec path — update to 0.144+ for the app-server integration.".to_string(),
                 );
             }
         } else {
@@ -129,27 +138,28 @@ impl Harness for Codex {
     async fn run_turn(&self, ctx: &mut TurnCtx) -> Result<()> {
         // app-server for codex ≥ 0.144 (the validated protocol version);
         // legacy exec for older CLIs, for one release. ORX_CODEX_EXEC=1 is the
-        // escape hatch if app-server misbehaves.
-        if std::env::var_os("ORX_CODEX_EXEC").is_some() || !app_server_supported().await {
+        // escape hatch if app-server misbehaves ("0"/empty don't count).
+        let force_exec = std::env::var("ORX_CODEX_EXEC").is_ok_and(|v| !v.is_empty() && v != "0");
+        if force_exec || !app_server_supported().await {
             return run_turn_exec(ctx).await;
         }
         run_turn_app_server(ctx).await
     }
 
     fn options(&self) -> HarnessOptions {
-        // `codex exec` is non-interactive — no approval channel to prompt over
-        // (verified: on-request emits no approval event; the sandbox just allows
-        // or denies), so permission modes map onto the *sandbox policy*. We offer
-        // only Auto + Bypass, matching Claude. A `Plan`→`read-only` sandbox was
-        // considered but dropped for the same reason plan mode was dropped for
-        // Claude: read-only blocks the `orx` inspection the agent needs *and* the
-        // launches that are the point. (Codex has a real first-class Plan mode,
-        // but only over `app-server`/the TUI — `codex exec` doesn't honor it;
-        // verified `-c collaboration_mode="plan"` is accepted but ignored.)
+        // Approvals are `never` on both transports this release, so permission
+        // modes map onto the *sandbox policy*; we offer only Auto + Bypass,
+        // matching Claude. On app-server that's a deliberate hold — the pure
+        // transport swap (see `codex_policies`); the follow-up flips Auto to
+        // `on-request` and can then revisit Codex's first-class Plan mode,
+        // which app-server does support. On the legacy exec fallback there is
+        // no approval channel at all, and a `Plan`→`read-only` sandbox was
+        // dropped for the same reason as Claude's: read-only blocks the `orx`
+        // inspection the agent needs *and* the launches that are the point.
         //   * Auto  — workspace-write, plus network, the orx data dir, and
-        //     the hub clone's `.git` (see `run_turn`), since exec can't
-        //     approve its way past any of those denials the way the TUI can.
-        //   * Bypass— full access (`--dangerously-bypass-approvals-and-sandbox`).
+        //     the hub clone's `.git` (see `sandbox_policy_json`, and
+        //     `run_turn_exec` for the legacy `-c` form).
+        //   * Bypass— full access.
         HarnessOptions::none()
             .with_permission_modes(
                 &[PermissionMode::Auto, PermissionMode::Bypass],
@@ -231,9 +241,10 @@ fn codex_policies(mode: Option<PermissionMode>) -> (&'static str, &'static str) 
 /// The per-turn `sandboxPolicy` object. workspace-write carries the same
 /// grants the exec path passed via `-c`: the orx data dir + the hub clone's
 /// `.git` as writable roots (see `ensure_orx_data_dir` / `shared_git_dir`),
-/// and network on (the agent's job is driving the orx API and git). Unlike
-/// the exec `-c` override this is a first-class param and does not clobber
-/// the user's config.toml roots.
+/// and network on (the agent's job is driving the orx API and git). Like the
+/// exec `-c` override, this is a full policy replacement for the turn — a
+/// user's own config.toml `writableRoots` don't survive it (no append form
+/// exists on either transport).
 async fn sandbox_policy_json(mode: Option<PermissionMode>, workspace: &Path) -> Value {
     match mode.unwrap_or(PermissionMode::Auto) {
         PermissionMode::Bypass => serde_json::json!({ "type": "dangerFullAccess" }),
@@ -284,6 +295,17 @@ fn apply_notification(ctx: &mut TurnCtx, method: &str, params: &Value) -> Option
             ) else {
                 return None;
             };
+            // Deltas can beat `item/started`; a placeholder part (command
+            // unknown yet) is corrected by the later item events.
+            if !part_exists(ctx, item_id) {
+                ctx.upsert_part(tool_part(
+                    item_id.to_string(),
+                    "bash",
+                    "running",
+                    Some(serde_json::json!({ "command": "" })),
+                    None,
+                ));
+            }
             if let Some(part) = ctx.assistant.parts.iter_mut().find(|p| p.id == item_id) {
                 if let Some(state) = part.state.as_mut() {
                     let output = state.output.get_or_insert_with(String::new);
@@ -308,6 +330,12 @@ fn apply_notification(ctx: &mut TurnCtx, method: &str, params: &Value) -> Option
             if status == "failed" {
                 return Some(TurnEnd::Failed(error_message(turn.get("error"))));
             }
+            // Defensive: the pins say turn/completed carries a final status,
+            // but a non-final one must not truncate the turn if codex ever
+            // regresses.
+            if status == "inProgress" {
+                return None;
+            }
             return Some(TurnEnd::Done); // completed | interrupted
         }
         _ => {}
@@ -330,6 +358,46 @@ fn append_delta(ctx: &mut TurnCtx, params: &Value, make: impl FnOnce(String) -> 
     ctx.append_part_text(item_id, delta);
 }
 
+/// Whether the assistant message already carries a part with this id.
+fn part_exists(ctx: &TurnCtx, id: &str) -> bool {
+    ctx.assistant.parts.iter().any(|p| p.id == id)
+}
+
+/// A tool-flavored WirePart (bash / edit) in one of the three statuses.
+fn tool_part(
+    id: String,
+    tool: &str,
+    status: &str,
+    input: Option<Value>,
+    output: Option<String>,
+) -> WirePart {
+    WirePart {
+        id,
+        kind: "tool".into(),
+        text: None,
+        tool: Some(tool.into()),
+        state: Some(WireToolState {
+            status: status.into(),
+            input,
+            output,
+            error: None,
+            title: None,
+        }),
+        prompt: None,
+    }
+}
+
+/// running / error / completed for a (possibly still-open) tool item.
+fn tool_status(completed: bool, failed: bool) -> &'static str {
+    if !completed {
+        "running"
+    } else if failed {
+        "error"
+    } else {
+        "completed"
+    }
+}
+
 /// A ThreadItem (from `item/started` / `item/completed`) → WirePart.
 fn apply_item(ctx: &mut TurnCtx, item: &Value, completed: bool) {
     let Some(id) = item.get("id").and_then(Value::as_str).map(str::to_string) else {
@@ -340,13 +408,13 @@ fn apply_item(ctx: &mut TurnCtx, item: &Value, completed: bool) {
             let text = item.get("text").and_then(Value::as_str).unwrap_or("");
             // The completed item is authoritative — but never wipe streamed
             // deltas with an empty final text.
-            if !completed || !text.is_empty() || ctx.assistant.parts.iter().all(|p| p.id != id) {
+            if !completed || !text.is_empty() || !part_exists(ctx, &id) {
                 ctx.upsert_part(WirePart::text(id, text));
             }
         }
         Some("reasoning") => {
             let text = reasoning_text(item);
-            if !completed || !text.is_empty() || ctx.assistant.parts.iter().all(|p| p.id != id) {
+            if !completed || !text.is_empty() || !part_exists(ctx, &id) {
                 ctx.upsert_part(WirePart::reasoning(id, &text));
             }
         }
@@ -373,29 +441,16 @@ fn apply_item(ctx: &mut TurnCtx, item: &Value, completed: bool) {
                         .and_then(|p| p.state.as_ref())
                         .and_then(|s| s.output.clone())
                 });
-            ctx.upsert_part(WirePart {
-                id,
-                kind: "tool".into(),
-                text: None,
-                tool: Some("bash".into()),
-                state: Some(WireToolState {
-                    status: if !completed {
-                        "running"
-                    } else if failed {
-                        "error"
-                    } else {
-                        "completed"
-                    }
-                    .into(),
-                    input: Some(serde_json::json!({
-                        "command": item.get("command").map(command_string).unwrap_or_default(),
-                    })),
-                    output,
-                    error: None,
-                    title: None,
-                }),
-                prompt: None,
+            let input = serde_json::json!({
+                "command": item.get("command").map(command_string).unwrap_or_default(),
             });
+            ctx.upsert_part(tool_part(
+                id,
+                "bash",
+                tool_status(completed, failed),
+                Some(input),
+                output,
+            ));
         }
         Some("fileChange") => {
             let failed = completed
@@ -403,30 +458,17 @@ fn apply_item(ctx: &mut TurnCtx, item: &Value, completed: bool) {
                     item.get("status").and_then(Value::as_str),
                     Some("completed")
                 );
-            ctx.upsert_part(WirePart {
+            let input = item
+                .get("changes")
+                .cloned()
+                .map(|c| serde_json::json!({ "changes": c }));
+            ctx.upsert_part(tool_part(
                 id,
-                kind: "tool".into(),
-                text: None,
-                tool: Some("edit".into()),
-                state: Some(WireToolState {
-                    status: if !completed {
-                        "running"
-                    } else if failed {
-                        "error"
-                    } else {
-                        "completed"
-                    }
-                    .into(),
-                    input: item
-                        .get("changes")
-                        .cloned()
-                        .map(|c| serde_json::json!({ "changes": c })),
-                    output: None,
-                    error: None,
-                    title: None,
-                }),
-                prompt: None,
-            });
+                "edit",
+                tool_status(completed, failed),
+                input,
+                None,
+            ));
         }
         // userMessage (our own echo), mcpToolCall, webSearch, plan, …: not
         // rendered (parity with the exec path); unknown types tolerated.
@@ -500,18 +542,20 @@ async fn run_turn_app_server(ctx: &mut TurnCtx) -> Result<()> {
         Some(id) => {
             let mut params = thread_setup.clone();
             params["threadId"] = Value::String(id.clone());
-            match client.request("thread/resume", params).await {
+            match client.try_request("thread/resume", params).await? {
                 Ok(_) => {
                     client.set_resumed_thread(&id);
                     id
                 }
-                // Unresumable id (e.g. minted by the old exec path): start a
-                // fresh thread. Prior context is lost, matching what codex
-                // itself does when a rollout is gone.
-                Err(_) => start_thread(ctx, &client, thread_setup.clone()).await?,
+                // Codex *rejected* the id (e.g. minted by the old exec path,
+                // or the rollout is gone): start a fresh thread; prior context
+                // is lost either way. A transport failure, by contrast,
+                // propagates as the turn's error (the `?` above) — a resumable
+                // thread must never be discarded over a timeout/hiccup.
+                Err(_) => start_thread(ctx, &client, thread_setup).await?,
             }
         }
-        None => start_thread(ctx, &client, thread_setup.clone()).await?,
+        None => start_thread(ctx, &client, thread_setup).await?,
     };
 
     // Route events to this turn before starting it — nothing is missed.
@@ -532,11 +576,23 @@ async fn run_turn_app_server(ctx: &mut TurnCtx) -> Result<()> {
     if let Some(effort) = codex_reasoning(ctx.reasoning_level.as_deref()) {
         turn_params["effort"] = Value::String(effort.to_string());
     }
-    client.request("turn/start", turn_params).await?;
+    let started = client.request("turn/start", turn_params).await?;
+    // Everything below is filtered to this turn: an earlier turn of the same
+    // session that was orx-side aborted (its native interrupt raced or never
+    // fired) can still be streaming into the shared channel, and its tail —
+    // fatally, its `turn/completed` — must not leak into this transcript.
+    let turn_id = started
+        .get("turn")
+        .and_then(|t| t.get("id"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
 
     while let Some(event) = rx.recv().await {
         match event {
-            crate::local::codex::TurnEvent::Notification { method, params } => {
+            TurnEvent::Notification { method, params } => {
+                if event_turn_mismatch(turn_id.as_deref(), &params) {
+                    continue;
+                }
                 if method == "turn/started" {
                     if let Some(turn_id) = params
                         .get("turn")
@@ -552,7 +608,11 @@ async fn run_turn_app_server(ctx: &mut TurnCtx) -> Result<()> {
                         return Ok(());
                     }
                     Some(TurnEnd::Failed(message)) => {
-                        ctx.push_error(message);
+                        // A terminal `error` notification may have already
+                        // pushed this exact message — don't render it twice.
+                        if !has_error_part(ctx, &message) {
+                            ctx.push_error(message);
+                        }
                         let _ = ctx.flush();
                         // The turn *finished* (with an error the transcript
                         // already shows); an Err here would double-report.
@@ -561,16 +621,14 @@ async fn run_turn_app_server(ctx: &mut TurnCtx) -> Result<()> {
                     None => {}
                 }
             }
-            crate::local::codex::TurnEvent::Request { id, .. } => {
+            TurnEvent::Request { id, .. } => {
                 // approvalPolicy is `never` on every mode, so no approval
                 // should arrive; decline defensively rather than leave the
                 // server blocked on an unanswered request. The follow-up
                 // surfaces these as permission cards.
-                let _ = client
-                    .respond(&id, serde_json::json!({ "decision": "decline" }))
-                    .await;
+                let _ = client.respond_decline(&id).await;
             }
-            crate::local::codex::TurnEvent::Closed => {
+            TurnEvent::Closed => {
                 return Err(anyhow!(
                     "codex app-server exited mid-turn; see {}",
                     crate::store::data_dir().join("agent-codex.log").display()
@@ -582,12 +640,32 @@ async fn run_turn_app_server(ctx: &mut TurnCtx) -> Result<()> {
     Err(anyhow!("codex app-server event stream ended mid-turn"))
 }
 
+/// True when the notification names a turn that is not ours. Notifications
+/// without a turn id (warnings, thread-level events) pass through.
+fn event_turn_mismatch(expected: Option<&str>, params: &Value) -> bool {
+    let Some(expected) = expected else {
+        return false;
+    };
+    let event_turn = params.get("turnId").and_then(Value::as_str).or_else(|| {
+        params
+            .get("turn")
+            .and_then(|t| t.get("id"))
+            .and_then(Value::as_str)
+    });
+    event_turn.is_some_and(|t| t != expected)
+}
+
+/// Whether the transcript already shows an error part with this message.
+fn has_error_part(ctx: &TurnCtx, message: &str) -> bool {
+    ctx.assistant.parts.iter().any(|p| {
+        p.state
+            .as_ref()
+            .is_some_and(|s| s.status == "error" && s.error.as_deref() == Some(message))
+    })
+}
+
 /// `thread/start` and record the new thread id as the session's native id.
-async fn start_thread(
-    ctx: &mut TurnCtx,
-    client: &std::sync::Arc<crate::local::codex::CodexClient>,
-    params: Value,
-) -> Result<String> {
+async fn start_thread(ctx: &mut TurnCtx, client: &CodexClient, params: Value) -> Result<String> {
     let result = client.request("thread/start", params).await?;
     let thread_id = result
         .get("thread")
@@ -721,9 +799,7 @@ fn command_string(v: &Value) -> String {
 }
 
 async fn run_turn_exec(ctx: &mut TurnCtx) -> Result<()> {
-    let bin = find_codex().ok_or_else(|| {
-        anyhow!("codex not found on PATH — install Codex and run `codex login` first")
-    })?;
+    let bin = find_codex_required()?;
     let project = ctx.project.clone();
     let session_id = ctx.session_id.clone();
     let (repo, playbook) =
@@ -1082,6 +1158,11 @@ mod tests {
         for line in transcript {
             match crate::local::codex::classify_line(line) {
                 crate::local::codex::Line::Notification { method, params } => {
+                    assert!(
+                        !event_turn_mismatch(Some("turn1"), &params)
+                            || params.get("turnId").is_none(),
+                        "fixture events all belong to turn1"
+                    );
                     if let Some(end) = apply_notification(&mut ctx, &method, &params) {
                         ended = Some(end);
                         break;
@@ -1113,19 +1194,32 @@ mod tests {
         );
     }
 
-    /// The live approval request from the spike classifies as a server→client
-    /// request (id + method) — the shape the run loop must answer by id.
+    /// Foreign-turn tails (an aborted predecessor still streaming) are
+    /// filtered; turn-less notifications (warnings) pass through.
     #[test]
-    fn approval_request_classifies_as_request() {
-        let line = r#"{"method":"item/commandExecution/requestApproval","id":0,"params":{"threadId":"t1","turnId":"turn1","itemId":"call_1","startedAtMs":1,"reason":"Allow writing the requested probe file outside the workspace?","command":"/bin/zsh -lc 'touch /outside/probe.txt'","cwd":"/ws"}}"#;
-        match crate::local::codex::classify_line(line) {
-            crate::local::codex::Line::Request { id, method, params } => {
-                assert_eq!(id, serde_json::json!(0));
-                assert_eq!(method, "item/commandExecution/requestApproval");
-                assert_eq!(params["itemId"], "call_1");
-            }
-            other => panic!("expected Request, got {other:?}"),
-        }
+    fn turn_filter_skips_foreign_turns_only() {
+        let expected = Some("turn2");
+        assert!(event_turn_mismatch(
+            expected,
+            &serde_json::json!({"turnId": "turn1", "delta": "stale"})
+        ));
+        assert!(event_turn_mismatch(
+            expected,
+            &serde_json::json!({"turn": {"id": "turn1", "status": "completed"}})
+        ));
+        assert!(!event_turn_mismatch(
+            expected,
+            &serde_json::json!({"turnId": "turn2"})
+        ));
+        assert!(!event_turn_mismatch(
+            expected,
+            &serde_json::json!({"message": "no turn id here"})
+        ));
+        // Before turn/start answers, nothing is filtered.
+        assert!(!event_turn_mismatch(
+            None,
+            &serde_json::json!({"turnId": "turn1"})
+        ));
     }
 
     #[test]
@@ -1192,7 +1286,7 @@ mod tests {
         );
         match end {
             Some(TurnEnd::Failed(msg)) => assert_eq!(msg, "boom"),
-            other => panic!("expected Failed, got {:?}", other.is_some()),
+            _ => panic!("expected Failed"),
         }
         // Interrupted is a clean end, not a failure.
         let end = apply_notification(

--- a/src/local/harness/codex.rs
+++ b/src/local/harness/codex.rs
@@ -206,8 +206,12 @@ fn absolute_git_dir(workspace: &Path, dir: &Path) -> Option<PathBuf> {
 /// outside every workspace — so `workspace-write` denies the open and every
 /// store-touching command dies with "unable to open database file". Created
 /// here (host side, unsandboxed) so canonicalize can't fail before first use;
-/// canonicalized for the same reason as `shared_git_dir`.
-fn orx_data_dir() -> Option<PathBuf> {
+/// canonicalized for the same reason as `shared_git_dir`. Note the grant is
+/// the whole data dir — every project's store rows plus `run-logs/` and the
+/// `agent-*.log` files — not scoped to the session; that's inherent to the
+/// CLI opening the shared DB directly, and still strictly narrower than
+/// Bypass.
+fn ensure_orx_data_dir() -> Option<PathBuf> {
     let dir = crate::store::data_dir();
     std::fs::create_dir_all(&dir).ok()?;
     dir.canonicalize().ok()
@@ -290,6 +294,7 @@ async fn run_turn(ctx: &mut TurnCtx) -> Result<()> {
     // Permission mode → sandbox policy. `codex exec` can't prompt, so the
     // sandbox is the approval boundary: non-bypass modes run sandboxed with
     // approvals disabled (nothing to escalate to), `Bypass` drops both.
+    let mut data_dir_pin: Option<PathBuf> = None;
     //
     // Set the policy via `-c sandbox_mode=` rather than `-s`: the `exec resume`
     // subcommand rejects `-s` ("unexpected argument"), but accepts `-c` on both
@@ -314,18 +319,20 @@ async fn run_turn(ctx: &mut TurnCtx) -> Result<()> {
             //   * The orx store isn't writable — the SQLite DB lives in the
             //     data dir under `~/.local/share`, outside the workspace, so
             //     every `orx` command that touches it fails with "unable to
-            //     open database file"; grant the data dir (see `orx_data_dir`).
+            //     open database file"; grant the data dir (see
+            //     `ensure_orx_data_dir`).
             //   * Git metadata isn't writable — codex protects `.git` inside
             //     the workspace, and a worktree's real metadata (the hub
             //     clone's `.git`) sits outside it — so `git fetch`/`commit`
             //     fail outright; grant the common dir (see `shared_git_dir`).
-            //     Note `-c` *replaces* any `writable_roots` from the user's
-            //     config.toml for the turn (there is no append form; `exec
-            //     --add-dir` is unverified on the resume path).
+            // Note `-c` *replaces* any `writable_roots` from the user's
+            // config.toml for the turn (there is no append form; `exec
+            // --add-dir` is unverified on the resume path).
             if policy == "workspace-write" {
                 cmd.args(["-c", "sandbox_workspace_write.network_access=true"]);
+                data_dir_pin = ensure_orx_data_dir();
                 let mut roots = Vec::new();
-                roots.extend(orx_data_dir());
+                roots.extend(data_dir_pin.clone());
                 roots.extend(shared_git_dir(&repo).await);
                 if let Some(override_arg) = writable_roots_override(&roots) {
                     cmd.args(["-c", &override_arg]);
@@ -354,6 +361,16 @@ async fn run_turn(ctx: &mut TurnCtx) -> Result<()> {
     };
     cmd.arg(prompt);
     prepare_env(&mut cmd);
+    // Pin the sandboxed turn's store to the exact path granted above. The
+    // grant was resolved from the host's env, but the child could resolve a
+    // different data dir — `prepare_env` injects dashboard-synced vars (a
+    // synced `ORX_DATA_DIR`/`XDG_DATA_HOME` absent from the host env), and a
+    // relative `ORX_DATA_DIR` resolves against the child's cwd, not ours.
+    // Must come after `prepare_env`: later `cmd.env` calls win, and the
+    // synced-env injection guards on the *process* env, not the cmd's map.
+    if let Some(dir) = &data_dir_pin {
+        cmd.env("ORX_DATA_DIR", dir);
+    }
     // The sandbox blocks the keyring `gh` keeps its token in ("stored token is
     // invalid" from inside the workspace), so resolve it out here and pass it
     // down; both `gh` and its git credential helper prefer these env vars.

--- a/src/local/harness/codex.rs
+++ b/src/local/harness/codex.rs
@@ -1,13 +1,20 @@
 //! Codex harness.
 //!
-//! Chat: one `codex exec --json` process per turn, JSONL events on stdout,
-//! multi-turn via `codex exec resume <session>`. Uses the user's own
-//! `codex login` (ChatGPT plan or API key). Codex has no system-prompt flag and
-//! reads AGENTS.md (which the repo may own), so the playbook is injected as
-//! tagged context on the first turn — the display transcript stores only the
-//! user's text. The event parser accepts both JSONL shapes codex has shipped:
-//! legacy `{"id", "msg": {"type": ...}}` and item-style `{"type":
-//! "item.completed", "item": {...}}`.
+//! Chat rides Codex's **app-server** protocol (codex ≥ 0.144): one long-lived
+//! `codex app-server` child per session (see `local::codex`), a thread per
+//! session (`thread/start` / `thread/resume` — the thread id persists as the
+//! session's `native_session_id`), one `turn/start` per message, events
+//! streamed as JSON-RPC notifications. The playbook rides
+//! `developerInstructions` (a real instruction channel — no more first-turn
+//! `<system-context>` text wrapping), and the sandbox policy travels per turn
+//! (`sandboxPolicy` with writable roots + network). Verified against
+//! codex-cli 0.144.0 via `codex app-server generate-json-schema` plus a live
+//! spike; the fixture transcript in the tests pins the wire shapes.
+//!
+//! Older codex (< 0.144) falls back to the legacy exec path for one release:
+//! one `codex exec --json` process per turn, JSONL events on stdout,
+//! multi-turn via `codex exec resume <session>`, playbook injected as tagged
+//! context on the first turn. `ORX_CODEX_EXEC=1` forces the fallback.
 //!
 //! Detection: `~/.codex/auth.json` holds either an `OPENAI_API_KEY` or an OAuth
 //! `id_token` JWT we decode (unverified) for the account email and plan.
@@ -100,6 +107,18 @@ impl Harness for Codex {
         info.agent_ready = info.installed && info.authenticated;
         if info.agent_ready {
             info = info.with_models(&CODEX_MODELS);
+            // Old CLIs still work via the legacy exec path, but without the
+            // app-server wins (permission prompts on sandbox escalations).
+            let too_old = info
+                .version
+                .as_deref()
+                .and_then(parse_codex_version)
+                .is_some_and(|v| v < MIN_APP_SERVER_VERSION);
+            if too_old {
+                info.agent_note = Some(
+                    "Update Codex to 0.144+ for permission prompts; older versions use the legacy exec path.".to_string(),
+                );
+            }
         } else {
             info.agent_note =
                 Some("Install Codex and sign in (`codex login`) to chat with it here.".to_string());
@@ -108,7 +127,13 @@ impl Harness for Codex {
     }
 
     async fn run_turn(&self, ctx: &mut TurnCtx) -> Result<()> {
-        run_turn(ctx).await
+        // app-server for codex ≥ 0.144 (the validated protocol version);
+        // legacy exec for older CLIs, for one release. ORX_CODEX_EXEC=1 is the
+        // escape hatch if app-server misbehaves.
+        if std::env::var_os("ORX_CODEX_EXEC").is_some() || !app_server_supported().await {
+            return run_turn_exec(ctx).await;
+        }
+        run_turn_app_server(ctx).await
     }
 
     fn options(&self) -> HarnessOptions {
@@ -146,6 +171,436 @@ impl Harness for Codex {
         Some(super::CODEX_PROMPT)
     }
 }
+
+// --- app-server path (codex ≥ 0.144) -----------------------------------------
+
+/// First protocol version the harness was validated against (schema dump +
+/// live spike). Older CLIs take the exec fallback below.
+const MIN_APP_SERVER_VERSION: (u64, u64, u64) = (0, 144, 0);
+
+/// `codex --version` output → (major, minor, patch). Accepts "codex-cli
+/// 0.144.0" and bare "0.144.0"; a `-suffix` on the patch is tolerated.
+fn parse_codex_version(version: &str) -> Option<(u64, u64, u64)> {
+    let token = version.split_whitespace().last()?;
+    let mut parts = token.splitn(3, '.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?;
+    let patch = patch
+        .split(|c: char| !c.is_ascii_digit())
+        .next()?
+        .parse()
+        .ok()?;
+    Some((major, minor, patch))
+}
+
+/// Whether the installed codex speaks the validated app-server protocol.
+/// Probed once per process (a codex upgrade mid-run takes an `orx up` restart
+/// to notice — acceptable).
+async fn app_server_supported() -> bool {
+    static SUPPORTED: tokio::sync::OnceCell<bool> = tokio::sync::OnceCell::const_new();
+    *SUPPORTED
+        .get_or_init(|| async {
+            let Some(bin) = find_codex() else {
+                return false;
+            };
+            bin_version(&bin)
+                .await
+                .as_deref()
+                .and_then(parse_codex_version)
+                .is_some_and(|v| v >= MIN_APP_SERVER_VERSION)
+        })
+        .await
+}
+
+/// Session mode → (thread `sandbox` mode, `approvalPolicy`). Approvals stay
+/// `never` on every mode for now — the sandbox is still the boundary, exactly
+/// like the exec path — so this PR is a pure transport swap. The follow-up
+/// flips Auto to `on-request`, surfacing sandbox escalations as permission
+/// cards (verified live: 0.144 asks *before* running an out-of-sandbox
+/// command).
+fn codex_policies(mode: Option<PermissionMode>) -> (&'static str, &'static str) {
+    match mode.unwrap_or(PermissionMode::Auto) {
+        PermissionMode::Bypass => ("danger-full-access", "never"),
+        // Plan/AcceptEdits/Ask have no distinct semantics here (mirrors
+        // `codex_sandbox` on the exec path): the balanced default.
+        _ => ("workspace-write", "never"),
+    }
+}
+
+/// The per-turn `sandboxPolicy` object. workspace-write carries the same
+/// grants the exec path passed via `-c`: the orx data dir + the hub clone's
+/// `.git` as writable roots (see `ensure_orx_data_dir` / `shared_git_dir`),
+/// and network on (the agent's job is driving the orx API and git). Unlike
+/// the exec `-c` override this is a first-class param and does not clobber
+/// the user's config.toml roots.
+async fn sandbox_policy_json(mode: Option<PermissionMode>, workspace: &Path) -> Value {
+    match mode.unwrap_or(PermissionMode::Auto) {
+        PermissionMode::Bypass => serde_json::json!({ "type": "dangerFullAccess" }),
+        _ => {
+            let mut roots: Vec<String> = Vec::new();
+            roots.extend(ensure_orx_data_dir().map(|p| p.to_string_lossy().into_owned()));
+            roots.extend(
+                shared_git_dir(workspace)
+                    .await
+                    .map(|p| p.to_string_lossy().into_owned()),
+            );
+            serde_json::json!({
+                "type": "workspaceWrite",
+                "writableRoots": roots,
+                "networkAccess": true,
+            })
+        }
+    }
+}
+
+/// One app-server notification → transcript state. Pure (fixture-tested):
+/// touches only `ctx.assistant.parts` via the TurnCtx helpers. Returns the
+/// turn's terminal state when this event ends it.
+enum TurnEnd {
+    Done,
+    Failed(String),
+}
+
+fn apply_notification(ctx: &mut TurnCtx, method: &str, params: &Value) -> Option<TurnEnd> {
+    match method {
+        "item/started" | "item/completed" => {
+            if let Some(item) = params.get("item") {
+                apply_item(ctx, item, method == "item/completed");
+            }
+        }
+        "item/agentMessage/delta" => {
+            append_delta(ctx, params, |id| WirePart::text(id, ""));
+        }
+        // GPT-5 reasoning streams summaries; raw content deltas are the
+        // fallback shape. Only one of the two fires per item in practice.
+        "item/reasoning/summaryTextDelta" | "item/reasoning/textDelta" => {
+            append_delta(ctx, params, |id| WirePart::reasoning(id, ""));
+        }
+        "item/commandExecution/outputDelta" => {
+            let (Some(item_id), Some(delta)) = (
+                params.get("itemId").and_then(Value::as_str),
+                params.get("delta").and_then(Value::as_str),
+            ) else {
+                return None;
+            };
+            if let Some(part) = ctx.assistant.parts.iter_mut().find(|p| p.id == item_id) {
+                if let Some(state) = part.state.as_mut() {
+                    let output = state.output.get_or_insert_with(String::new);
+                    output.push_str(delta);
+                }
+            }
+        }
+        "error" => {
+            // Transient errors are retried by codex itself (willRetry); only
+            // terminal ones reach the transcript.
+            let will_retry = params
+                .get("willRetry")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            if !will_retry {
+                ctx.push_error(error_message(params.get("error")));
+            }
+        }
+        "turn/completed" => {
+            let turn = params.get("turn").unwrap_or(&Value::Null);
+            let status = turn.get("status").and_then(Value::as_str).unwrap_or("");
+            if status == "failed" {
+                return Some(TurnEnd::Failed(error_message(turn.get("error"))));
+            }
+            return Some(TurnEnd::Done); // completed | interrupted
+        }
+        _ => {}
+    }
+    None
+}
+
+/// Append a streamed delta to its part, creating the (empty) part on the
+/// first delta — deltas can arrive before we see `item/started`.
+fn append_delta(ctx: &mut TurnCtx, params: &Value, make: impl FnOnce(String) -> WirePart) {
+    let (Some(item_id), Some(delta)) = (
+        params.get("itemId").and_then(Value::as_str),
+        params.get("delta").and_then(Value::as_str),
+    ) else {
+        return;
+    };
+    if ctx.assistant.parts.iter().all(|p| p.id != item_id) {
+        ctx.upsert_part(make(item_id.to_string()));
+    }
+    ctx.append_part_text(item_id, delta);
+}
+
+/// A ThreadItem (from `item/started` / `item/completed`) → WirePart.
+fn apply_item(ctx: &mut TurnCtx, item: &Value, completed: bool) {
+    let Some(id) = item.get("id").and_then(Value::as_str).map(str::to_string) else {
+        return;
+    };
+    match item.get("type").and_then(Value::as_str) {
+        Some("agentMessage") => {
+            let text = item.get("text").and_then(Value::as_str).unwrap_or("");
+            // The completed item is authoritative — but never wipe streamed
+            // deltas with an empty final text.
+            if !completed || !text.is_empty() || ctx.assistant.parts.iter().all(|p| p.id != id) {
+                ctx.upsert_part(WirePart::text(id, text));
+            }
+        }
+        Some("reasoning") => {
+            let text = reasoning_text(item);
+            if !completed || !text.is_empty() || ctx.assistant.parts.iter().all(|p| p.id != id) {
+                ctx.upsert_part(WirePart::reasoning(id, &text));
+            }
+        }
+        Some("commandExecution") => {
+            let failed = completed
+                && (!matches!(
+                    item.get("status").and_then(Value::as_str),
+                    Some("completed")
+                ) || item
+                    .get("exitCode")
+                    .and_then(Value::as_i64)
+                    .is_some_and(|c| c != 0));
+            // Streamed output (outputDelta) survives a completed item without
+            // aggregatedOutput; when present, aggregatedOutput is authoritative.
+            let output = item
+                .get("aggregatedOutput")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .or_else(|| {
+                    ctx.assistant
+                        .parts
+                        .iter()
+                        .find(|p| p.id == id)
+                        .and_then(|p| p.state.as_ref())
+                        .and_then(|s| s.output.clone())
+                });
+            ctx.upsert_part(WirePart {
+                id,
+                kind: "tool".into(),
+                text: None,
+                tool: Some("bash".into()),
+                state: Some(WireToolState {
+                    status: if !completed {
+                        "running"
+                    } else if failed {
+                        "error"
+                    } else {
+                        "completed"
+                    }
+                    .into(),
+                    input: Some(serde_json::json!({
+                        "command": item.get("command").map(command_string).unwrap_or_default(),
+                    })),
+                    output,
+                    error: None,
+                    title: None,
+                }),
+                prompt: None,
+            });
+        }
+        Some("fileChange") => {
+            let failed = completed
+                && !matches!(
+                    item.get("status").and_then(Value::as_str),
+                    Some("completed")
+                );
+            ctx.upsert_part(WirePart {
+                id,
+                kind: "tool".into(),
+                text: None,
+                tool: Some("edit".into()),
+                state: Some(WireToolState {
+                    status: if !completed {
+                        "running"
+                    } else if failed {
+                        "error"
+                    } else {
+                        "completed"
+                    }
+                    .into(),
+                    input: item
+                        .get("changes")
+                        .cloned()
+                        .map(|c| serde_json::json!({ "changes": c })),
+                    output: None,
+                    error: None,
+                    title: None,
+                }),
+                prompt: None,
+            });
+        }
+        // userMessage (our own echo), mcpToolCall, webSearch, plan, …: not
+        // rendered (parity with the exec path); unknown types tolerated.
+        _ => {}
+    }
+}
+
+/// Display text for a reasoning item: streamed content, else the summary.
+fn reasoning_text(item: &Value) -> String {
+    let join = |key: &str| {
+        item.get(key)
+            .and_then(Value::as_array)
+            .map(|parts| {
+                parts
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .collect::<Vec<_>>()
+                    .join("\n\n")
+            })
+            .unwrap_or_default()
+    };
+    let content = join("content");
+    if content.is_empty() {
+        join("summary")
+    } else {
+        content
+    }
+}
+
+/// Best human-readable message out of a TurnError-ish value.
+fn error_message(error: Option<&Value>) -> String {
+    error
+        .and_then(|e| {
+            e.get("message")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .or_else(|| e.as_str().map(str::to_string))
+        })
+        .unwrap_or_else(|| "codex reported an error".to_string())
+}
+
+async fn run_turn_app_server(ctx: &mut TurnCtx) -> Result<()> {
+    let project = ctx.project.clone();
+    let session_id = ctx.session_id.clone();
+    let (repo, playbook) =
+        tokio::task::spawn_blocking(move || ensure_playbook(&project, &session_id))
+            .await
+            .map_err(|e| anyhow!("playbook task failed: {e}"))??;
+    let playbook_md = std::fs::read_to_string(&playbook).unwrap_or_default();
+
+    let client = ctx.host.codex.ensure(&ctx.session_id).await?;
+    let (sandbox_mode, approval_policy) = codex_policies(ctx.permission_mode);
+
+    // Thread bring-up: reuse the thread this child already carries, resume a
+    // persisted one on a fresh child (after an orx up restart or child crash),
+    // else start a new thread. The playbook rides developerInstructions on
+    // both start and resume, so a long-lived session picks up playbook
+    // improvements on the next restart rather than keeping its first version
+    // forever.
+    let mut thread_setup = serde_json::json!({
+        "cwd": repo.to_string_lossy(),
+        "sandbox": sandbox_mode,
+        "approvalPolicy": approval_policy,
+        "developerInstructions": playbook_md,
+    });
+    if let Some(model) = &ctx.model {
+        thread_setup["model"] = Value::String(model.clone());
+    }
+    let thread_id = match ctx.native_session_id.clone() {
+        Some(id) if client.resumed_thread().as_deref() == Some(id.as_str()) => id,
+        Some(id) => {
+            let mut params = thread_setup.clone();
+            params["threadId"] = Value::String(id.clone());
+            match client.request("thread/resume", params).await {
+                Ok(_) => {
+                    client.set_resumed_thread(&id);
+                    id
+                }
+                // Unresumable id (e.g. minted by the old exec path): start a
+                // fresh thread. Prior context is lost, matching what codex
+                // itself does when a rollout is gone.
+                Err(_) => start_thread(ctx, &client, thread_setup.clone()).await?,
+            }
+        }
+        None => start_thread(ctx, &client, thread_setup.clone()).await?,
+    };
+
+    // Route events to this turn before starting it — nothing is missed.
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let _route = client.register_turn(tx);
+
+    let mut turn_params = serde_json::json!({
+        "threadId": thread_id,
+        "input": [{ "type": "text", "text": ctx.text }],
+        // Explicit per turn — the composer can change mode/model mid-session,
+        // and `sandboxPolicy` is the only carrier of writable roots.
+        "approvalPolicy": approval_policy,
+        "sandboxPolicy": sandbox_policy_json(ctx.permission_mode, &repo).await,
+    });
+    if let Some(model) = &ctx.model {
+        turn_params["model"] = Value::String(model.clone());
+    }
+    if let Some(effort) = codex_reasoning(ctx.reasoning_level.as_deref()) {
+        turn_params["effort"] = Value::String(effort.to_string());
+    }
+    client.request("turn/start", turn_params).await?;
+
+    while let Some(event) = rx.recv().await {
+        match event {
+            crate::local::codex::TurnEvent::Notification { method, params } => {
+                if method == "turn/started" {
+                    if let Some(turn_id) = params
+                        .get("turn")
+                        .and_then(|t| t.get("id"))
+                        .and_then(Value::as_str)
+                    {
+                        client.set_active_turn(turn_id);
+                    }
+                }
+                match apply_notification(ctx, &method, &params) {
+                    Some(TurnEnd::Done) => {
+                        let _ = ctx.flush();
+                        return Ok(());
+                    }
+                    Some(TurnEnd::Failed(message)) => {
+                        ctx.push_error(message);
+                        let _ = ctx.flush();
+                        // The turn *finished* (with an error the transcript
+                        // already shows); an Err here would double-report.
+                        return Ok(());
+                    }
+                    None => {}
+                }
+            }
+            crate::local::codex::TurnEvent::Request { id, .. } => {
+                // approvalPolicy is `never` on every mode, so no approval
+                // should arrive; decline defensively rather than leave the
+                // server blocked on an unanswered request. The follow-up
+                // surfaces these as permission cards.
+                let _ = client
+                    .respond(&id, serde_json::json!({ "decision": "decline" }))
+                    .await;
+            }
+            crate::local::codex::TurnEvent::Closed => {
+                return Err(anyhow!(
+                    "codex app-server exited mid-turn; see {}",
+                    crate::store::data_dir().join("agent-codex.log").display()
+                ));
+            }
+        }
+        ctx.maybe_flush();
+    }
+    Err(anyhow!("codex app-server event stream ended mid-turn"))
+}
+
+/// `thread/start` and record the new thread id as the session's native id.
+async fn start_thread(
+    ctx: &mut TurnCtx,
+    client: &std::sync::Arc<crate::local::codex::CodexClient>,
+    params: Value,
+) -> Result<String> {
+    let result = client.request("thread/start", params).await?;
+    let thread_id = result
+        .get("thread")
+        .and_then(|t| t.get("id"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("thread/start returned no thread id"))?
+        .to_string();
+    ctx.set_native_session_id(&thread_id);
+    client.set_resumed_thread(&thread_id);
+    Ok(thread_id)
+}
+
+// --- legacy exec path (codex < 0.144, and ORX_CODEX_EXEC=1) -------------------
 
 /// Session mode → Codex `exec` sandbox policy. `codex exec` can't prompt for
 /// approval, so the sandbox *is* the permission boundary. `Bypass` is the one
@@ -211,7 +666,7 @@ fn absolute_git_dir(workspace: &Path, dir: &Path) -> Option<PathBuf> {
 /// `agent-*.log` files — not scoped to the session; that's inherent to the
 /// CLI opening the shared DB directly, and still strictly narrower than
 /// Bypass.
-fn ensure_orx_data_dir() -> Option<PathBuf> {
+pub(crate) fn ensure_orx_data_dir() -> Option<PathBuf> {
     let dir = crate::store::data_dir();
     std::fs::create_dir_all(&dir).ok()?;
     dir.canonicalize().ok()
@@ -265,7 +720,7 @@ fn command_string(v: &Value) -> String {
     }
 }
 
-async fn run_turn(ctx: &mut TurnCtx) -> Result<()> {
+async fn run_turn_exec(ctx: &mut TurnCtx) -> Result<()> {
     let bin = find_codex().ok_or_else(|| {
         anyhow!("codex not found on PATH — install Codex and run `codex login` first")
     })?;
@@ -568,6 +1023,185 @@ fn handle_item(ctx: &mut TurnCtx, item: &Value, next_id: &mut impl FnMut(&str) -
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn version_parses_cli_output_and_gates() {
+        assert_eq!(parse_codex_version("codex-cli 0.144.0"), Some((0, 144, 0)));
+        assert_eq!(parse_codex_version("0.150.2"), Some((0, 150, 2)));
+        assert_eq!(
+            parse_codex_version("codex-cli 1.0.3-nightly"),
+            Some((1, 0, 3))
+        );
+        assert_eq!(parse_codex_version("codex-cli"), None);
+        assert_eq!(parse_codex_version(""), None);
+        // The gate itself: tuple ordering does the right thing.
+        assert!(parse_codex_version("codex-cli 0.143.9").unwrap() < MIN_APP_SERVER_VERSION);
+        assert!(parse_codex_version("codex-cli 0.144.0").unwrap() >= MIN_APP_SERVER_VERSION);
+    }
+
+    #[test]
+    fn policies_map_modes_to_thread_params() {
+        // Every non-bypass mode is the balanced sandbox; approvals stay off
+        // in this release (pure transport swap — see codex_policies docs).
+        assert_eq!(codex_policies(None), ("workspace-write", "never"));
+        assert_eq!(
+            codex_policies(Some(PermissionMode::Auto)),
+            ("workspace-write", "never")
+        );
+        assert_eq!(
+            codex_policies(Some(PermissionMode::Bypass)),
+            ("danger-full-access", "never")
+        );
+    }
+
+    /// Fold a trimmed live transcript (captured from the 0.144 spike, ids
+    /// shortened) through the notification mapper and check the final parts.
+    /// Pins: streamed deltas accumulate; the completed agentMessage is
+    /// authoritative; a declined/failed command renders as an error tool part;
+    /// unknown notifications are ignored; turn/completed ends the fold.
+    #[test]
+    fn transcript_fold_builds_the_expected_parts() {
+        let transcript = [
+            r#"{"method":"turn/started","params":{"threadId":"t1","turn":{"id":"turn1","status":"inProgress"}}}"#,
+            r#"{"method":"mcpServer/startupStatus/updated","params":{"name":"x","status":"ready"}}"#,
+            r#"{"method":"item/started","params":{"item":{"type":"userMessage","id":"u1"},"threadId":"t1","turnId":"turn1"}}"#,
+            r#"{"method":"item/started","params":{"item":{"type":"reasoning","id":"rs_1","summary":[],"content":[]},"threadId":"t1","turnId":"turn1"}}"#,
+            r#"{"method":"item/reasoning/summaryTextDelta","params":{"delta":"thinking…","itemId":"rs_1","threadId":"t1","turnId":"turn1"}}"#,
+            r#"{"method":"item/completed","params":{"item":{"type":"reasoning","id":"rs_1","summary":[],"content":[]},"threadId":"t1","turnId":"turn1"}}"#,
+            r#"{"method":"item/started","params":{"item":{"type":"commandExecution","id":"call_1","command":"/bin/zsh -lc 'touch /outside/probe.txt'","cwd":"/ws","status":"inProgress","aggregatedOutput":null,"exitCode":null},"threadId":"t1","turnId":"turn1"}}"#,
+            r#"{"method":"item/completed","params":{"item":{"type":"commandExecution","id":"call_1","command":"/bin/zsh -lc 'touch /outside/probe.txt'","cwd":"/ws","status":"declined","aggregatedOutput":null,"exitCode":null},"threadId":"t1","turnId":"turn1"}}"#,
+            r#"{"method":"item/started","params":{"item":{"type":"agentMessage","id":"msg_1","text":"","phase":"final_answer"},"threadId":"t1","turnId":"turn1"}}"#,
+            r#"{"method":"item/agentMessage/delta","params":{"delta":"Command","itemId":"msg_1","threadId":"t1","turnId":"turn1"}}"#,
+            r#"{"method":"item/agentMessage/delta","params":{"delta":" was not run.","itemId":"msg_1","threadId":"t1","turnId":"turn1"}}"#,
+            r#"{"method":"item/completed","params":{"item":{"type":"agentMessage","id":"msg_1","text":"Command was not run because the required escalation was rejected.","phase":"final_answer"},"threadId":"t1","turnId":"turn1"}}"#,
+            r#"{"method":"turn/completed","params":{"threadId":"t1","turn":{"id":"turn1","status":"completed"}}}"#,
+        ];
+
+        let mut ctx = TurnCtx::test_stub();
+        let mut ended = None;
+        for line in transcript {
+            match crate::local::codex::classify_line(line) {
+                crate::local::codex::Line::Notification { method, params } => {
+                    if let Some(end) = apply_notification(&mut ctx, &method, &params) {
+                        ended = Some(end);
+                        break;
+                    }
+                }
+                other => panic!("fixture line classified unexpectedly: {other:?}"),
+            }
+        }
+        assert!(matches!(ended, Some(TurnEnd::Done)));
+
+        let parts = &ctx.assistant.parts;
+        assert_eq!(parts.len(), 3, "reasoning + command + message: {parts:?}");
+        // Reasoning: streamed summary delta survives the empty completed item.
+        assert_eq!(parts[0].kind, "reasoning");
+        assert_eq!(parts[0].text.as_deref(), Some("thinking…"));
+        // Declined command → error tool part with the command as input.
+        assert_eq!(parts[1].kind, "tool");
+        let state = parts[1].state.as_ref().unwrap();
+        assert_eq!(state.status, "error");
+        assert_eq!(
+            state.input.as_ref().unwrap()["command"],
+            "/bin/zsh -lc 'touch /outside/probe.txt'"
+        );
+        // Agent message: the completed item's full text wins over the deltas.
+        assert_eq!(parts[2].kind, "text");
+        assert_eq!(
+            parts[2].text.as_deref(),
+            Some("Command was not run because the required escalation was rejected.")
+        );
+    }
+
+    /// The live approval request from the spike classifies as a server→client
+    /// request (id + method) — the shape the run loop must answer by id.
+    #[test]
+    fn approval_request_classifies_as_request() {
+        let line = r#"{"method":"item/commandExecution/requestApproval","id":0,"params":{"threadId":"t1","turnId":"turn1","itemId":"call_1","startedAtMs":1,"reason":"Allow writing the requested probe file outside the workspace?","command":"/bin/zsh -lc 'touch /outside/probe.txt'","cwd":"/ws"}}"#;
+        match crate::local::codex::classify_line(line) {
+            crate::local::codex::Line::Request { id, method, params } => {
+                assert_eq!(id, serde_json::json!(0));
+                assert_eq!(method, "item/commandExecution/requestApproval");
+                assert_eq!(params["itemId"], "call_1");
+            }
+            other => panic!("expected Request, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn command_output_deltas_accumulate_and_final_output_wins() {
+        let mut ctx = TurnCtx::test_stub();
+        apply_notification(
+            &mut ctx,
+            "item/started",
+            &serde_json::json!({"item":{"type":"commandExecution","id":"c1","command":"ls","status":"inProgress"}}),
+        );
+        for delta in ["a\n", "b\n"] {
+            apply_notification(
+                &mut ctx,
+                "item/commandExecution/outputDelta",
+                &serde_json::json!({"itemId":"c1","delta":delta}),
+            );
+        }
+        // No aggregatedOutput on the completed item → streamed output survives.
+        apply_notification(
+            &mut ctx,
+            "item/completed",
+            &serde_json::json!({"item":{"type":"commandExecution","id":"c1","command":"ls","status":"completed","exitCode":0}}),
+        );
+        let state = ctx.assistant.parts[0].state.as_ref().unwrap();
+        assert_eq!(state.status, "completed");
+        assert_eq!(state.output.as_deref(), Some("a\nb\n"));
+
+        // With aggregatedOutput present, it is authoritative.
+        apply_notification(
+            &mut ctx,
+            "item/completed",
+            &serde_json::json!({"item":{"type":"commandExecution","id":"c1","command":"ls","status":"completed","exitCode":0,"aggregatedOutput":"final"}}),
+        );
+        let state = ctx.assistant.parts[0].state.as_ref().unwrap();
+        assert_eq!(state.output.as_deref(), Some("final"));
+    }
+
+    #[test]
+    fn error_notification_respects_will_retry() {
+        let mut ctx = TurnCtx::test_stub();
+        apply_notification(
+            &mut ctx,
+            "error",
+            &serde_json::json!({"error":{"message":"transient"},"willRetry":true}),
+        );
+        assert!(ctx.assistant.parts.is_empty(), "retried errors stay silent");
+        apply_notification(
+            &mut ctx,
+            "error",
+            &serde_json::json!({"error":{"message":"fatal"},"willRetry":false}),
+        );
+        assert_eq!(ctx.assistant.parts.len(), 1);
+        let state = ctx.assistant.parts[0].state.as_ref().unwrap();
+        assert_eq!(state.status, "error");
+    }
+
+    #[test]
+    fn failed_turn_surfaces_its_error() {
+        let mut ctx = TurnCtx::test_stub();
+        let end = apply_notification(
+            &mut ctx,
+            "turn/completed",
+            &serde_json::json!({"turn":{"id":"t","status":"failed","error":{"message":"boom"}}}),
+        );
+        match end {
+            Some(TurnEnd::Failed(msg)) => assert_eq!(msg, "boom"),
+            other => panic!("expected Failed, got {:?}", other.is_some()),
+        }
+        // Interrupted is a clean end, not a failure.
+        let end = apply_notification(
+            &mut ctx,
+            "turn/completed",
+            &serde_json::json!({"turn":{"id":"t","status":"interrupted"}}),
+        );
+        assert!(matches!(end, Some(TurnEnd::Done)));
+    }
 
     #[test]
     fn sandbox_maps_modes_to_exec_policies() {

--- a/src/local/harness/codex.rs
+++ b/src/local/harness/codex.rs
@@ -558,7 +558,9 @@ async fn run_turn_app_server(ctx: &mut TurnCtx) -> Result<()> {
                 // propagates as the turn's error (the `?` above) — a resumable
                 // thread must never be discarded over a timeout/hiccup.
                 Err(err) => {
-                    eprintln!("orx up: codex thread/resume rejected ({err}); starting a fresh thread");
+                    eprintln!(
+                        "orx up: codex thread/resume rejected ({err}); starting a fresh thread"
+                    );
                     start_thread(ctx, &client, thread_setup).await?
                 }
             }

--- a/src/local/harness/mod.rs
+++ b/src/local/harness/mod.rs
@@ -18,7 +18,7 @@
 //! skill installer all pick it up with no further edits.
 
 mod claude;
-mod codex;
+pub(crate) mod codex;
 mod cursor;
 mod detect;
 mod opencode;

--- a/src/local/mod.rs
+++ b/src/local/mod.rs
@@ -7,6 +7,7 @@
 //! require credentials on the server path.
 
 pub mod chat;
+pub mod codex;
 pub mod experiments;
 pub mod files;
 pub mod git;

--- a/src/local/opencode.rs
+++ b/src/local/opencode.rs
@@ -407,7 +407,8 @@ fn exclude_agent_files(hub: &Path) {
 /// Ensure the project's hub clone and this session's private worktree exist,
 /// and write the autoresearch playbook into the worktree. Every harness
 /// adapter injects this same file (opencode via config `instructions`, Claude
-/// Code via `--append-system-prompt`, Codex via first-turn context). Returns
+/// Code via `--append-system-prompt`, Codex via `developerInstructions` —
+/// legacy exec: first-turn context). Returns
 /// `(workdir, playbook)` — the worktree the harness runs in and the playbook
 /// path inside it.
 pub fn ensure_playbook(project: &LocalProject, session_id: &str) -> Result<(PathBuf, PathBuf)> {


### PR DESCRIPTION
> Stacked on #60. PR1 of the app-server migration: pure transport swap, behavior-identical (approvals stay off). PR2 flips Auto to `on-request` and surfaces approval requests as permission cards.

## Why

Codex Auto mode ran one `codex exec --json` process per turn under the workspace-write seatbelt with `approval_policy=never`. `exec` has no approval channel, so every sandbox denial is a hard failure (the "unable to open database file" class fixed in #60) and every newly-discovered write location needs another `writable_roots` grant — an endless allowlist. Codex's **app-server** protocol (what the TUI/IDE use) has real server→client approval requests; this PR moves the harness onto it so the follow-up can turn denials into one-click Allow/Deny cards.

## Validation spike (before any code)

- Pinned all wire shapes against codex-cli 0.144.0 via `codex app-server generate-json-schema` (free) plus a live driver: newline-delimited JSON-RPC, `thread/start`/`thread/resume`/`turn/start`/`turn/interrupt`, `sandboxPolicy` as a first-class per-turn object carrying `writableRoots` + `networkAccess`, approval replies as wrapped `{"decision": ...}` objects.
- **Upstream #21982 (sandbox-escalation approvals stall over app-server) does NOT reproduce on 0.144.0**: a live turn writing outside the writable roots produced `item/commandExecution/requestApproval` *before* execution; our decline was honored and the turn continued gracefully. Network denials fail-to-model (no escalation) — Auto keeps `networkAccess: true`.
- `ReasoningEffort` is a free-form string in the schema, so `xhigh` is safe.

## What changed

- **`src/local/codex.rs` (new)** — `CodexHost`: one long-lived `codex app-server` child per session (the `AgentHost` pattern), spawn-on-demand with an abort-proof detached bring-up (spawn → register → handshake; an interrupted first turn can't orphan a child). `CodexClient`: JSON-RPC actor — pure `classify_line`, reader task, request/response correlation, server-request (approval) plumbing with a stale-answer guard, bounded native interrupt.
- **`src/local/harness/codex.rs`** — `run_turn` now drives a thread per session: `thread/start` (playbook via `developerInstructions` — no more `<system-context>` first-turn wrapping), `thread/resume` across `orx up` restarts (falls back to a fresh thread only on server rejection, never on transport errors), `turn/start` with explicit per-turn model/effort/sandbox. Events are filtered by turn id (an aborted predecessor's tail can't leak into a successor's transcript) and mapped to wire parts. Sandbox parity with exec is kept: data-dir + hub-`.git` writable roots, network on, `ORX_DATA_DIR` pin, `GH_TOKEN` injection.
- **Legacy exec fallback** kept for codex < 0.144 for one release (`ORX_CODEX_EXEC=1` escape hatch); `detect()` notes the upgrade. Delete in PR3.
- Wiring: `ChatHost.codex`, native `turn/interrupt` on interrupt, kill on session/project delete, shutdown ordering.

## Review

Three rounds of 4-agent review. Round 1 majors fixed: turn-id event filter, `TurnRoute` same-channel drop guard, bounded interrupt, missed `delete_project` kill site, resume-vs-transport error split. Round 2 major fixed: detached abort-proof bring-up. Round 3: all four reviewers signed off.

## Testing

- `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --locked` (79 tests) clean.
- New unit tests: wire-line classification (with live-captured approval fixture), whole-turn fold over a spike transcript, turn filter, delta accumulation vs authoritative output, willRetry, failed/interrupted turns, version gate, mode→policy mapping, error-dedup guard.
- Live E2E on an isolated `orx up --port 4977`: sandboxed `orx projects` works over app-server (the original bug's exact command); streaming renders; restart + `thread/resume` recalls prior context; interrupt clears busy; session delete reaps the child and cleans the worktree; SIGINT shutdown leaves no orphans.

## Notes for follow-ups

- **PR2** (approvals): flip `codex_policies` Auto → `on-request`; map `requestApproval` → permission cards (native_id = rpc id); `resume_from_prompt` → `{"decision": accept|decline}`; keep declining stale-turn requests; add a decline-outstanding sweep on turn exit; `item/tool/requestUserInput` has a different reply schema.
- **PR3** (delete exec path): mechanical banner-to-tests cut, but keep/repurpose the version gate as a hard "too old" note; legacy tests are interleaved in the tests module; one doc ref in `src/local/opencode.rs`; `prepare_env`/tokio-io imports become unused.
- Known accepted trade-offs (documented in code): child env frozen at spawn (token rotation needs respawn); mid-handshake reuse can fail one turn cleanly in a rare abort race; per-turn `sandboxPolicy` replaces user config roots (same as the exec `-c` did).