### PR TITLE
jobs: default PYTHONUNBUFFERED=1 so streamed logs never stall

### DIFF
--- a/src/jobs/kubernetes.rs
+++ b/src/jobs/kubernetes.rs
@@ -472,6 +472,12 @@ fn prepare_docs(
             .filter(|e| e["name"] != "ORX_SCRIPT")
             .collect();
         env.push(json!({ "name": "ORX_SCRIPT", "value": script }));
+        // Default the container's Python to unbuffered so the job's prints
+        // stream live (kubectl logs -f can't flush what the app never wrote).
+        // A user-set value in the manifest wins.
+        if !env.iter().any(|e| e["name"] == super::PYTHONUNBUFFERED) {
+            env.push(json!({ "name": super::PYTHONUNBUFFERED, "value": "1" }));
+        }
         c["env"] = json!(env);
         let env_from = c["envFrom"]
             .as_array_mut()
@@ -870,11 +876,39 @@ mod tests {
         let (docs, _) = prepare(j).unwrap();
         let c = &docs[0]["spec"]["template"]["spec"]["containers"][0];
         let env = c["env"].as_array().unwrap();
-        assert_eq!(env.len(), 2);
+        // FOO + rewritten ORX_SCRIPT + the injected PYTHONUNBUFFERED default.
+        assert_eq!(env.len(), 3);
         assert!(env.iter().any(|e| e["name"] == "FOO"));
         assert!(env
             .iter()
             .any(|e| e["name"] == "ORX_SCRIPT" && e["value"] == "echo hi"));
         assert_eq!(c["envFrom"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn python_unbuffered_defaulted_and_author_value_wins() {
+        // Default: injected when the author didn't set it.
+        let (docs, _) = prepare(job("train")).unwrap();
+        let c = &docs[0]["spec"]["template"]["spec"]["containers"][0];
+        assert!(c["env"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|e| e["name"] == "PYTHONUNBUFFERED" && e["value"] == "1"));
+
+        // Override: an explicit author value is preserved, not duplicated.
+        let mut j = job("train");
+        j["spec"]["template"]["spec"]["containers"][0]["env"] =
+            json!([{ "name": "PYTHONUNBUFFERED", "value": "0" }]);
+        let (docs, _) = prepare(j).unwrap();
+        let c = &docs[0]["spec"]["template"]["spec"]["containers"][0];
+        let hits: Vec<_> = c["env"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|e| e["name"] == "PYTHONUNBUFFERED")
+            .collect();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0]["value"], "0");
     }
 }

--- a/src/jobs/localbox.rs
+++ b/src/jobs/localbox.rs
@@ -41,8 +41,11 @@ pub fn run_job(spec: &LocalJobSpec) -> Result<PathBuf> {
     let dir = run_dir(&spec.run_id);
     std::fs::create_dir_all(&dir)
         .map_err(|e| anyhow!("Could not create {}: {}", dir.display(), e))?;
-    let exports: String = spec
-        .env
+    // Default the job's Python to unbuffered so its prints land in `log` (which
+    // we tail) live instead of block-buffering behind the redirect (see
+    // jobs::default_unbuffered).
+    let env = super::default_unbuffered(&spec.env);
+    let exports: String = env
         .iter()
         .map(|(k, v)| format!("export {}={}", k, sh_quote(v)))
         .collect::<Vec<_>>()
@@ -218,6 +221,9 @@ mod tests {
         .unwrap();
         let state = wait_terminal(&dir);
         assert_eq!(state.stage, "COMPLETED", "message: {:?}", state.message);
+        // Python is defaulted to unbuffered so tailed-`log` output streams live.
+        let run_sh = std::fs::read_to_string(dir.join("run.sh")).unwrap();
+        assert!(run_sh.contains("export PYTHONUNBUFFERED='1'\n"));
 
         let mut lines = Vec::new();
         let seen = stream_logs(&dir, 0, &mut |l| lines.push(l.to_string())).unwrap();

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -14,9 +14,29 @@ pub mod openresearch;
 pub mod slurm;
 pub mod ssh;
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::error::{anyhow, Result};
+
+/// CPython env var that forces stdout/stderr unbuffered. Every backend streams a
+/// job's output by tailing a pipe or a redirected `log` file, so a block-buffered
+/// job would make its logs appear frozen until the buffer fills. We default it on
+/// so prints stream live; it's inert for non-Python jobs and inherited by child
+/// processes (unlike the `-u` flag).
+pub const PYTHONUNBUFFERED: &str = "PYTHONUNBUFFERED";
+
+/// Default `PYTHONUNBUFFERED=1` into a job's environment map unless the caller
+/// already set it (an explicit value always wins). Shared by every backend that
+/// carries env as a `HashMap`; kubernetes open-codes the equivalent because its
+/// env is a JSON `[{name, value}]` array, not a map.
+pub fn default_unbuffered(env: &HashMap<String, String>) -> HashMap<String, String> {
+    let mut env = env.clone();
+    env.entry(PYTHONUNBUFFERED.to_string())
+        .or_insert_with(|| "1".to_string());
+    env
+}
 
 /// Backend descriptor stored on the run (locally and mirrored to the api).
 /// `kind` discriminates. This is a fixed field list — a key absent here does
@@ -283,5 +303,17 @@ mod tests {
         let opts = target.extra_opts.join(" ");
         assert!(opts.contains("-p 22022"), "{opts}");
         assert!(opts.contains("StrictHostKeyChecking=no"), "{opts}");
+    }
+
+    #[test]
+    fn default_unbuffered_injects_when_absent_and_lets_author_win() {
+        // Injected when the caller didn't set it.
+        let got = default_unbuffered(&HashMap::new());
+        assert_eq!(got.get(PYTHONUNBUFFERED).map(String::as_str), Some("1"));
+
+        // An explicit value is preserved — even a falsy one — never overwritten.
+        let author = HashMap::from([(PYTHONUNBUFFERED.to_string(), "0".to_string())]);
+        let got = default_unbuffered(&author);
+        assert_eq!(got.get(PYTHONUNBUFFERED).map(String::as_str), Some("0"));
     }
 }

--- a/src/jobs/modal.rs
+++ b/src/jobs/modal.rs
@@ -305,6 +305,9 @@ async fn launcher_capture(args: &[&str], stdin: Option<&str>) -> Result<Vec<u8>>
     cmd.arg("-c")
         .arg(LAUNCHER)
         .args(args)
+        // Unbuffer the launcher's own stdout: we read it line-by-line, so block
+        // buffering (stdout is a pipe here, not a TTY) would stall log streaming.
+        .env(super::PYTHONUNBUFFERED, "1")
         .envs(modal_auth_env())
         .stdin(if stdin.is_some() {
             Stdio::piped()
@@ -406,6 +409,9 @@ pub async fn run_job(spec: &ModalJobSpec) -> Result<String> {
     // Merge stderr into stdout for the whole script so the single stdout stream
     // the launcher tails carries everything.
     let merged = format!("{{\n{}\n}} 2>&1", spec.script);
+    // Default the sandbox's Python to unbuffered so the job's own prints stream
+    // live instead of block-buffering behind a pipe (see jobs::default_unbuffered).
+    let env = super::default_unbuffered(&spec.env);
     let body = json!({
         "app": spec.app,
         "image": spec.image,
@@ -413,7 +419,7 @@ pub async fn run_job(spec: &ModalJobSpec) -> Result<String> {
         "gpu": spec.gpu,
         "cpu": spec.cpu,
         "memory": spec.memory,
-        "env": spec.env,
+        "env": env,
         "timeoutSeconds": spec.timeout_seconds,
         "tags": spec.tags,
     });
@@ -476,6 +482,9 @@ pub async fn stream_logs(
         .arg("-c")
         .arg(LAUNCHER)
         .args(["logs", sandbox_id])
+        // Unbuffer the launcher's own stdout: we read it line-by-line, so block
+        // buffering (stdout is a pipe here, not a TTY) would stall log streaming.
+        .env(super::PYTHONUNBUFFERED, "1")
         .envs(modal_auth_env())
         .stdin(Stdio::null())
         .stdout(Stdio::piped())

--- a/src/jobs/slurm.rs
+++ b/src/jobs/slurm.rs
@@ -169,10 +169,14 @@ fn render_sbatch(spec: &SlurmJobSpec) -> String {
     // The script exits with the payload's code so Slurm's own COMPLETED/FAILED
     // verdict mirrors the payload — inspect leans on that when the exit_code
     // file is NFS-lagged behind the compute node's write.
+    // Default the payload's Python to unbuffered so its prints stream live
+    // instead of block-buffering behind Slurm's --output redirect. Only the
+    // sbatch payload runs the job — the login-node setup script (below) is a
+    // git clone, so it keeps the raw env (see jobs::default_unbuffered).
     format!(
         "#!/usr/bin/env bash\n{directives}\n{exports}\n(\ncd repo || exit 97\n{command}\n)\ncode=$?\necho \"$code\" > exit_code\nexit \"$code\"\n",
         directives = directives.join("\n"),
-        exports = render_exports(&spec.env),
+        exports = render_exports(&super::default_unbuffered(&spec.env)),
         command = spec.command,
     )
 }
@@ -436,6 +440,9 @@ mod tests {
         assert!(!script.contains("--account"));
         assert!(!script.contains("--gres"));
         assert!(!script.contains("--time"));
+        // Python is defaulted to unbuffered even with no author env, so Slurm's
+        // --output redirect streams the job's prints live.
+        assert!(script.contains("export PYTHONUNBUFFERED='1'\n"));
         // Payload in a subshell; its code is recorded AND becomes the script's
         // exit status (Slurm's COMPLETED/FAILED must mirror the payload).
         assert!(script.ends_with(

--- a/src/jobs/ssh.rs
+++ b/src/jobs/ssh.rs
@@ -155,8 +155,11 @@ pub struct SshJobSpec {
 /// the remote run dir (relative to `$HOME`) — the reattach handle.
 pub async fn run_job(spec: &SshJobSpec) -> Result<String> {
     let dir = format!(".orx/runs/{}", spec.run_id);
-    let exports: String = spec
-        .env
+    // Default the remote job's Python to unbuffered so its prints land in `log`
+    // (which we tail) live instead of block-buffering behind the redirect
+    // (see jobs::default_unbuffered).
+    let env = super::default_unbuffered(&spec.env);
+    let exports: String = env
         .iter()
         .map(|(k, v)| format!("export {}={}", k, sh_quote(v)))
         .collect::<Vec<_>>()


### PR DESCRIPTION
## What

Every job backend surfaces logs by tailing a pipe (`kubectl logs -f`, the Modal launcher's stdout) or a redirected `log` file (ssh/localbox/slurm). When the job's Python **block-buffers** stdout — the default whenever stdout isn't a TTY — those logs appear frozen until the buffer fills or the process exits. Classic "frozen, then a wall of text" symptom, and it looks like an `orx` bug rather than the job's own buffering.

This defaults `PYTHONUNBUFFERED=1` into the job environment across **all five backends** so a job's prints stream live, while an explicit author-set value always wins.

## Where

| Backend | Injection point |
|---|---|
| **modal** | sandbox env (`run_job`), **plus** the local launcher subprocess whose stdout orx reads line-by-line — a separate layer with the same buffering problem |
| **kubernetes** | container `env` in the Job manifest (`prepare_docs`) |
| **ssh / localbox** | exported env in the generated `run.sh` |
| **slurm** | the sbatch payload's exports only — *not* the login-node git-clone setup script |

Shared via `jobs::default_unbuffered` for the HashMap-env backends; kubernetes open-codes the equivalent because its env is a JSON `[{name,value}]` array, not a map.

## Notes

- `PYTHONUNBUFFERED=1` is inert for non-Python jobs and is inherited by child processes (unlike the `-u` flag), so it also covers scripts that shell out to more Python.
- **Out of scope:** HuggingFace jobs stream via a server-side SSE log service with no local pipe to unbuffer; openresearch routes through the ssh backend, so it inherits the ssh fix automatically.

## Tests

New/updated unit tests pin the "default unless the author overrides" contract at the helper (`mod.rs`) and per backend (k8s / slurm / localbox). Full CI mirror green locally: `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --locked` (99 passed).