### PR TITLE
Jobs: default PYTHONUNBUFFERED=1 so logs stream live

### DIFF
--- a/src/jobs/kubernetes.rs
+++ b/src/jobs/kubernetes.rs
@@ -472,6 +472,12 @@ fn prepare_docs(
             .filter(|e| e["name"] != "ORX_SCRIPT")
             .collect();
         env.push(json!({ "name": "ORX_SCRIPT", "value": script }));
+        // Default the container's Python to unbuffered so the job's prints
+        // stream live instead of block-buffering behind the pipe kubectl reads.
+        // A user-set value in the manifest wins.
+        if !env.iter().any(|e| e["name"] == "PYTHONUNBUFFERED") {
+            env.push(json!({ "name": "PYTHONUNBUFFERED", "value": "1" }));
+        }
         c["env"] = json!(env);
         let env_from = c["envFrom"]
             .as_array_mut()
@@ -870,11 +876,39 @@ mod tests {
         let (docs, _) = prepare(j).unwrap();
         let c = &docs[0]["spec"]["template"]["spec"]["containers"][0];
         let env = c["env"].as_array().unwrap();
-        assert_eq!(env.len(), 2);
+        // FOO + rewritten ORX_SCRIPT + the injected PYTHONUNBUFFERED default.
+        assert_eq!(env.len(), 3);
         assert!(env.iter().any(|e| e["name"] == "FOO"));
         assert!(env
             .iter()
             .any(|e| e["name"] == "ORX_SCRIPT" && e["value"] == "echo hi"));
         assert_eq!(c["envFrom"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn python_unbuffered_defaulted_and_author_value_wins() {
+        // Default: injected when the author didn't set it.
+        let (docs, _) = prepare(job("train")).unwrap();
+        let c = &docs[0]["spec"]["template"]["spec"]["containers"][0];
+        assert!(c["env"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|e| e["name"] == "PYTHONUNBUFFERED" && e["value"] == "1"));
+
+        // Override: an explicit author value is preserved, not duplicated.
+        let mut j = job("train");
+        j["spec"]["template"]["spec"]["containers"][0]["env"] =
+            json!([{ "name": "PYTHONUNBUFFERED", "value": "0" }]);
+        let (docs, _) = prepare(j).unwrap();
+        let c = &docs[0]["spec"]["template"]["spec"]["containers"][0];
+        let hits: Vec<_> = c["env"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|e| e["name"] == "PYTHONUNBUFFERED")
+            .collect();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0]["value"], "0");
     }
 }

--- a/src/jobs/localbox.rs
+++ b/src/jobs/localbox.rs
@@ -41,8 +41,13 @@ pub fn run_job(spec: &LocalJobSpec) -> Result<PathBuf> {
     let dir = run_dir(&spec.run_id);
     std::fs::create_dir_all(&dir)
         .map_err(|e| anyhow!("Could not create {}: {}", dir.display(), e))?;
-    let exports: String = spec
-        .env
+    // Default the job's Python to unbuffered so its prints land in `log` (which
+    // we tail) live instead of block-buffering behind the redirect. An explicit
+    // user value still wins.
+    let mut env = spec.env.clone();
+    env.entry("PYTHONUNBUFFERED".to_string())
+        .or_insert_with(|| "1".to_string());
+    let exports: String = env
         .iter()
         .map(|(k, v)| format!("export {}={}", k, sh_quote(v)))
         .collect::<Vec<_>>()
@@ -212,7 +217,8 @@ mod tests {
 
         let dir = run_job(&LocalJobSpec {
             run_id: "lifecycle".into(),
-            script: "echo hello-$ORX_TEST_VAR".into(),
+            // Echoes the defaulted PYTHONUNBUFFERED too, proving it reaches the job.
+            script: "echo hello-$ORX_TEST_VAR unbuffered-$PYTHONUNBUFFERED".into(),
             env: HashMap::from([("ORX_TEST_VAR".to_string(), "42".to_string())]),
         })
         .unwrap();
@@ -222,7 +228,7 @@ mod tests {
         let mut lines = Vec::new();
         let seen = stream_logs(&dir, 0, &mut |l| lines.push(l.to_string())).unwrap();
         assert_eq!(seen, 1);
-        assert_eq!(lines, ["hello-42"]);
+        assert_eq!(lines, ["hello-42 unbuffered-1"]);
         // Re-poll past the consumed lines: nothing new.
         assert_eq!(stream_logs(&dir, seen, &mut |_| ()).unwrap(), seen);
 

--- a/src/jobs/modal.rs
+++ b/src/jobs/modal.rs
@@ -305,6 +305,9 @@ async fn launcher_capture(args: &[&str], stdin: Option<&str>) -> Result<Vec<u8>>
     cmd.arg("-c")
         .arg(LAUNCHER)
         .args(args)
+        // Unbuffer the launcher's own stdout: we read it line-by-line, so block
+        // buffering (stdout is a pipe here, not a TTY) would stall log streaming.
+        .env("PYTHONUNBUFFERED", "1")
         .envs(modal_auth_env())
         .stdin(if stdin.is_some() {
             Stdio::piped()
@@ -406,6 +409,12 @@ pub async fn run_job(spec: &ModalJobSpec) -> Result<String> {
     // Merge stderr into stdout for the whole script so the single stdout stream
     // the launcher tails carries everything.
     let merged = format!("{{\n{}\n}} 2>&1", spec.script);
+    // Default the sandbox's Python to unbuffered so the job's own prints stream
+    // live instead of block-buffering behind a pipe. Inherited by child
+    // processes too (unlike `-u`); an explicit user value still wins.
+    let mut env = spec.env.clone();
+    env.entry("PYTHONUNBUFFERED".to_string())
+        .or_insert_with(|| "1".to_string());
     let body = json!({
         "app": spec.app,
         "image": spec.image,
@@ -413,7 +422,7 @@ pub async fn run_job(spec: &ModalJobSpec) -> Result<String> {
         "gpu": spec.gpu,
         "cpu": spec.cpu,
         "memory": spec.memory,
-        "env": spec.env,
+        "env": env,
         "timeoutSeconds": spec.timeout_seconds,
         "tags": spec.tags,
     });
@@ -476,6 +485,9 @@ pub async fn stream_logs(
         .arg("-c")
         .arg(LAUNCHER)
         .args(["logs", sandbox_id])
+        // Unbuffer the launcher's own stdout: we read it line-by-line, so block
+        // buffering (stdout is a pipe here, not a TTY) would stall log streaming.
+        .env("PYTHONUNBUFFERED", "1")
         .envs(modal_auth_env())
         .stdin(Stdio::null())
         .stdout(Stdio::piped())

--- a/src/jobs/slurm.rs
+++ b/src/jobs/slurm.rs
@@ -178,6 +178,12 @@ fn render_sbatch(spec: &SlurmJobSpec) -> String {
 }
 
 fn render_exports(env: &HashMap<String, String>) -> String {
+    // Default the job's Python to unbuffered so its prints land in the tailed
+    // output live instead of block-buffering behind the redirect. An explicit
+    // user value still wins.
+    let mut env = env.clone();
+    env.entry("PYTHONUNBUFFERED".to_string())
+        .or_insert_with(|| "1".to_string());
     let mut pairs: Vec<_> = env.iter().collect();
     pairs.sort(); // deterministic script for tests & debugging
     pairs
@@ -457,6 +463,19 @@ mod tests {
         assert!(script.contains("#SBATCH --account=lab-a\n"));
         assert!(script.contains("#SBATCH --time=04:00:00\n"));
         assert!(script.contains("export TOKEN='it'\\''s; rm -rf /'\n"));
+    }
+
+    #[test]
+    fn python_unbuffered_defaulted_and_author_value_wins() {
+        // Default: injected when the job didn't set it.
+        let exports = render_exports(&HashMap::new());
+        assert!(exports.contains("export PYTHONUNBUFFERED='1'"));
+
+        // Override: an explicit user value is preserved, not duplicated.
+        let env = HashMap::from([("PYTHONUNBUFFERED".to_string(), "0".to_string())]);
+        let exports = render_exports(&env);
+        assert!(exports.contains("export PYTHONUNBUFFERED='0'"));
+        assert_eq!(exports.matches("export PYTHONUNBUFFERED=").count(), 1);
     }
 
     #[test]

--- a/src/jobs/ssh.rs
+++ b/src/jobs/ssh.rs
@@ -155,8 +155,13 @@ pub struct SshJobSpec {
 /// the remote run dir (relative to `$HOME`) — the reattach handle.
 pub async fn run_job(spec: &SshJobSpec) -> Result<String> {
     let dir = format!(".orx/runs/{}", spec.run_id);
-    let exports: String = spec
-        .env
+    // Default the remote job's Python to unbuffered so its prints land in `log`
+    // (which we tail) live instead of block-buffering behind the redirect. An
+    // explicit user value still wins.
+    let mut env = spec.env.clone();
+    env.entry("PYTHONUNBUFFERED".to_string())
+        .or_insert_with(|| "1".to_string());
+    let exports: String = env
         .iter()
         .map(|(k, v)| format!("export {}={}", k, sh_quote(v)))
         .collect::<Vec<_>>()


### PR DESCRIPTION
## What

Job stdout could stall in a userspace buffer instead of reaching the log stream we tail. Python **block-buffers** stdout when it's a pipe or file redirect (not a TTY), so a running job's `print()`s wouldn't appear live in `orx` — they'd land in one burst at flush/exit.

This defaults `PYTHONUNBUFFERED=1` for the job across **every** backend so prints flush per-write and stream live. An explicit user-set value always wins (default only fills the gap).

## Per-backend

| Backend | Where |
|---------|-------|
| **kubernetes** | inject into each container's `env` array (skipped if the manifest already sets it) |
| **modal** | default the sandbox env in `run_job`; also unbuffer the **launcher's own** stdout in the streaming paths (`launcher_capture`, `stream_logs`) since we read its pipe line-by-line |
| **ssh** | default in the exported env before the tailed `> log` redirect |
| **localbox** | same as ssh |
| **slurm** | default inside the shared `render_exports` helper — covers both the sbatch payload script and the login-node setup script in one place |

`PYTHONUNBUFFERED` propagates to child Python processes too (unlike `python -u`, which only affects the top-level interpreter), and is inert for non-Python jobs.

## Tests

- **kubernetes**: `python_unbuffered_defaulted_and_author_value_wins` — asserts default injection and that an author value isn't overridden/duplicated.
- **slurm**: same-named test over `render_exports` — default + author-wins + no duplication.
- **localbox**: extended `local_job_lifecycle` to echo `$PYTHONUNBUFFERED` and assert the job observes `1` end-to-end.

All CI checks pass locally: `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --locked` (99 passed).

## Review

Reviewed via the repo's multi-agent flow (2 correctness + 2 design agents, two rounds). Round 1 flagged that slurm/localbox shared the same buffering defect and had been left out — fixed here. Round 2 cleared the additions with no blockers; the DRY question (4 near-identical `entry().or_insert_with()` sites) resolved to keep them inline (different contexts; k8s can't share the HashMap shape; per-backend comments carry the rationale).