### PR TITLE
orx up: remote access over SSH

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -43,6 +43,7 @@ pub mod serve;
 pub mod skill;
 pub mod supervise;
 pub mod up;
+pub mod up_remote;
 pub mod update;
 pub mod version;
 pub mod wandb;

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -63,20 +63,63 @@ pub async fn run(args: UpArgs) -> Result<()> {
 
     let app = router(state);
     let url = format!("http://127.0.0.1:{port}");
-    eprintln!("orx up: dashboard on {url}");
-    if !args.no_browser {
-        browser::open_browser(&url);
+    // In an SSH session the loopback URL only works on the remote box and there's
+    // no local browser to open — print forwarding guidance instead of the bare
+    // URL, and skip the (futile) browser-open. Otherwise, today's local flow.
+    if let Some(session) = crate::remote::detect_ssh_session() {
+        eprint!("{}", session.instructions(port));
+    } else {
+        eprintln!("orx up: dashboard on {url}");
+        if !args.no_browser {
+            browser::open_browser(&url);
+        }
     }
 
     // select! instead of graceful shutdown: open SSE streams never complete,
     // so waiting on connections would hang Ctrl-C forever.
+    //
+    // We wait on SIGTERM/SIGHUP as well as SIGINT: when this server is started
+    // over SSH by `orx up --remote`, closing that tunnel (the launcher's Ctrl-C)
+    // delivers SIGHUP here as the channel tears down — without handling it the
+    // remote server would leak, staying bound to its port after the tunnel dies.
     tokio::select! {
         r = axum::serve(listener, app) => r.map_err(|e| anyhow!("orx up: server error: {e}"))?,
-        _ = tokio::signal::ctrl_c() => eprintln!("orx up: shutting down"),
+        _ = shutdown_signal() => eprintln!("orx up: shutting down"),
     }
     agent.shutdown().await;
     codex.shutdown().await;
     Ok(())
+}
+
+/// Resolves when the process is asked to stop. SIGINT everywhere; on Unix also
+/// SIGTERM and SIGHUP (SIGHUP is what an SSH tunnel delivers on disconnect, so
+/// a `--remote`-launched server exits with its tunnel instead of leaking).
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, Signal, SignalKind};
+        // If a signal stream can't be installed, that arm simply never fires —
+        // fall back to whatever handlers do register rather than aborting.
+        async fn wait(s: &mut Option<Signal>) {
+            match s {
+                Some(s) => {
+                    s.recv().await;
+                }
+                None => std::future::pending().await,
+            }
+        }
+        let mut term = signal(SignalKind::terminate()).ok();
+        let mut hup = signal(SignalKind::hangup()).ok();
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = wait(&mut term) => {}
+            _ = wait(&mut hup) => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
 }
 
 #[derive(Clone)]

--- a/src/commands/up_remote.rs
+++ b/src/commands/up_remote.rs
@@ -1,0 +1,245 @@
+//! `orx up --remote <host>` — run `orx up` on a remote box and forward it here.
+//!
+//! This is the laptop-side half of remote access. Unlike a bare `orx up` on a
+//! box you SSH'd into (which can only *print* an `ssh -L` command — see
+//! `crate::remote`), here orx owns the SSH client, so it can set up the local
+//! forward itself: it starts `orx up` on the remote, tunnels the port to this
+//! machine, waits for the server to come up, and opens the browser.
+//!
+//! Transport is the `ssh` binary with the same ControlMaster/BatchMode options
+//! the SSH job backend uses (`crate::jobs::ssh`); auth is the user's own
+//! `~/.ssh/config` + agent/keys — orx never reads a key.
+
+use std::process::Stdio;
+use std::time::{Duration, Instant};
+
+use tokio::process::{Child, Command};
+
+use crate::error::{anyhow, Result};
+use crate::jobs::ssh::SshTarget;
+use crate::{browser, UpArgs};
+
+/// How long to wait for the remote server to answer through the forward.
+const HEALTH_TIMEOUT: Duration = Duration::from_secs(60);
+
+pub async fn run(host: &str, args: UpArgs) -> Result<()> {
+    let port = args.port;
+    let target = SshTarget::alias(host);
+
+    // One round-trip that both proves the host is reachable and checks `orx` is
+    // installed there — the forward would come up but nothing would serve on it
+    // otherwise. A transport error means unreachable; a clean run without the
+    // marker means `orx` is missing. (No separate preflight: its git check is
+    // irrelevant to `orx up`, and it'd cost an extra unmultiplexed handshake.)
+    eprintln!("orx up --remote: checking {host}…");
+    // The command exits 0 either way (emitting a distinct marker) so a non-zero
+    // exit from ssh_run unambiguously means "transport failed / unreachable" —
+    // not "orx missing". Without the `else` branch, a missing orx exits non-zero
+    // and would be misreported as an unreachable host.
+    match crate::jobs::ssh::ssh_run(
+        &target,
+        "if command -v orx >/dev/null 2>&1; then echo ORX_OK; else echo ORX_MISSING; fi",
+        None,
+    )
+    .await
+    {
+        Err(e) => {
+            return Err(anyhow!(
+                "can't reach '{host}' over SSH: {e}. Check it's an ~/.ssh/config \
+                 alias (or user@host) you can `ssh` into."
+            ));
+        }
+        Ok(out) if !out.contains("ORX_OK") => {
+            return Err(anyhow!(
+                "`orx` isn't installed on '{host}' (or not on its non-interactive \
+                 PATH). Install it there, then re-run `orx up --remote {host}`."
+            ));
+        }
+        Ok(_) => {}
+    }
+
+    // One ssh invocation that both forwards the port and starts the remote
+    // server. `-N` would suppress the remote command, so we pass the command
+    // explicitly and rely on `-L` for the tunnel. The remote binds its own
+    // loopback:port; `-L 127.0.0.1:port:localhost:port` maps this machine's
+    // loopback to it — we pin the local bind to 127.0.0.1 (not the default
+    // `localhost`, which can resolve to ::1 first on a dual-stack host) so it
+    // matches the IPv4 address `wait_healthy` and the browser use.
+    // `--no-browser` on the remote: there's no display there, and we open ours.
+    let remote_cmd = remote_up_cmd(port);
+    let forward = forward_spec(port);
+    let mut child = spawn_ssh_forward(&target, &forward, &remote_cmd)?;
+
+    // Wait until the remote server answers through the forward (or ssh dies).
+    eprintln!("orx up --remote: starting orx up on {host} and forwarding port {port}…");
+    if let Err(e) = wait_healthy(&mut child, port).await {
+        let _ = child.start_kill();
+        let _ = child.wait().await;
+        return Err(e);
+    }
+
+    let url = format!("http://localhost:{port}");
+    eprintln!("orx up --remote: dashboard on {url} (forwarded from {host})");
+    if !args.no_browser {
+        browser::open_browser(&url);
+    }
+    eprintln!("orx up --remote: press Ctrl-C to stop forwarding.");
+
+    // Hold the tunnel open until the user quits or ssh exits on its own.
+    tokio::select! {
+        status = child.wait() => {
+            let status = status.map_err(|e| anyhow!("ssh wait failed: {e}"))?;
+            if !status.success() {
+                return Err(anyhow!(
+                    "ssh forwarding to '{host}' ended unexpectedly ({status})."
+                ));
+            }
+        }
+        _ = tokio::signal::ctrl_c() => {
+            eprintln!("orx up --remote: shutting down");
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+        }
+    }
+    Ok(())
+}
+
+/// The remote command: start `orx up` bound to the remote's loopback, no
+/// browser there (we open ours), on the port we forward.
+fn remote_up_cmd(port: u16) -> String {
+    format!("orx up --no-browser --port {port}")
+}
+
+/// The `-L` forward value. Local bind pinned to `127.0.0.1` (see the call site).
+fn forward_spec(port: u16) -> String {
+    format!("127.0.0.1:{port}:localhost:{port}")
+}
+
+/// The full ssh argv (minus the `ssh` program name). Pure, so it can be tested.
+fn ssh_forward_args(target: &SshTarget, forward: &str, remote_cmd: &str) -> Vec<String> {
+    let mut args = base_ssh_opts();
+    args.push("-L".into());
+    args.push(forward.into());
+    args.extend(target.extra_opts.iter().cloned());
+    args.push("--".into());
+    args.push(target.dest.clone());
+    args.push(remote_cmd.into());
+    args
+}
+
+/// Spawn `ssh <opts> -L <forward> -- <dest> <remote_cmd>` with the shared
+/// connection options, detaching stdin so ssh never blocks on a password prompt.
+fn spawn_ssh_forward(target: &SshTarget, forward: &str, remote_cmd: &str) -> Result<Child> {
+    let mut cmd = Command::new("ssh");
+    cmd.args(ssh_forward_args(target, forward, remote_cmd))
+        .stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    cmd.spawn().map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            anyhow!("`ssh` not found on PATH — remote access needs the OpenSSH client.")
+        } else {
+            anyhow!("could not run ssh: {e}")
+        }
+    })
+}
+
+/// Connection options for the tunnel. Notable choices:
+/// - `ExitOnForwardFailure=yes`: if the local port is already taken (e.g. your
+///   own `orx up` on the same port), ssh exits instead of running the remote
+///   server anyway and leaving us to health-check the *wrong* local server.
+/// - `BatchMode=yes`: never prompt — fail fast rather than hang.
+/// - keepalives so a silent forward isn't reaped by a NAT/idle timeout.
+///
+/// We don't multiplex here (this is a long-lived foreground session, not the
+/// job backend's many short polls), so no ControlMaster.
+fn base_ssh_opts() -> Vec<String> {
+    [
+        "ExitOnForwardFailure=yes",
+        "BatchMode=yes",
+        "ConnectTimeout=10",
+        "ServerAliveInterval=30",
+        "ServerAliveCountMax=3",
+    ]
+    .iter()
+    .flat_map(|o| ["-o".to_string(), (*o).to_string()])
+    .collect()
+}
+
+/// Poll the forwarded `/api/health` until the remote server answers, giving up
+/// after [`HEALTH_TIMEOUT`] or if the ssh child exits first.
+async fn wait_healthy(child: &mut Child, port: u16) -> Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()?;
+    let url = format!("http://127.0.0.1:{port}/api/health");
+    let deadline = Instant::now() + HEALTH_TIMEOUT;
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Err(anyhow!(
+                "ssh exited before the remote server came up ({status}). \
+                 Is `orx` runnable on the remote's non-interactive shell?"
+            ));
+        }
+        if let Ok(resp) = client.get(&url).send().await {
+            if resp.status().is_success() {
+                return Ok(());
+            }
+        }
+        if Instant::now() >= deadline {
+            return Err(anyhow!(
+                "remote orx up didn't answer on the forwarded port {port} within {}s.",
+                HEALTH_TIMEOUT.as_secs()
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn forward_and_remote_cmd_use_the_same_port() {
+        assert_eq!(forward_spec(4899), "127.0.0.1:4899:localhost:4899");
+        assert_eq!(remote_up_cmd(4899), "orx up --no-browser --port 4899");
+    }
+
+    #[test]
+    fn base_opts_exit_on_forward_failure() {
+        // Without this, a busy local port lets ssh run the remote server anyway
+        // and we'd health-check the wrong (local) server. Load-bearing.
+        let opts = base_ssh_opts();
+        let joined = opts.join(" ");
+        assert!(joined.contains("-o ExitOnForwardFailure=yes"));
+        assert!(joined.contains("-o BatchMode=yes"));
+    }
+
+    #[test]
+    fn ssh_args_are_ordered_opts_then_forward_then_dest_then_cmd() {
+        let target = SshTarget::alias("mybox");
+        let args = ssh_forward_args(&target, "127.0.0.1:7:localhost:7", "orx up");
+        // -L and its value are adjacent and precede the `--` separator.
+        let l = args.iter().position(|a| a == "-L").unwrap();
+        assert_eq!(args[l + 1], "127.0.0.1:7:localhost:7");
+        let sep = args.iter().position(|a| a == "--").unwrap();
+        assert!(l < sep, "-L must come before --");
+        // dest then the remote command follow the separator, in that order.
+        assert_eq!(args[sep + 1], "mybox");
+        assert_eq!(args[sep + 2], "orx up");
+    }
+
+    #[test]
+    fn extra_opts_land_before_the_separator() {
+        let target = SshTarget {
+            dest: "mybox".into(),
+            extra_opts: vec!["-p".into(), "2222".into()],
+        };
+        let args = ssh_forward_args(&target, "127.0.0.1:7:localhost:7", "orx up");
+        let sep = args.iter().position(|a| a == "--").unwrap();
+        let p = args.iter().position(|a| a == "-p").unwrap();
+        assert!(p < sep, "extra_opts must precede the -- separator");
+        assert_eq!(args[p + 1], "2222");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod jobs;
 #[allow(dead_code)]
 mod local;
 mod output;
+mod remote;
 mod store;
 mod updates;
 
@@ -615,9 +616,16 @@ pub struct SuperviseArgs {
 
 #[derive(Args, Debug)]
 pub struct UpArgs {
-    /// Port to bind on 127.0.0.1.
+    /// Port to bind on 127.0.0.1. With `--remote`, the local port to forward.
     #[arg(long, default_value_t = 4791)]
     pub port: u16,
+    /// Run `orx up` on a remote box over SSH and forward it here. The value is
+    /// an `~/.ssh/config` host alias (or `user@host`). Starts the server there,
+    /// tunnels `--port` to your laptop, and opens your browser. Note: the remote
+    /// dashboard is unauthenticated and bound to that host's loopback, so anyone
+    /// else with an account on that host can reach it.
+    #[arg(long, value_name = "HOST")]
+    pub remote: Option<String>,
     /// Don't open the dashboard in the browser on startup.
     #[arg(long)]
     pub no_browser: bool,
@@ -745,6 +753,9 @@ async fn dispatch(command: Command) -> error::Result<()> {
         Command::Update(args) => commands::update::run(args).await,
         Command::Serve(args) => commands::serve::run(args).await,
         Command::Supervise(args) => commands::supervise::run(args).await,
-        Command::Up(args) => commands::up::run(args).await,
+        Command::Up(args) => match args.remote.clone() {
+            Some(host) => commands::up_remote::run(&host, args).await,
+            None => commands::up::run(args).await,
+        },
     }
 }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,0 +1,194 @@
+//! Detecting when `orx` is running inside an SSH session, and guiding the user
+//! to reach a loopback-bound server (`orx up`) from their laptop.
+//!
+//! `orx up` binds `127.0.0.1` with no auth (see `commands::up`), so when the
+//! process is on a remote box the laptop can't reach it directly — and we must
+//! NOT expose it on `0.0.0.0` (an unauthenticated dashboard on a shared host is
+//! an actively-exploited attack surface). The safe, idiomatic answer is SSH
+//! local port forwarding (`ssh -L`), the same pattern Jupyter/TensorBoard users
+//! follow.
+//!
+//! The catch: an `ssh -L` forward can only be created by the SSH *client* on the
+//! laptop. This process runs on the *server* side, so the most it can do is
+//! print the exact command to paste. Fully automatic forwarding lives in
+//! `orx up --remote <host>` (`commands::up_remote`), which owns the client side.
+
+/// Facts about the current SSH session, parsed from `SSH_CONNECTION`.
+///
+/// `SSH_CONNECTION` is set by sshd as `"clientIP clientPort serverIP serverPort"`.
+/// We keep the server-side fields: `server_ip` is a best-effort reconnect hint
+/// (often a private/NATed address that is NOT reachable as-is), and `sshd_port`
+/// is the port sshd listens on (usually 22).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SshSession {
+    /// 3rd field of `SSH_CONNECTION` — the server address as the server sees it.
+    pub server_ip: String,
+    /// 4th field of `SSH_CONNECTION` — the sshd port (usually 22).
+    pub sshd_port: String,
+}
+
+/// Detect whether we're in an SSH session, reading only the environment.
+///
+/// Presence is decided by `SSH_CONNECTION`/`SSH_TTY`/`SSH_CLIENT` (any one).
+/// The parsed [`SshSession`] fields come from `SSH_CONNECTION` when it is
+/// well-formed; a session detected only via `SSH_TTY`/`SSH_CLIENT`, or with a
+/// malformed `SSH_CONNECTION`, still returns `Some` but with empty hint fields.
+pub fn detect_ssh_session() -> Option<SshSession> {
+    detect_from(
+        std::env::var("SSH_CONNECTION").ok().as_deref(),
+        std::env::var("SSH_TTY").is_ok() || std::env::var("SSH_CLIENT").is_ok(),
+    )
+}
+
+/// Testable core: given the raw `SSH_CONNECTION` value (if any) and whether some
+/// other SSH marker is present, decide the session.
+fn detect_from(ssh_connection: Option<&str>, other_marker: bool) -> Option<SshSession> {
+    match ssh_connection {
+        Some(conn) => {
+            // "clientIP clientPort serverIP serverPort". Take fields 3 and 4 when
+            // present; tolerate a malformed value by falling back to empty hints
+            // rather than reporting "not in SSH" (the var's presence is itself
+            // the SSH signal).
+            let fields: Vec<&str> = conn.split_whitespace().collect();
+            let (server_ip, sshd_port) = match fields.as_slice() {
+                [_, _, ip, port, ..] => ((*ip).to_string(), (*port).to_string()),
+                _ => (String::new(), String::new()),
+            };
+            Some(SshSession {
+                server_ip,
+                sshd_port,
+            })
+        }
+        None if other_marker => Some(SshSession {
+            server_ip: String::new(),
+            sshd_port: String::new(),
+        }),
+        None => None,
+    }
+}
+
+impl SshSession {
+    /// Is `server_ip` a plausibly-routable public address worth suggesting? A
+    /// private/loopback/link-local/CGNAT address from `SSH_CONNECTION` is usually
+    /// the box's internal interface and won't work from the laptop, so we don't
+    /// offer it. This is a hint filter, not a security boundary.
+    fn server_ip_hint(&self) -> Option<&str> {
+        let ip = self.server_ip.trim();
+        if ip.is_empty() {
+            return None;
+        }
+        if let Ok(v4) = ip.parse::<std::net::Ipv4Addr>() {
+            // `is_private()` misses CGNAT (100.64.0.0/10, RFC 6598), which is
+            // common on cloud/NAT'd boxes — filter it too.
+            let [a, b, ..] = v4.octets();
+            let is_cgnat = a == 100 && (64..=127).contains(&b);
+            if v4.is_private()
+                || v4.is_loopback()
+                || v4.is_link_local()
+                || v4.is_unspecified()
+                || is_cgnat
+            {
+                return None;
+            }
+        }
+        // IPv6 (or an unparseable value): don't filter, just don't over-promise.
+        Some(ip)
+    }
+
+    /// The multi-line message to print on `orx up` startup when we're in SSH.
+    /// `port` is the port `orx up` bound on the remote's loopback.
+    ///
+    /// The reader is *inside* the SSH session, so the text is careful to say
+    /// "from your laptop, not this session" — both suggested commands run on the
+    /// laptop, never here.
+    pub fn instructions(&self, port: u16) -> String {
+        let mut out = format!(
+            "orx up: dashboard on http://127.0.0.1:{port} (on this remote host)\n\n\
+             You're connected over SSH, so this URL only works on the remote box.\n\
+             Both options below run on your laptop — not in this SSH session.\n\n\
+             The easiest way — from your laptop, run:\n\n\
+             \x20   orx up --remote <the-host-you-ssh'd-into>\n\n\
+             That launches orx up on this host, forwards the port to your laptop,\n\
+             and opens your browser. Nothing else to run here.\n\n\
+             Or, to reach the server already running here, open a new terminal on\n\
+             your laptop and forward the port yourself, then browse to \
+             http://localhost:{port} :\n\n\
+             \x20   ssh -N -L {port}:localhost:{port} <the-host-you-ssh'd-into>\n\
+             \x20   (that command stays running with no output — leave it open)\n"
+        );
+        if let Some(ip) = self.server_ip_hint() {
+            out.push_str(&format!(
+                "\n(if you don't know the host name, the address {ip} may work in \
+                 both commands above)\n"
+            ));
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_well_formed_ssh_connection() {
+        let s = detect_from(Some("203.0.113.7 51344 198.51.100.5 22"), false).unwrap();
+        assert_eq!(s.server_ip, "198.51.100.5");
+        assert_eq!(s.sshd_port, "22");
+    }
+
+    #[test]
+    fn absent_everything_is_none() {
+        assert_eq!(detect_from(None, false), None);
+    }
+
+    #[test]
+    fn ssh_tty_only_detects_with_empty_hints() {
+        let s = detect_from(None, true).unwrap();
+        assert!(s.server_ip.is_empty());
+        assert!(s.sshd_port.is_empty());
+    }
+
+    #[test]
+    fn malformed_ssh_connection_still_detects() {
+        // Present but not 4 fields: we're clearly in SSH, just no usable hint.
+        let s = detect_from(Some("garbage"), false).unwrap();
+        assert!(s.server_ip.is_empty());
+        let s2 = detect_from(Some("10.0.0.1 5000"), false).unwrap();
+        assert!(s2.server_ip.is_empty());
+    }
+
+    #[test]
+    fn private_server_ip_is_not_hinted() {
+        let s = detect_from(Some("203.0.113.7 51344 10.0.0.5 22"), false).unwrap();
+        // Parsed and stored, but filtered out of the suggestion.
+        assert_eq!(s.server_ip, "10.0.0.5");
+        assert!(s.server_ip_hint().is_none());
+        assert!(!s.instructions(4791).contains("10.0.0.5"));
+    }
+
+    #[test]
+    fn cgnat_server_ip_is_not_hinted() {
+        // 100.64.0.0/10 (RFC 6598) is carrier NAT, not reachable from the laptop.
+        let s = detect_from(Some("203.0.113.7 51344 100.64.1.2 22"), false).unwrap();
+        assert_eq!(s.server_ip, "100.64.1.2");
+        assert!(s.server_ip_hint().is_none());
+    }
+
+    #[test]
+    fn public_server_ip_is_hinted() {
+        let s = detect_from(Some("203.0.113.7 51344 198.51.100.5 22"), false).unwrap();
+        assert_eq!(s.server_ip_hint(), Some("198.51.100.5"));
+        assert!(s.instructions(4791).contains("198.51.100.5"));
+    }
+
+    #[test]
+    fn instructions_mention_both_paths_and_port() {
+        let msg = detect_from(Some("203.0.113.7 51344 10.0.0.5 22"), false)
+            .unwrap()
+            .instructions(4899);
+        assert!(msg.contains("orx up --remote"));
+        assert!(msg.contains("ssh -N -L 4899:localhost:4899"));
+        assert!(msg.contains("http://localhost:4899"));
+    }
+}

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -13,6 +13,35 @@
 //! print the exact command to paste. Fully automatic forwarding lives in
 //! `orx up --remote <host>` (`commands::up_remote`), which owns the client side.
 
+use std::io::IsTerminal;
+
+/// Whether stderr can render ANSI: a real terminal and `NO_COLOR` unset. Pipes,
+/// CI, and redirects get plain text — never raw escape codes. Mirrors the same
+/// gate in [`crate::updates`].
+fn stderr_supports_ansi() -> bool {
+    std::env::var_os("NO_COLOR").is_none() && std::io::stderr().is_terminal()
+}
+
+/// Bold when `enabled`, else the text unchanged. `\x1b[22m` resets bold/faint
+/// specifically (not `\x1b[0m`, which would clear surrounding styling too).
+fn bold(text: &str, enabled: bool) -> String {
+    if enabled {
+        format!("\x1b[1m{text}\x1b[22m")
+    } else {
+        text.to_string()
+    }
+}
+
+/// Dim (faint) when `enabled`, else the text unchanged — used to push the
+/// secondary path and asides behind the one command that matters.
+fn dim(text: &str, enabled: bool) -> String {
+    if enabled {
+        format!("\x1b[2m{text}\x1b[22m")
+    } else {
+        text.to_string()
+    }
+}
+
 /// Facts about the current SSH session, parsed from `SSH_CONNECTION`.
 ///
 /// `SSH_CONNECTION` is set by sshd as `"clientIP clientPort serverIP serverPort"`.
@@ -95,34 +124,60 @@ impl SshSession {
         Some(ip)
     }
 
-    /// The multi-line message to print on `orx up` startup when we're in SSH.
-    /// `port` is the port `orx up` bound on the remote's loopback.
+    /// The message to print on `orx up` startup when we're in SSH. `port` is the
+    /// port `orx up` bound on the remote's loopback.
     ///
     /// The reader is *inside* the SSH session, so the text is careful to say
-    /// "from your laptop, not this session" — both suggested commands run on the
-    /// laptop, never here.
+    /// "from your laptop" — both suggested commands run on the laptop, never here.
+    /// Styling is stripped on pipes/CI/`NO_COLOR` so those get clean plain text.
     pub fn instructions(&self, port: u16) -> String {
+        self.render_instructions(port, stderr_supports_ansi())
+    }
+
+    /// Core of [`instructions`], with ANSI styling as an explicit arg so it's
+    /// testable without touching the environment.
+    fn render_instructions(&self, port: u16, ansi: bool) -> String {
+        // `<ssh-alias>` is the ~/.ssh/config alias / user@host the reader typed
+        // to connect — carried inline so the "not the box's IP" point lands next
+        // to the placeholder instead of in a separate paragraph.
+        let alias = dim("<ssh-alias>", ansi);
         let mut out = format!(
-            "orx up: dashboard on http://127.0.0.1:{port} (on this remote host)\n\n\
-             You're connected over SSH, so this URL only works on the remote box.\n\
-             Both options below run on your laptop — not in this SSH session.\n\n\
-             Replace <ssh-alias> with the name you gave `ssh` to connect — the\n\
-             ~/.ssh/config alias (or user@host), not the box's IP address.\n\n\
-             The easiest way — from your laptop, run:\n\n\
-             \x20   orx up --remote <ssh-alias>\n\n\
-             That launches orx up on this host, forwards the port to your laptop,\n\
-             and opens your browser. Nothing else to run here.\n\n\
-             Or, to reach the server already running here, open a new terminal on\n\
-             your laptop and forward the port yourself, then browse to \
-             http://localhost:{port} :\n\n\
-             \x20   ssh -N -L {port}:localhost:{port} <ssh-alias>\n\
-             \x20   (that command stays running with no output — leave it open)\n"
+            "{header}\n\n\
+             {intro}\n\n\
+             {run_from_laptop}\n\
+             \x20 {primary} {alias}\n\n\
+             {alias_note}\n\n\
+             {or_line}\n\
+             \x20 {manual}\n",
+            header = bold(
+                &format!("orx up: serving on http://127.0.0.1:{port} (this remote host)"),
+                ansi,
+            ),
+            intro = "This URL only works here on the box. To open it on your laptop,\n\
+                     run one of these — from your laptop, not this SSH session:",
+            run_from_laptop = "Easiest — let orx forward it for you:",
+            primary = bold("orx up --remote", ansi),
+            alias_note = dim(
+                "<ssh-alias> is the name you gave ssh (~/.ssh/config alias or \
+                 user@host), not the box's IP.",
+                ansi,
+            ),
+            or_line = dim("Or forward it yourself in a new laptop terminal:", ansi),
+            manual = dim(
+                &format!(
+                    "ssh -N -L {port}:localhost:{port} <ssh-alias>   \
+                     # then open http://localhost:{port}",
+                ),
+                ansi,
+            ),
         );
         if let Some(ip) = self.server_ip_hint() {
-            out.push_str(&format!(
-                "\n(no alias set up? the address {ip} may work in place of \
-                 <ssh-alias>, though you may need your usual `-i`/`-p` ssh options)\n"
+            out.push('\n');
+            out.push_str(&dim(
+                &format!("No alias? {ip} may work in its place (add your usual -i/-p)."),
+                ansi,
             ));
+            out.push('\n');
         }
         out
     }
@@ -166,7 +221,7 @@ mod tests {
         // Parsed and stored, but filtered out of the suggestion.
         assert_eq!(s.server_ip, "10.0.0.5");
         assert!(s.server_ip_hint().is_none());
-        assert!(!s.instructions(4791).contains("10.0.0.5"));
+        assert!(!s.render_instructions(4791, false).contains("10.0.0.5"));
     }
 
     #[test]
@@ -181,19 +236,38 @@ mod tests {
     fn public_server_ip_is_hinted() {
         let s = detect_from(Some("203.0.113.7 51344 198.51.100.5 22"), false).unwrap();
         assert_eq!(s.server_ip_hint(), Some("198.51.100.5"));
-        assert!(s.instructions(4791).contains("198.51.100.5"));
+        assert!(s.render_instructions(4791, false).contains("198.51.100.5"));
     }
 
     #[test]
     fn instructions_mention_both_paths_and_port() {
+        // Plain (no ANSI) so assertions match the literal text.
         let msg = detect_from(Some("203.0.113.7 51344 10.0.0.5 22"), false)
             .unwrap()
-            .instructions(4899);
+            .render_instructions(4899, false);
         assert!(msg.contains("orx up --remote"));
         assert!(msg.contains("ssh -N -L 4899:localhost:4899"));
         assert!(msg.contains("http://localhost:4899"));
         // The placeholder is the ssh alias, and the text says so explicitly.
         assert!(msg.contains("<ssh-alias>"));
-        assert!(msg.contains("not the box's IP address"));
+        assert!(msg.contains("not the box's IP"));
+    }
+
+    #[test]
+    fn styling_is_stripped_when_ansi_disabled() {
+        // No raw escape codes leak into non-terminal output.
+        let msg = detect_from(Some("203.0.113.7 51344 198.51.100.5 22"), false)
+            .unwrap()
+            .render_instructions(4791, false);
+        assert!(!msg.contains('\x1b'));
+    }
+
+    #[test]
+    fn styling_wraps_the_primary_command_when_ansi_enabled() {
+        let msg = detect_from(Some("203.0.113.7 51344 10.0.0.5 22"), false)
+            .unwrap()
+            .render_instructions(4791, true);
+        // The primary command is bolded; the whole thing carries escape codes.
+        assert!(msg.contains("\x1b[1morx up --remote\x1b[22m"));
     }
 }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -106,20 +106,22 @@ impl SshSession {
             "orx up: dashboard on http://127.0.0.1:{port} (on this remote host)\n\n\
              You're connected over SSH, so this URL only works on the remote box.\n\
              Both options below run on your laptop — not in this SSH session.\n\n\
+             Replace <ssh-alias> with the name you gave `ssh` to connect — the\n\
+             ~/.ssh/config alias (or user@host), not the box's IP address.\n\n\
              The easiest way — from your laptop, run:\n\n\
-             \x20   orx up --remote <the-host-you-ssh'd-into>\n\n\
+             \x20   orx up --remote <ssh-alias>\n\n\
              That launches orx up on this host, forwards the port to your laptop,\n\
              and opens your browser. Nothing else to run here.\n\n\
              Or, to reach the server already running here, open a new terminal on\n\
              your laptop and forward the port yourself, then browse to \
              http://localhost:{port} :\n\n\
-             \x20   ssh -N -L {port}:localhost:{port} <the-host-you-ssh'd-into>\n\
+             \x20   ssh -N -L {port}:localhost:{port} <ssh-alias>\n\
              \x20   (that command stays running with no output — leave it open)\n"
         );
         if let Some(ip) = self.server_ip_hint() {
             out.push_str(&format!(
-                "\n(if you don't know the host name, the address {ip} may work in \
-                 both commands above)\n"
+                "\n(no alias set up? the address {ip} may work in place of \
+                 <ssh-alias>, though you may need your usual `-i`/`-p` ssh options)\n"
             ));
         }
         out
@@ -190,5 +192,8 @@ mod tests {
         assert!(msg.contains("orx up --remote"));
         assert!(msg.contains("ssh -N -L 4899:localhost:4899"));
         assert!(msg.contains("http://localhost:4899"));
+        // The placeholder is the ssh alias, and the text says so explicitly.
+        assert!(msg.contains("<ssh-alias>"));
+        assert!(msg.contains("not the box's IP address"));
     }
 }


### PR DESCRIPTION
## Problem

Running `orx up` while SSH'd into a remote box is broken today. The server binds `127.0.0.1` with no auth (deliberately), so:
- its loopback URL is unreachable from your laptop, and
- there's no browser on a headless remote box to open.

You're left staring at an unreachable `http://127.0.0.1:4791`.

This adds two complementary paths, both keeping the server on loopback — **never `0.0.0.0`** (an unauthenticated dashboard on a shared host is an actively-exploited attack surface).

## Part A — guidance from the remote side (`src/remote.rs`)

When `orx up` runs **inside** an SSH session (detected via `SSH_CONNECTION`/`SSH_TTY`/`SSH_CLIENT`), it skips the futile browser-open and prints exact forwarding instructions instead:

```
orx up: dashboard on http://127.0.0.1:4791 (on this remote host)

You're connected over SSH, so this URL only works on the remote box.
Both options below run on your laptop — not in this SSH session.

The easiest way — from your laptop, run:

    orx up --remote <the-host-you-ssh'd-into>

That launches orx up on this host, forwards the port to your laptop,
and opens your browser. Nothing else to run here.

Or, to reach the server already running here, open a new terminal on
your laptop and forward the port yourself, then browse to http://localhost:4791 :

    ssh -N -L 4791:localhost:4791 <the-host-you-ssh'd-into>
    (that command stays running with no output — leave it open)
```

A public `SSH_CONNECTION` server IP is offered as a best-effort hint; private/loopback/link-local/**CGNAT** (100.64/10) addresses are filtered out since they're not reachable from the laptop.

## Part B — automatic forwarding from the laptop (`src/commands/up_remote.rs`)

`orx up --remote <host>` runs from your laptop, so orx owns the SSH client and can set up the forward itself:

1. One SSH round-trip: confirm the host is reachable **and** `orx` is installed there.
2. Start `orx up --no-browser --port N` on the remote (binds its loopback).
3. Bring up `ssh -L 127.0.0.1:N:localhost:N` — `ExitOnForwardFailure=yes` so a busy **local** port fails loudly instead of silently attaching to the wrong server; local bind pinned to `127.0.0.1` to avoid the `::1` dual-stack trap.
4. Poll the forwarded `/api/health` until the remote server answers (or ssh dies).
5. Open the laptop browser; hold the tunnel until Ctrl-C.

One command from the laptop — no manual SSH, no second terminal.

## Supporting change

`orx up` now shuts down on **SIGTERM/SIGHUP** as well as SIGINT (`shutdown_signal()` in `up.rs`). When the `--remote` tunnel closes, sshd delivers SIGHUP to the remote server — without this it would leak, staying bound to its port after the tunnel dies.

## Security

- The `-L` forward and both server binds are **loopback-only**; no `0.0.0.0`, `GatewayPorts`, or `-g` anywhere.
- The remote dashboard is unauthenticated on the remote's loopback, so **co-tenants on that host can reach it** — called out in the `--remote` help text.

## Tests

- `src/remote.rs`: 9 unit tests — SSH detection (well-formed/malformed/tty-only/absent), IP-hint filtering (private/CGNAT/public), and the instructions text.
- `src/commands/up_remote.rs`: pure arg/string builders tested — port coupling, `ExitOnForwardFailure` presence, and ssh argv ordering (opts → `-L` → extra_opts → `--` → dest → cmd).

CI green locally: `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --locked` (111 passed).

## Review

Reviewed via the repo's multi-agent loop (2 correctness + 2 design, three rounds). Round 1 caught a silent wrong-server misfire on local-port collision (missing `ExitOnForwardFailure`), a CI-breaking `useless_format`, a remote-orphan-on-Ctrl-C gap, and misleading user text. Round 2 caught a follow-on bug where "orx not installed" was misreported as "host unreachable" (the probe exited non-zero). Round 3 verified the fixes with no regressions.