### PR TITLE
orx up --remote: custom SSH port support + readable, honest banner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,7 +928,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openresearch-cli"
-version = "0.1.57"
+version = "0.1.58"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openresearch-cli"
-version = "0.1.57"
+version = "0.1.58"
 edition = "2021"
 description = "OpenResearch CLI (orx) — Rust port"
 repository = "https://github.com/alphaXiv/openresearch-cli"

--- a/src/commands/up_remote.rs
+++ b/src/commands/up_remote.rs
@@ -16,7 +16,7 @@ use std::time::{Duration, Instant};
 use tokio::process::{Child, Command};
 
 use crate::error::{anyhow, Result};
-use crate::jobs::ssh::SshTarget;
+use crate::jobs::ssh::{HostKeyPolicy, SshTarget};
 use crate::{browser, UpArgs};
 
 /// How long to wait for the remote server to answer through the forward.
@@ -24,7 +24,7 @@ const HEALTH_TIMEOUT: Duration = Duration::from_secs(60);
 
 pub async fn run(host: &str, args: UpArgs) -> Result<()> {
     let port = args.port;
-    let target = SshTarget::alias(host);
+    let target = parse_remote_target(host);
 
     // One round-trip that both proves the host is reachable and checks `orx` is
     // installed there — the forward would come up but nothing would serve on it
@@ -46,7 +46,11 @@ pub async fn run(host: &str, args: UpArgs) -> Result<()> {
         Err(e) => {
             return Err(anyhow!(
                 "can't reach '{host}' over SSH: {e}. Check it's an ~/.ssh/config \
-                 alias (or user@host) you can `ssh` into."
+                 alias, or a user@host (add :PORT for a non-standard SSH port, \
+                 e.g. root@1.2.3.4:2222) you can `ssh` into. A custom key or jump \
+                 host isn't reconstructed here — put it in ~/.ssh/config. If it's a \
+                 new host reached by name, `ssh` in once first to trust its key; if \
+                 its key changed (a reused IP), clear it with `ssh-keygen -R`."
             ));
         }
         Ok(out) if !out.contains("ORX_OK") => {
@@ -102,6 +106,89 @@ pub async fn run(host: &str, args: UpArgs) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Turn the `--remote` value into an [`SshTarget`], supporting a trailing
+/// `:PORT` so boxes on a non-standard SSH port (RunPod / openresearch dev nodes,
+/// reached as `root@1.2.3.4:38455`) work with no `~/.ssh/config` entry.
+///
+/// - `alias` / `user@host` (no port) → a bare alias: `~/.ssh/config` alone
+///   decides everything, exactly as before.
+/// - `user@<hostname>:PORT` → `-p PORT` only; the user's own config/known_hosts
+///   still govern host-key checking, since a name they typed may be one they've
+///   pinned. We must not silently weaken verification for it.
+/// - `user@<ip>:PORT` → `-p PORT` plus `StrictHostKeyChecking=accept-new`
+///   (trust-on-first-use against the real `known_hosts`). A raw IP is the
+///   freshly-provisioned-box case (RunPod/openresearch): nothing is pinned yet,
+///   so first-use auto-accept lets `orx up --remote` connect without a prompt,
+///   while a later key change is still caught. Caveat: if a provider recycles
+///   that IP:port onto a *different* box, the pin now mismatches and ssh refuses
+///   until the user runs `ssh-keygen -R`; that loud failure is the safe choice
+///   over silently trusting whatever answers.
+///
+/// A trailing `:PORT` is only recognized when it's `1..=65535` and the address
+/// isn't a raw (unbracketed) IPv6 literal — so IPv6 hosts and aliases containing
+/// colons are left untouched rather than mis-split into host + bogus port.
+fn parse_remote_target(host: &str) -> SshTarget {
+    match split_host_port(host) {
+        Some((dest, port)) => {
+            let policy = if host_is_ip_literal(&dest) {
+                HostKeyPolicy::AcceptNew
+            } else {
+                HostKeyPolicy::UserConfig
+            };
+            SshTarget::host_port(dest, port, policy)
+        }
+        None => SshTarget::alias(host),
+    }
+}
+
+/// `(host, PORT)` when `host` ends in `:<port>` with `port` in `1..=65535` and
+/// `host` is not a raw (unbracketed) IPv6 literal. Returns `None` for aliases,
+/// bare `user@host`, `host:0`, out-of-range ports, and `2001:db8::1`-style
+/// addresses, so those keep their exact prior behavior instead of being
+/// mis-parsed into a host + spurious port.
+fn split_host_port(host: &str) -> Option<(String, u16)> {
+    let (head, tail) = host.rsplit_once(':')?;
+    // Reject if the port isn't purely numeric and in range (0 and >65535 are
+    // not usable ports, so treat them as "no port here", not a silent -p 0).
+    if tail.is_empty() || !tail.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let port = tail.parse::<u16>().ok().filter(|&p| p != 0)?;
+    // Disambiguate IPv6: a `:` remaining in the host means the split colon was
+    // *inside* an address (raw `2001:db8::1`, or an unclosed `[…`), not a port
+    // separator. Only a bracketed literal (`[2001:db8::1]`) is a valid host half
+    // here — mirroring how ssh requires brackets for an IPv6 host with a port.
+    // Check the part *after* any `user@`, so `user@[::1]:2222` isn't mistaken for
+    // an unbracketed literal (its `head` starts with `user@`, not `[`).
+    let host_only = strip_user(head);
+    let bracketed_v6 = host_only.starts_with('[') && host_only.ends_with(']');
+    if host_only.contains(':') && !bracketed_v6 {
+        return None;
+    }
+    Some((head.to_string(), port))
+}
+
+/// The host portion of a destination, dropping an optional leading `user@`.
+fn strip_user(dest: &str) -> &str {
+    dest.rsplit_once('@').map_or(dest, |(_, h)| h)
+}
+
+/// Whether `dest` (an alias or `user@host`) resolves to a bare IP literal — the
+/// signal that this is a freshly-provisioned box (nothing pinned) rather than a
+/// hostname the user may already trust. Strips an optional `user@` and matched
+/// IPv6 brackets before parsing.
+fn host_is_ip_literal(dest: &str) -> bool {
+    use std::net::IpAddr;
+    let host = strip_user(dest);
+    // Strip brackets only as a matched pair, so a malformed one-sided `[…`
+    // doesn't parse as an IP.
+    let host = match (host.strip_prefix('['), host.strip_suffix(']')) {
+        (Some(_), Some(_)) => &host[1..host.len() - 1],
+        _ => host,
+    };
+    host.parse::<IpAddr>().is_ok()
 }
 
 /// The remote command: start `orx up` bound to the remote's loopback, no
@@ -241,5 +328,102 @@ mod tests {
         let p = args.iter().position(|a| a == "-p").unwrap();
         assert!(p < sep, "extra_opts must precede the -- separator");
         assert_eq!(args[p + 1], "2222");
+    }
+
+    #[test]
+    fn bare_alias_and_userhost_stay_plain_aliases() {
+        // No port, no imposed opts — `~/.ssh/config` keeps full control.
+        for h in ["mybox", "root@example.com"] {
+            let t = parse_remote_target(h);
+            assert_eq!(t.dest, h);
+            assert!(t.extra_opts.is_empty(), "{h} should get no extra opts");
+        }
+    }
+
+    #[test]
+    fn ip_with_port_gets_accept_new_tofu_not_devnull() {
+        // The RunPod / openresearch case: root@<ip>:38455 → -p 38455 plus genuine
+        // trust-on-first-use (accept-new against real known_hosts). It must NOT
+        // use UserKnownHostsFile=/dev/null (that's accept-every-time, reserved
+        // for provider-managed boxes).
+        let t = parse_remote_target("root@38.128.232.245:38455");
+        assert_eq!(t.dest, "root@38.128.232.245");
+        let joined = t.extra_opts.join(" ");
+        assert!(joined.contains("-p 38455"));
+        assert!(joined.contains("StrictHostKeyChecking=accept-new"));
+        assert!(
+            !joined.contains("/dev/null"),
+            "user-typed host must keep its real known_hosts"
+        );
+        // And it flows all the way into the ssh argv, before the `--`.
+        let args = ssh_forward_args(&t, "127.0.0.1:7:localhost:7", "orx up");
+        let sep = args.iter().position(|a| a == "--").unwrap();
+        let p = args.iter().position(|a| a == "-p").unwrap();
+        assert!(p < sep && args[p + 1] == "38455");
+        assert_eq!(args[sep + 1], "root@38.128.232.245");
+    }
+
+    #[test]
+    fn hostname_with_port_gets_dash_p_only_no_hostkey_override() {
+        // A *name* the user typed may be one they've pinned — appending :PORT
+        // must not silently downgrade host-key verification. Only `-p` is added.
+        let t = parse_remote_target("root@example.com:2222");
+        assert_eq!(t.dest, "root@example.com");
+        assert_eq!(t.extra_opts, vec!["-p".to_string(), "2222".to_string()]);
+    }
+
+    #[test]
+    fn ipv6_and_odd_trailing_colons_are_not_treated_as_ports() {
+        // Bracketed IPv6 without a port: colon is inside the literal.
+        assert_eq!(parse_remote_target("[::1]").dest, "[::1]");
+        assert!(parse_remote_target("[::1]").extra_opts.is_empty());
+        // RAW (unbracketed) IPv6 must NOT be mis-split into host + port.
+        assert_eq!(parse_remote_target("2001:db8::5").dest, "2001:db8::5");
+        assert!(parse_remote_target("2001:db8::5").extra_opts.is_empty());
+        // A trailing colon with no digits, non-numeric, or :0 isn't a port.
+        assert!(parse_remote_target("host:").extra_opts.is_empty());
+        assert!(parse_remote_target("host:abc").extra_opts.is_empty());
+        assert!(parse_remote_target("host:0").extra_opts.is_empty());
+        assert_eq!(parse_remote_target("host:0").dest, "host:0");
+        // >u16 falls through to a bare alias (ssh will surface the bad host).
+        assert!(parse_remote_target("host:99999").extra_opts.is_empty());
+        // Bracketed IPv6 *with* a port is honored (and an IP literal → accept-new).
+        let t = parse_remote_target("[2001:db8::1]:2222");
+        assert_eq!(t.dest, "[2001:db8::1]");
+        let joined = t.extra_opts.join(" ");
+        assert!(joined.contains("-p 2222"));
+        assert!(joined.contains("StrictHostKeyChecking=accept-new"));
+    }
+
+    #[test]
+    fn user_prefixed_bracketed_ipv6_keeps_its_port() {
+        // Regression: `user@[::1]:2222` must NOT drop the port (the bracket check
+        // has to look past the `user@` prefix, or it silently connects on :22).
+        let t = parse_remote_target("root@[::1]:2222");
+        assert_eq!(t.dest, "root@[::1]");
+        let joined = t.extra_opts.join(" ");
+        assert!(joined.contains("-p 2222"), "port must survive: {joined}");
+        // `[::1]` is a loopback IP literal → accept-new TOFU.
+        assert!(joined.contains("StrictHostKeyChecking=accept-new"));
+    }
+
+    #[test]
+    fn host_is_ip_literal_classifies_forms() {
+        // IPs in every shape we can be handed → true.
+        for d in [
+            "1.2.3.4",
+            "root@1.2.3.4",
+            "[2001:db8::1]",
+            "root@[::1]",
+            "::ffff:1.2.3.4",
+        ] {
+            assert!(host_is_ip_literal(d), "{d} should be an IP literal");
+        }
+        // Hostnames (incl. a numeric-looking one) → false.
+        for d in ["example.com", "root@example.com", "1.2.3.4.example.com"] {
+            assert!(!host_is_ip_literal(d), "{d} should be a hostname");
+        }
+        // A malformed one-sided bracket must NOT parse as an IP.
+        assert!(!host_is_ip_literal("[1.2.3.4"));
     }
 }

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -178,32 +178,23 @@ impl BackendDescriptor {
     }
 
     /// The box's SSH endpoint as a ready-to-use target, once the supervisor
-    /// has recorded it (openresearch_job only). Host keys are accepted on
-    /// first use: the box is freshly provisioned and providers recycle proxy
-    /// host:port pairs, so pinning would only produce false mismatches — the
-    /// platform's own ssh access to these boxes behaves the same way.
+    /// has recorded it (openresearch_job only). Uses
+    /// [`ssh::HostKeyPolicy::Ephemeral`] — see its docs for why these
+    /// machine-provisioned, host:port-recycled boxes accept any key.
     pub fn openresearch_ssh_target(&self) -> Option<ssh::SshTarget> {
         if self.kind != "openresearch_job" {
             return None;
         }
-        let (host, port, user) = (
-            self.ssh_host.as_deref()?,
-            self.ssh_port?,
-            self.ssh_user.as_deref()?,
-        );
-        Some(ssh::SshTarget {
-            dest: format!("{user}@{host}"),
-            extra_opts: vec![
-                "-p".into(),
-                port.to_string(),
-                "-o".into(),
-                "StrictHostKeyChecking=no".into(),
-                "-o".into(),
-                "UserKnownHostsFile=/dev/null".into(),
-                "-o".into(),
-                "LogLevel=ERROR".into(),
-            ],
-        })
+        let host = self.ssh_host.as_deref()?;
+        let user = self.ssh_user.as_deref()?;
+        // Stored as i64 (SQLite); a real SSH port fits u16. Bail rather than
+        // panic if the row somehow holds an out-of-range value.
+        let port = u16::try_from(self.ssh_port?).ok()?;
+        Some(ssh::SshTarget::host_port(
+            format!("{user}@{host}"),
+            port,
+            ssh::HostKeyPolicy::Ephemeral,
+        ))
     }
 }
 

--- a/src/jobs/ssh.rs
+++ b/src/jobs/ssh.rs
@@ -39,6 +39,24 @@ pub struct SshTarget {
     pub extra_opts: Vec<String>,
 }
 
+/// How to treat the remote's SSH host key for a `host_port` target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostKeyPolicy {
+    /// `~/.ssh/config` + the user's own `known_hosts` decide everything — impose
+    /// nothing. For a user-typed hostname they may already have pinned.
+    UserConfig,
+    /// `StrictHostKeyChecking=accept-new` against the user's real `known_hosts`:
+    /// genuine trust-on-first-use — the first connection is accepted and
+    /// recorded, and a later key change is caught. For a freshly-seen box
+    /// identified by a raw IP (nothing to have pinned yet).
+    AcceptNew,
+    /// `StrictHostKeyChecking=no` + `UserKnownHostsFile=/dev/null`: accept any
+    /// key every time, persist nothing. ONLY for machine-provisioned boxes whose
+    /// proxy `host:port` pairs are recycled by the provider, where a real pin
+    /// would just produce spurious mismatches (see `openresearch_ssh_target`).
+    Ephemeral,
+}
+
 impl SshTarget {
     /// A bare alias — `~/.ssh/config` alone decides the endpoint.
     pub fn alias(host: &str) -> Self {
@@ -46,6 +64,32 @@ impl SshTarget {
             dest: host.to_string(),
             extra_opts: Vec::new(),
         }
+    }
+
+    /// `dest` (an alias or `user@host`) on an explicit `port`, with an explicit
+    /// host-key `policy`. Centralizes the `-p`/`-o` opt vector that both the
+    /// `--remote` CLI and the openresearch backend need, so the host-key
+    /// rationale lives in one place ([`HostKeyPolicy`]) instead of drifting
+    /// across call sites.
+    pub fn host_port(dest: String, port: u16, policy: HostKeyPolicy) -> Self {
+        let mut extra_opts = vec!["-p".into(), port.to_string()];
+        match policy {
+            HostKeyPolicy::UserConfig => {}
+            HostKeyPolicy::AcceptNew => {
+                extra_opts.extend(["-o".into(), "StrictHostKeyChecking=accept-new".into()]);
+            }
+            HostKeyPolicy::Ephemeral => {
+                extra_opts.extend([
+                    "-o".into(),
+                    "StrictHostKeyChecking=no".into(),
+                    "-o".into(),
+                    "UserKnownHostsFile=/dev/null".into(),
+                    "-o".into(),
+                    "LogLevel=ERROR".into(),
+                ]);
+            }
+        }
+        Self { dest, extra_opts }
     }
 }
 
@@ -315,6 +359,38 @@ mod tests {
         assert!(target.extra_opts.is_empty());
         // No `-p`/`-o Strict…` beyond the shared multiplexing opts.
         assert_eq!(ssh_opts(&target).len(), 10);
+    }
+
+    #[test]
+    fn host_port_policy_shapes_the_opt_vector() {
+        // UserConfig: -p only, user's own config/known_hosts untouched.
+        let t = SshTarget::host_port("root@h".into(), 2222, HostKeyPolicy::UserConfig);
+        assert_eq!(t.extra_opts, vec!["-p".to_string(), "2222".to_string()]);
+
+        // AcceptNew: real TOFU — accept-new, but NOT /dev/null.
+        let t = SshTarget::host_port("root@h".into(), 2222, HostKeyPolicy::AcceptNew);
+        let joined = t.extra_opts.join(" ");
+        assert!(joined.contains("-p 2222"));
+        assert!(joined.contains("StrictHostKeyChecking=accept-new"));
+        assert!(!joined.contains("/dev/null"));
+
+        // Ephemeral: provider box — accept-anything, persist nothing. Assert the
+        // EXACT vector so the openresearch backend (which relies on this shape,
+        // incl. LogLevel=ERROR and ordering) can't silently drift.
+        let t = SshTarget::host_port("root@h".into(), 2222, HostKeyPolicy::Ephemeral);
+        assert_eq!(
+            t.extra_opts,
+            vec![
+                "-p",
+                "2222",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-o",
+                "UserKnownHostsFile=/dev/null",
+                "-o",
+                "LogLevel=ERROR",
+            ]
+        );
     }
 
     /// Explicit targets on the same host but different ports must not share a

--- a/src/main.rs
+++ b/src/main.rs
@@ -639,10 +639,12 @@ pub struct UpArgs {
     #[arg(long, default_value_t = 4791)]
     pub port: u16,
     /// Run `orx up` on a remote box over SSH and forward it here. The value is
-    /// an `~/.ssh/config` host alias (or `user@host`). Starts the server there,
-    /// tunnels `--port` to your laptop, and opens your browser. Note: the remote
-    /// dashboard is unauthenticated and bound to that host's loopback, so anyone
-    /// else with an account on that host can reach it.
+    /// an `~/.ssh/config` host alias, or `user@host` (append `:PORT` for a
+    /// non-standard SSH port, e.g. `root@1.2.3.4:38455`). Only user@host + port
+    /// are reconstructed; a custom key or jump host must come from `~/.ssh/config`.
+    /// Starts the server there, tunnels `--port` to your laptop, and opens your
+    /// browser. Note: the remote dashboard is unauthenticated and bound to that
+    /// host's loopback, so anyone else with an account on that host can reach it.
     #[arg(long, value_name = "HOST")]
     pub remote: Option<String>,
     /// Don't open the dashboard in the browser on startup.

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -155,54 +155,51 @@ impl SshSession {
         // fill-in-the-blank), and prose dimmed so it frames rather than competes.
         //
         // Adaptive target: many boxes (RunPod / openresearch dev nodes) are
-        // reached by raw `user@host -p PORT`, with no `~/.ssh/config` alias — so
+        // reached by raw `user@host:PORT`, with no `~/.ssh/config` alias — so
         // "<ssh-alias>" is a dead end there. We anchor on the one thing every
-        // reader has: the `user@host` (and any `-p PORT`) they just typed to get
-        // in. When `SSH_CONNECTION` hands us a usable *public* server IP we splice
-        // it straight in so the command is nearly copy-paste; otherwise we show a
-        // `<user@host>` placeholder and point at their own `ssh` line.
+        // reader has: the `user@host` (and any custom port) they just typed to
+        // get in. `orx up --remote` accepts a trailing `:PORT` (see
+        // `commands::up_remote`), so option 1 is a genuine one-command path even
+        // on a non-standard port. When `SSH_CONNECTION` hands us a usable
+        // *public* server IP we splice it straight in; otherwise we show the
+        // `<user@host>` placeholder and point at the reader's own `ssh` line.
         let prompt = dim("$", ansi);
-        let hosted_ip = self.server_ip_hint();
-        // What goes in the connection-target slot of each command: the box's own
-        // public IP when `SSH_CONNECTION` gives us a usable one (nearly
-        // copy-paste), else a `<user@host>` placeholder — the one thing every
-        // reader has, alias or not.
-        let target = match hosted_ip {
-            Some(ip) => cyan(ip, ansi),
-            None => cyan("<user@host>", ansi),
-        };
-        // Custom SSH ports (RunPod / openresearch dev nodes connect on e.g.
-        // :38455) can't be recovered here: `SSH_CONNECTION`'s port field is
-        // sshd's own listen port, not the one the client dialed. Only the manual
-        // `ssh` command can carry `-p PORT`; `orx up --remote` has no port flag,
-        // so we deliberately keep the port slot OFF the option-1 line.
-        let port_slot = cyan("[-p PORT]", ansi);
+        let server_ip = self.server_ip_hint();
+        // The connection target both commands share. `[:PORT]` is a cyan optional
+        // slot: the client-dialed port can't be recovered from `SSH_CONNECTION`
+        // (its port field is sshd's own listen port, e.g. :22, not RunPod's
+        // :38455), so the reader supplies it from the ssh command they ran.
+        let host_part = server_ip.unwrap_or("<user@host>");
+        let target = format!("{}{}", cyan(host_part, ansi), cyan("[:PORT]", ansi));
 
         // Each command: bold command-text + cyan target + dim trailing comment,
         // so within a line the part you type stays bright and asides recede.
         let primary = format!("{} {target}", bold("orx up --remote", ansi));
         let manual = format!(
-            "{} {port_slot} {target}   {}",
+            "{} {target}   {}",
             bold(&format!("ssh -N -L {port}:localhost:{port}"), ansi),
             dim(&format!("# then open http://localhost:{port}"), ansi),
         );
 
-        // Point the reader at where the target comes from — their own `ssh`
-        // line — and flag the custom-port caveat that bites RunPod users:
-        // option 1 only works on the default port 22 / a config alias, so on a
-        // non-standard port option 2 is the one to use.
-        let target_note = match hosted_ip {
+        // Point the reader at where the target comes from — their own `ssh` line
+        // — and be honest about option 1's limit: `orx up --remote` reconstructs
+        // only user@host + port, so a connection that needs `-i key` / a jump
+        // host (and isn't in ~/.ssh/config) has to use option 2 or a config entry.
+        let target_note = match server_ip {
             Some(ip) => format!(
-                "{ip} is this box's address. If it doesn't connect, use the same \
-                 user@host (and -p PORT) from the ssh command you ran to get here."
+                "{ip} is this box's address. If it doesn't connect, use the \
+                 user@host and port from the ssh command you ran to get here."
             ),
-            None => "<user@host> = whatever you typed to ssh into this box \
-                     (e.g. root@203.0.113.5), no ~/.ssh/config alias needed. \
-                     [-p PORT] = the port you connect on; drop it if that's 22."
+            None => "<user@host>[:PORT] = the user, host, and -p port from the ssh \
+                     command you ran to get here (e.g. root@203.0.113.5:2222). \
+                     No ~/.ssh/config alias needed."
                 .to_string(),
         };
-        let port_caveat = "On a non-default SSH port, use option 2 — orx up --remote \
-                           can't pass -p yet.";
+        // Only surfaced with option 1, since option 2 is a plain ssh you can add
+        // flags to yourself.
+        let key_caveat = "If you ssh in with a custom key or jump host that isn't in \
+                          ~/.ssh/config, option 1 can't see it — use option 2, or add \
+                          an ~/.ssh/config entry.";
 
         format!(
             "{header}\n\n\
@@ -212,7 +209,7 @@ impl SshSession {
              {opt2}\n\
              \x20 {prompt} {manual}\n\n\
              {target_note}\n\
-             {port_caveat}\n",
+             {key_caveat}\n",
             header = bold(
                 &format!("orx up: serving on http://127.0.0.1:{port} (this remote host)"),
                 ansi,
@@ -222,13 +219,10 @@ impl SshSession {
                  run one of these in a laptop terminal — not in this SSH session:",
                 ansi,
             ),
-            opt1 = bold(
-                "1) Let orx forward it for you (default port 22 / an alias):",
-                ansi
-            ),
-            opt2 = bold("2) Or forward it yourself (works on any port):", ansi),
+            opt1 = bold("1) Let orx forward it for you (easiest):", ansi),
+            opt2 = bold("2) Or forward it yourself:", ansi),
             target_note = dim(&target_note, ansi),
-            port_caveat = dim(port_caveat, ansi),
+            key_caveat = dim(key_caveat, ansi),
         )
     }
 }
@@ -302,13 +296,16 @@ mod tests {
         // We anchor on `user@host` (works with no ~/.ssh/config alias), not on a
         // bare "alias" the reader may not have.
         assert!(msg.contains("<user@host>"));
-        assert!(msg.contains("no ~/.ssh/config alias needed"));
+        assert!(msg.contains("No ~/.ssh/config alias needed"));
+        // And the note is honest about option 1's key/jump-host limit.
+        assert!(msg.contains("custom key or jump host"));
     }
 
     #[test]
-    fn custom_port_slot_is_only_on_the_manual_command() {
-        // `orx up --remote` has no `-p` flag, so the port slot must NOT appear on
-        // option 1 — only on the manual `ssh` line, which does accept `-p`.
+    fn both_commands_carry_the_optional_port_slot() {
+        // `orx up --remote` now accepts a trailing `:PORT`, so the `[:PORT]` slot
+        // rides on the shared target and appears on BOTH commands — option 1 is a
+        // real one-command path even on a non-standard SSH port.
         let msg = detect_from(Some("203.0.113.7 51344 10.0.0.5 22"), false)
             .unwrap()
             .render_instructions(4791, false);
@@ -316,14 +313,12 @@ mod tests {
             .lines()
             .find(|l| l.contains("$ orx up --remote"))
             .expect("option-1 command line present");
-        assert!(!primary_line.contains("-p PORT"));
+        assert!(primary_line.contains("<user@host>[:PORT]"));
         let manual_line = msg
             .lines()
             .find(|l| l.contains("$ ssh -N -L"))
             .expect("option-2 command line present");
-        assert!(manual_line.contains("[-p PORT]"));
-        // And the caveat spells out why option 1 can't do custom ports.
-        assert!(msg.contains("orx up --remote can't pass -p yet"));
+        assert!(manual_line.contains("<user@host>[:PORT]"));
     }
 
     #[test]
@@ -333,8 +328,17 @@ mod tests {
         let msg = detect_from(Some("203.0.113.7 51344 198.51.100.5 22"), false)
             .unwrap()
             .render_instructions(4791, false);
-        assert!(msg.contains("orx up --remote 198.51.100.5"));
-        assert!(msg.contains("198.51.100.5   # then open"));
+        assert!(msg.contains("orx up --remote 198.51.100.5[:PORT]"));
+        // The manual command carries the same target; assert the two facts
+        // separately rather than pinning the whitespace/comment glue between them.
+        let manual_line = msg
+            .lines()
+            .find(|l| l.contains("$ ssh -N -L"))
+            .expect("manual command line present");
+        assert!(manual_line.contains("198.51.100.5[:PORT]"));
+        assert!(manual_line.contains("http://localhost:4791"));
+        // The accompanying note names the IP (its dedicated branch).
+        assert!(msg.contains("198.51.100.5 is this box's address"));
         // No leftover placeholder when we filled the IP in.
         assert!(!msg.contains("<user@host>"));
     }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -151,31 +151,68 @@ impl SshSession {
     fn render_instructions(&self, port: u16, ansi: bool) -> String {
         // The two commands are the whole point, so they're the brightest thing
         // on screen: bold command text, a `$` prompt so they read as "type
-        // this", and the `<ssh-alias>` placeholder in cyan (readable, obviously
-        // a fill-in-the-blank) rather than dimmed into the background. Prose is
-        // dimmed so it frames the commands instead of competing with them.
-        let alias = cyan("<ssh-alias>", ansi);
+        // this", the connection target in cyan (readable, obviously a
+        // fill-in-the-blank), and prose dimmed so it frames rather than competes.
+        //
+        // Adaptive target: many boxes (RunPod / openresearch dev nodes) are
+        // reached by raw `user@host -p PORT`, with no `~/.ssh/config` alias — so
+        // "<ssh-alias>" is a dead end there. We anchor on the one thing every
+        // reader has: the `user@host` (and any `-p PORT`) they just typed to get
+        // in. When `SSH_CONNECTION` hands us a usable *public* server IP we splice
+        // it straight in so the command is nearly copy-paste; otherwise we show a
+        // `<user@host>` placeholder and point at their own `ssh` line.
         let prompt = dim("$", ansi);
+        let hosted_ip = self.server_ip_hint();
+        // What goes in the connection-target slot of each command: the box's own
+        // public IP when `SSH_CONNECTION` gives us a usable one (nearly
+        // copy-paste), else a `<user@host>` placeholder — the one thing every
+        // reader has, alias or not.
+        let target = match hosted_ip {
+            Some(ip) => cyan(ip, ansi),
+            None => cyan("<user@host>", ansi),
+        };
+        // Custom SSH ports (RunPod / openresearch dev nodes connect on e.g.
+        // :38455) can't be recovered here: `SSH_CONNECTION`'s port field is
+        // sshd's own listen port, not the one the client dialed. Only the manual
+        // `ssh` command can carry `-p PORT`; `orx up --remote` has no port flag,
+        // so we deliberately keep the port slot OFF the option-1 line.
+        let port_slot = cyan("[-p PORT]", ansi);
 
-        // Each command is built from bold command-text + cyan placeholder + a
-        // dim trailing comment, so within one line the part you type stays
-        // bright and the aside recedes. `<ssh-alias>` is the ~/.ssh/config alias
-        // / user@host the reader connected with; its note sits right below.
-        let primary = format!("{} {alias}", bold("orx up --remote", ansi));
+        // Each command: bold command-text + cyan target + dim trailing comment,
+        // so within a line the part you type stays bright and asides recede.
+        let primary = format!("{} {target}", bold("orx up --remote", ansi));
         let manual = format!(
-            "{} {alias}   {}",
+            "{} {port_slot} {target}   {}",
             bold(&format!("ssh -N -L {port}:localhost:{port}"), ansi),
             dim(&format!("# then open http://localhost:{port}"), ansi),
         );
 
-        let mut out = format!(
+        // Point the reader at where the target comes from — their own `ssh`
+        // line — and flag the custom-port caveat that bites RunPod users:
+        // option 1 only works on the default port 22 / a config alias, so on a
+        // non-standard port option 2 is the one to use.
+        let target_note = match hosted_ip {
+            Some(ip) => format!(
+                "{ip} is this box's address. If it doesn't connect, use the same \
+                 user@host (and -p PORT) from the ssh command you ran to get here."
+            ),
+            None => "<user@host> = whatever you typed to ssh into this box \
+                     (e.g. root@203.0.113.5), no ~/.ssh/config alias needed. \
+                     [-p PORT] = the port you connect on; drop it if that's 22."
+                .to_string(),
+        };
+        let port_caveat = "On a non-default SSH port, use option 2 — orx up --remote \
+                           can't pass -p yet.";
+
+        format!(
             "{header}\n\n\
              {intro}\n\n\
              {opt1}\n\
-             \x20 {prompt} {primary}\n\
-             \x20 {alias_note}\n\n\
+             \x20 {prompt} {primary}\n\n\
              {opt2}\n\
-             \x20 {prompt} {manual}\n",
+             \x20 {prompt} {manual}\n\n\
+             {target_note}\n\
+             {port_caveat}\n",
             header = bold(
                 &format!("orx up: serving on http://127.0.0.1:{port} (this remote host)"),
                 ansi,
@@ -185,22 +222,14 @@ impl SshSession {
                  run one of these in a laptop terminal — not in this SSH session:",
                 ansi,
             ),
-            opt1 = bold("1) Let orx forward it for you (easiest):", ansi),
-            alias_note = dim(
-                "<ssh-alias> = the ssh alias / user@host you connect with, not the box's IP.",
-                ansi,
+            opt1 = bold(
+                "1) Let orx forward it for you (default port 22 / an alias):",
+                ansi
             ),
-            opt2 = bold("2) Or forward it yourself:", ansi),
-        );
-        if let Some(ip) = self.server_ip_hint() {
-            out.push('\n');
-            out.push_str(&dim(
-                &format!("No alias? {ip} may work in its place (add your usual -i/-p)."),
-                ansi,
-            ));
-            out.push('\n');
-        }
-        out
+            opt2 = bold("2) Or forward it yourself (works on any port):", ansi),
+            target_note = dim(&target_note, ansi),
+            port_caveat = dim(port_caveat, ansi),
+        )
     }
 }
 
@@ -262,16 +291,52 @@ mod tests {
 
     #[test]
     fn instructions_mention_both_paths_and_port() {
-        // Plain (no ANSI) so assertions match the literal text.
+        // Private server IP → the placeholder branch. Plain (no ANSI) so
+        // assertions match the literal text.
         let msg = detect_from(Some("203.0.113.7 51344 10.0.0.5 22"), false)
             .unwrap()
             .render_instructions(4899, false);
         assert!(msg.contains("orx up --remote"));
         assert!(msg.contains("ssh -N -L 4899:localhost:4899"));
         assert!(msg.contains("http://localhost:4899"));
-        // The placeholder is the ssh alias, and the text says so explicitly.
-        assert!(msg.contains("<ssh-alias>"));
-        assert!(msg.contains("not the box's IP"));
+        // We anchor on `user@host` (works with no ~/.ssh/config alias), not on a
+        // bare "alias" the reader may not have.
+        assert!(msg.contains("<user@host>"));
+        assert!(msg.contains("no ~/.ssh/config alias needed"));
+    }
+
+    #[test]
+    fn custom_port_slot_is_only_on_the_manual_command() {
+        // `orx up --remote` has no `-p` flag, so the port slot must NOT appear on
+        // option 1 — only on the manual `ssh` line, which does accept `-p`.
+        let msg = detect_from(Some("203.0.113.7 51344 10.0.0.5 22"), false)
+            .unwrap()
+            .render_instructions(4791, false);
+        let primary_line = msg
+            .lines()
+            .find(|l| l.contains("$ orx up --remote"))
+            .expect("option-1 command line present");
+        assert!(!primary_line.contains("-p PORT"));
+        let manual_line = msg
+            .lines()
+            .find(|l| l.contains("$ ssh -N -L"))
+            .expect("option-2 command line present");
+        assert!(manual_line.contains("[-p PORT]"));
+        // And the caveat spells out why option 1 can't do custom ports.
+        assert!(msg.contains("orx up --remote can't pass -p yet"));
+    }
+
+    #[test]
+    fn public_server_ip_is_inlined_into_the_commands() {
+        // A usable public IP is spliced straight into both commands so they're
+        // nearly copy-paste, instead of leaving a placeholder.
+        let msg = detect_from(Some("203.0.113.7 51344 198.51.100.5 22"), false)
+            .unwrap()
+            .render_instructions(4791, false);
+        assert!(msg.contains("orx up --remote 198.51.100.5"));
+        assert!(msg.contains("198.51.100.5   # then open"));
+        // No leftover placeholder when we filled the IP in.
+        assert!(!msg.contains("<user@host>"));
     }
 
     #[test]
@@ -295,7 +360,7 @@ mod tests {
     #[test]
     fn both_commands_are_bold_and_placeholders_are_cyan_not_dim() {
         // Readability fix: the commands you type must be the brightest thing on
-        // screen, and the `<ssh-alias>` you fill in must be legible cyan — not
+        // screen, and the `<user@host>` you fill in must be legible cyan — not
         // dimmed into the background like it used to be.
         let msg = detect_from(Some("203.0.113.7 51344 10.0.0.5 22"), false)
             .unwrap()
@@ -304,7 +369,7 @@ mod tests {
         assert!(msg.contains("\x1b[1morx up --remote\x1b[22m"));
         assert!(msg.contains("\x1b[1mssh -N -L 4791:localhost:4791\x1b[22m"));
         // The placeholder is cyan (\x1b[36m…\x1b[39m), and never dimmed.
-        assert!(msg.contains("\x1b[36m<ssh-alias>\x1b[39m"));
-        assert!(!msg.contains("\x1b[2m<ssh-alias>\x1b[22m"));
+        assert!(msg.contains("\x1b[36m<user@host>\x1b[39m"));
+        assert!(!msg.contains("\x1b[2m<user@host>\x1b[22m"));
     }
 }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -32,11 +32,23 @@ fn bold(text: &str, enabled: bool) -> String {
     }
 }
 
-/// Dim (faint) when `enabled`, else the text unchanged — used to push the
-/// secondary path and asides behind the one command that matters.
+/// Dim (faint) when `enabled`, else the text unchanged — used for the prose
+/// asides that explain the commands, so the commands themselves stand out.
 fn dim(text: &str, enabled: bool) -> String {
     if enabled {
         format!("\x1b[2m{text}\x1b[22m")
+    } else {
+        text.to_string()
+    }
+}
+
+/// Cyan when `enabled`, else the text unchanged. Used for the `<…>` fill-in-the-
+/// blank placeholders inside commands: they must read as "replace me" without
+/// fading out — dimming them (the old behavior) buried the one word the reader
+/// most needs to see. `\x1b[39m` resets only the foreground color.
+fn cyan(text: &str, enabled: bool) -> String {
+    if enabled {
+        format!("\x1b[36m{text}\x1b[39m")
     } else {
         text.to_string()
     }
@@ -137,39 +149,48 @@ impl SshSession {
     /// Core of [`instructions`], with ANSI styling as an explicit arg so it's
     /// testable without touching the environment.
     fn render_instructions(&self, port: u16, ansi: bool) -> String {
-        // `<ssh-alias>` is the ~/.ssh/config alias / user@host the reader typed
-        // to connect — carried inline so the "not the box's IP" point lands next
-        // to the placeholder instead of in a separate paragraph.
-        let alias = dim("<ssh-alias>", ansi);
+        // The two commands are the whole point, so they're the brightest thing
+        // on screen: bold command text, a `$` prompt so they read as "type
+        // this", and the `<ssh-alias>` placeholder in cyan (readable, obviously
+        // a fill-in-the-blank) rather than dimmed into the background. Prose is
+        // dimmed so it frames the commands instead of competing with them.
+        let alias = cyan("<ssh-alias>", ansi);
+        let prompt = dim("$", ansi);
+
+        // Each command is built from bold command-text + cyan placeholder + a
+        // dim trailing comment, so within one line the part you type stays
+        // bright and the aside recedes. `<ssh-alias>` is the ~/.ssh/config alias
+        // / user@host the reader connected with; its note sits right below.
+        let primary = format!("{} {alias}", bold("orx up --remote", ansi));
+        let manual = format!(
+            "{} {alias}   {}",
+            bold(&format!("ssh -N -L {port}:localhost:{port}"), ansi),
+            dim(&format!("# then open http://localhost:{port}"), ansi),
+        );
+
         let mut out = format!(
             "{header}\n\n\
              {intro}\n\n\
-             {run_from_laptop}\n\
-             \x20 {primary} {alias}\n\n\
-             {alias_note}\n\n\
-             {or_line}\n\
-             \x20 {manual}\n",
+             {opt1}\n\
+             \x20 {prompt} {primary}\n\
+             \x20 {alias_note}\n\n\
+             {opt2}\n\
+             \x20 {prompt} {manual}\n",
             header = bold(
                 &format!("orx up: serving on http://127.0.0.1:{port} (this remote host)"),
                 ansi,
             ),
-            intro = "This URL only works here on the box. To open it on your laptop,\n\
-                     run one of these — from your laptop, not this SSH session:",
-            run_from_laptop = "Easiest — let orx forward it for you:",
-            primary = bold("orx up --remote", ansi),
+            intro = dim(
+                "This URL only works here on the box. To open it from your laptop,\n\
+                 run one of these in a laptop terminal — not in this SSH session:",
+                ansi,
+            ),
+            opt1 = bold("1) Let orx forward it for you (easiest):", ansi),
             alias_note = dim(
-                "<ssh-alias> is the name you gave ssh (~/.ssh/config alias or \
-                 user@host), not the box's IP.",
+                "<ssh-alias> = the ssh alias / user@host you connect with, not the box's IP.",
                 ansi,
             ),
-            or_line = dim("Or forward it yourself in a new laptop terminal:", ansi),
-            manual = dim(
-                &format!(
-                    "ssh -N -L {port}:localhost:{port} <ssh-alias>   \
-                     # then open http://localhost:{port}",
-                ),
-                ansi,
-            ),
+            opt2 = bold("2) Or forward it yourself:", ansi),
         );
         if let Some(ip) = self.server_ip_hint() {
             out.push('\n');
@@ -269,5 +290,21 @@ mod tests {
             .render_instructions(4791, true);
         // The primary command is bolded; the whole thing carries escape codes.
         assert!(msg.contains("\x1b[1morx up --remote\x1b[22m"));
+    }
+
+    #[test]
+    fn both_commands_are_bold_and_placeholders_are_cyan_not_dim() {
+        // Readability fix: the commands you type must be the brightest thing on
+        // screen, and the `<ssh-alias>` you fill in must be legible cyan — not
+        // dimmed into the background like it used to be.
+        let msg = detect_from(Some("203.0.113.7 51344 10.0.0.5 22"), false)
+            .unwrap()
+            .render_instructions(4791, true);
+        // Both commands bold.
+        assert!(msg.contains("\x1b[1morx up --remote\x1b[22m"));
+        assert!(msg.contains("\x1b[1mssh -N -L 4791:localhost:4791\x1b[22m"));
+        // The placeholder is cyan (\x1b[36m…\x1b[39m), and never dimmed.
+        assert!(msg.contains("\x1b[36m<ssh-alias>\x1b[39m"));
+        assert!(!msg.contains("\x1b[2m<ssh-alias>\x1b[22m"));
     }
 }


### PR DESCRIPTION
## What & why

Started as "the `orx up` SSH banner is unreadable and assumes a `~/.ssh/config` alias that RunPod/openresearch boxes don't have," and grew into making the one-command path (`orx up --remote`) actually work for those boxes.

The trigger: on a fresh RunPod box you connect with `ssh -p 38455 root@1.2.3.4` — no alias. The old banner told you to type `<ssh-alias>` (a dead end) and `orx up --remote` couldn't pass a custom SSH port, so neither advertised path worked.

## Changes

**1. Readable, honest banner** (`src/remote.rs`)
- Commands are **bold** with a `$` prompt; the connection target is **cyan** (legible placeholder) instead of dimmed; only prose is dim.
- Adaptive target: inline the box's public IP when `SSH_CONNECTION` gives a usable one, else a `<user@host>[:PORT]` placeholder — the one thing every reader has, alias or not.
- Honest about limits: `orx up --remote` reconstructs only user@host + port, so a custom key / jump host must come from `~/.ssh/config` (spelled out in the banner + `--remote` help + the reachability error).

**2. Custom SSH port support** (`src/commands/up_remote.rs`, `src/main.rs`)
- `orx up --remote root@1.2.3.4:38455` now works — `parse_remote_target` splits a trailing `:PORT` into `-p PORT`. One command from the laptop: starts `orx up` on the box, forwards the port, opens the browser.

**3. Security-aware host-key policy** (`src/jobs/ssh.rs`) — from review
- New `HostKeyPolicy` enum behind `SshTarget::host_port`, centralizing the `-p`/`-o` opt vector (the openresearch backend now uses it too; behavior byte-identical, guarded by an exact-vector test).
- A user-typed **hostname** with a port keeps the user's own known_hosts (`UserConfig`) — appending `:PORT` must **not** silently disable verification for a host they may have pinned.
- Only a raw **IP** (the freshly-provisioned-box signal) gets `accept-new` TOFU against the real known_hosts. `UserKnownHostsFile=/dev/null` stays reserved for provider-managed boxes.

**4. Parser hardening** — from review
- Raw IPv6 (`2001:db8::5`) no longer mis-split into host + `-p 5`.
- `user@[::1]:2222` no longer silently drops its port (bracket check now looks past `user@`).
- `port == 0` and `> u16` rejected (fall through to a bare alias rather than a bogus `-p`).

## For a RunPod box `ssh -p 38455 root@1.2.3.4`, one command from the laptop:
```
orx up --remote root@1.2.3.4:38455
```

## Review
Ran the repo's 4-agent review loop over two rounds (2 correctness + 2 quality each). Round 1 surfaced the host-key-downgrade and IPv6 issues; round 2 confirmed the fixes and caught the `user@[ipv6]:port` port-drop blocker, now fixed with a regression test. All findings addressed.

## Tests
Policy dispatch (IP→accept-new vs hostname→user-config), IPv6 (raw/bracketed/user-prefixed), port 0, >u16, `host_is_ip_literal` forms, exact `Ephemeral` opt vector, and the banner's bold/cyan/adaptive rendering. `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --locked` all green (145 tests). Rebased onto current origin/main (#75).