### PR TITLE
Claude plan mode: read-only orx allowed via PreToolUse hook

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -33,6 +33,7 @@ pub mod login;
 pub mod logout;
 pub mod logs;
 pub mod paper;
+pub mod plan_gate;
 pub mod project;
 pub mod projects;
 pub mod query;

--- a/src/commands/plan_gate.rs
+++ b/src/commands/plan_gate.rs
@@ -1,0 +1,29 @@
+//! `orx plan-gate` — the Claude plan-mode `PreToolUse` hook body.
+//!
+//! Hidden from `--help`: it's not a user command, it's the executable the
+//! plan-mode settings file points its `PreToolUse` hook at (see
+//! `local::harness::claude::write_plan_settings`). Claude Code pipes the hook
+//! payload in on stdin; we print an `allow` decision for read-only `orx`
+//! inspection and stay silent otherwise, letting plan mode gate everything else.
+//!
+//! Always exits 0: a hook error must not block the turn, and "no decision" is
+//! expressed as empty stdout, not a failure.
+
+use std::io::Read;
+
+use crate::error::Result;
+use crate::local::harness::plan_gate_decide;
+
+pub async fn run() -> Result<()> {
+    let mut input = String::new();
+    // A read error just means "no decision" — defer to plan mode's gating.
+    if std::io::stdin().read_to_string(&mut input).is_err() {
+        return Ok(());
+    }
+    if let Ok(payload) = serde_json::from_str::<serde_json::Value>(&input) {
+        if let Some(decision) = plan_gate_decide(&payload) {
+            println!("{decision}");
+        }
+    }
+    Ok(())
+}

--- a/src/local/harness/claude.rs
+++ b/src/local/harness/claude.rs
@@ -116,18 +116,25 @@ impl Harness for ClaudeCode {
     }
 
     fn options(&self) -> HarnessOptions {
-        // Only Auto + Bypass. Headless `claude --print` has no interactive
+        // Plan + Auto + Bypass. Headless `claude --print` has no interactive
         // approval, so `ask`/`accept-edits` can't grant a blocked tool (they just
-        // deny). And `plan` — a hard read-only gate — fights the orx workflow:
-        // it blocks the read-only `orx` inspection the agent needs to plan *and*
-        // the launches that are the whole point, so "propose then approve"
-        // happens better in conversation (the agent describes its plan and asks
-        // before running `orx exp run`) than via a mode that can't run orx.
+        // deny) — those stay out.
+        //   * Plan  — read/propose only: file edits stay blocked until the user
+        //     approves the plan (via the ExitPlanMode card). Plan mode would
+        //     normally also gate `Bash(orx …)`, which would break planning — the
+        //     agent plans by *inspecting* prior runs/logs/evidence via read-only
+        //     `orx`. A `PreToolUse` hook (wired in `run_turn` only for this mode,
+        //     via `write_plan_settings`) lets read-only `orx` verbs through while
+        //     launches (`orx exp run`, `instance`, …) stay gated. See `plan_gate`.
         //   * Auto  — the balanced default; runs tools without prompting.
         //   * Bypass— runs everything, no sandbox.
         HarnessOptions::none()
             .with_permission_modes(
-                &[PermissionMode::Auto, PermissionMode::Bypass],
+                &[
+                    PermissionMode::Plan,
+                    PermissionMode::Auto,
+                    PermissionMode::Bypass,
+                ],
                 PermissionMode::Auto,
             )
             // Claude Code's `--effort` tiers (default `high` on current models).
@@ -187,6 +194,45 @@ fn claude_permission_mode(mode: Option<PermissionMode>) -> &'static str {
         PermissionMode::Auto => "auto",
         PermissionMode::Bypass => "bypassPermissions",
     }
+}
+
+/// Path (relative to the worktree) of the plan-mode settings file we write and
+/// pass via `--settings`. Lives under the same agent dir as the playbook, which
+/// is already git-excluded.
+const PLAN_SETTINGS_REL: &str = ".openresearch/agent/claude-plan-settings.json";
+
+/// Write the plan-mode `--settings` file into `repo` and return its path. The
+/// file registers a `PreToolUse` hook on `Bash` that runs `orx plan-gate`
+/// (this same binary), which allows read-only `orx` inspection through plan
+/// mode's gate while leaving launches/edits blocked. See `plan_gate`.
+///
+/// The hook command is this executable's absolute path, so it resolves without
+/// depending on `orx` being on Claude's `PATH`.
+fn write_plan_settings(repo: &std::path::Path) -> Result<PathBuf> {
+    let orx = std::env::current_exe()
+        .map_err(|e| anyhow!("cannot resolve orx binary path for plan-mode hook: {e}"))?;
+    let settings = serde_json::json!({
+        "hooks": {
+            "PreToolUse": [{
+                "matcher": "Bash",
+                "hooks": [{
+                    "type": "command",
+                    "command": format!(
+                        "{} plan-gate",
+                        crate::jobs::ssh::sh_quote(&orx.to_string_lossy())
+                    ),
+                }],
+            }],
+        }
+    });
+    let path = repo.join(PLAN_SETTINGS_REL);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| anyhow!("cannot create {}: {e}", parent.display()))?;
+    }
+    std::fs::write(&path, serde_json::to_vec_pretty(&settings).unwrap())
+        .map_err(|e| anyhow!("cannot write {}: {e}", path.display()))?;
+    Ok(path)
 }
 
 /// Session reasoning id → Claude Code `--effort` value. The composer only
@@ -375,6 +421,24 @@ async fn run_turn(ctx: &mut TurnCtx) -> Result<()> {
     }
     if let Some(native_id) = &ctx.native_session_id {
         cmd.args(["--resume", native_id]);
+    }
+    // In plan mode, a `PreToolUse` hook lets read-only `orx` inspection through
+    // (plan mode would otherwise gate `Bash(orx …)`); launches stay blocked. The
+    // settings file is written into the worktree and passed for this invocation.
+    if ctx.permission_mode == Some(PermissionMode::Plan) {
+        match write_plan_settings(&repo) {
+            Ok(path) => {
+                cmd.arg("--settings").arg(path);
+            }
+            // Non-fatal: without the hook, plan mode still runs — read-only orx
+            // just gets gated (no headless approval), so inspection is degraded
+            // but the turn proceeds rather than failing to spawn.
+            Err(e) => {
+                eprintln!(
+                    "orx up: plan-mode settings not written, orx inspection will be gated: {e}"
+                );
+            }
+        }
     }
     prepare_env(&mut cmd);
 

--- a/src/local/harness/mod.rs
+++ b/src/local/harness/mod.rs
@@ -23,6 +23,7 @@ mod cursor;
 mod detect;
 mod opencode;
 mod options;
+mod plan_gate;
 
 use std::path::PathBuf;
 
@@ -33,6 +34,7 @@ use crate::local::chat::{PromptAnswer, ResumeCtx, TurnCtx, WirePrompt};
 
 pub use detect::{HarnessInfo, ModelInfo};
 pub use options::{HarnessOptions, PermissionMode};
+pub use plan_gate::decide as plan_gate_decide;
 
 /// How an answered interactive prompt flows back into the harness. The two axes
 /// a harness can live on:
@@ -301,10 +303,12 @@ mod tests {
     /// must be the neutralized (harness-agnostic) permission-mode spellings.
     #[test]
     fn advertised_options_per_harness() {
-        // Claude: only Auto + Bypass. `ask`/`accept-edits` aren't grantable
-        // headless, and `plan` fought the orx workflow — all three dropped.
+        // Claude: Plan + Auto + Bypass. `ask`/`accept-edits` aren't grantable
+        // headless (dropped). `plan` is back: a PreToolUse hook lets read-only
+        // `orx` inspection through while launches/edits stay gated (see
+        // `plan_gate`). Default stays `auto`.
         let claude = options_for("claude-code");
-        assert_eq!(mode_ids(&claude), ["auto", "bypass"]);
+        assert_eq!(mode_ids(&claude), ["plan", "auto", "bypass"]);
         assert_eq!(claude.default_permission_mode, Some("auto"));
         assert_eq!(
             reasoning_ids(&claude),

--- a/src/local/harness/options.rs
+++ b/src/local/harness/options.rs
@@ -31,8 +31,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// Not every harness supports every mode — a harness advertises its supported
 /// subset via `options()` and the composer only offers those. `plan`, for
-/// instance, is Claude-only (Codex's sandbox has no read-only-with-proposals
-/// notion that maps to it, and opencode serve has no plan mode).
+/// instance, is Claude + OpenCode but not Codex (Codex's sandbox has no
+/// read-only-with-proposals notion that maps to it). Claude's plan mode pairs
+/// with a `PreToolUse` hook so read-only `orx` inspection still runs (see
+/// `plan_gate`); OpenCode has a native read-only `plan` agent.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum PermissionMode {

--- a/src/local/harness/plan_gate.rs
+++ b/src/local/harness/plan_gate.rs
@@ -1,0 +1,295 @@
+//! Claude plan-mode gate for `orx` shell commands.
+//!
+//! Claude Code's `--permission-mode plan` auto-approves its built-in read-only
+//! tools (file reads, `grep`, `git log`, …) but treats an arbitrary `Bash(orx …)`
+//! as a write it must gate — and headless `--print` can't answer that prompt, so
+//! the call just fails. That breaks planning, because the agent plans by
+//! *inspecting* prior runs, logs, and the evidence DB via read-only `orx`
+//! subcommands.
+//!
+//! The fix is a `PreToolUse` hook (wired only in plan mode — see
+//! `claude::write_plan_settings`) that runs `orx plan-gate`: it reads the hook's
+//! JSON off stdin, and if the tool is a Bash call invoking a *read-only* `orx`
+//! subcommand it prints an `"allow"` decision so the command runs. For anything
+//! else — a write/launch `orx` verb (`exp run`, `instance`, `create-*`, …), a
+//! non-`orx` command, or an unparseable one — it stays silent (exit 0, no
+//! stdout), so plan mode's normal gating applies and launches remain blocked
+//! until the user approves the plan.
+//!
+//! Classification is deliberately *allowlist-only*: an unknown or ambiguous
+//! subcommand is treated as NOT read-only (gated), so a newly added write verb
+//! can never leak through by default. The flip side is a maintenance
+//! obligation: the allowlist is a hand-kept mirror of the read-only `orx` verbs
+//! in `main.rs`'s `Command` enum. A newly added *read* verb stays gated until
+//! it's added here — `readonly_verbs_are_real_commands` guards against a rename
+//! silently un-gating nothing, but adding a new read verb is a manual step
+//! (there's a pointer comment on the `Command` enum).
+
+use serde_json::{json, Value};
+
+/// Top-level `orx` verbs that are read-only in every form (no subcommand can
+/// turn them into a write). Kept in lockstep with `main.rs`'s `Command` enum;
+/// `readonly_verbs_are_real_commands` guards against a rename.
+const WHOLE_VERB_READS: &[&str] = &[
+    "projects",
+    "explore",
+    "experiments",
+    "env",
+    "runs",
+    "logs",
+    "search-logs",
+    "artifacts",
+    "artifact",
+    "wandb",
+    "query",
+    "chart",
+    "compute",
+    "lit",
+    "paper",
+    "skill",
+    "version",
+];
+
+/// Decide whether a `PreToolUse` hook payload describes a read-only `orx`
+/// invocation that plan mode should let through. Returns the JSON to print on
+/// stdout (an `allow` decision) or `None` to stay silent and defer to plan
+/// mode's default gating.
+///
+/// The payload shape is Claude Code's hook contract: `tool_name` names the tool
+/// and `tool_input.command` carries the Bash command line.
+pub fn decide(payload: &Value) -> Option<Value> {
+    // Only Bash calls carry a shell command to inspect; every other tool defers.
+    if payload.get("tool_name").and_then(Value::as_str) != Some("Bash") {
+        return None;
+    }
+    let command = payload
+        .pointer("/tool_input/command")
+        .and_then(Value::as_str)?;
+
+    if !is_readonly_orx(command) {
+        return None;
+    }
+
+    Some(json!({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+            "permissionDecisionReason":
+                "read-only orx inspection is allowed during plan mode",
+        }
+    }))
+}
+
+/// True iff `command` is a single `orx` invocation whose (sub)command is on the
+/// read-only allowlist. Anything with shell metacharacters that could chain a
+/// second command (`;`, `&&`, `|`, `` ` ``, `$(`, redirection) is rejected — a
+/// read-only prefix must not be a smuggling vector for a write.
+fn is_readonly_orx(command: &str) -> bool {
+    let command = command.trim();
+    if command.contains([';', '|', '&', '`', '>', '<', '\n']) || command.contains("$(") {
+        return false;
+    }
+
+    // Tokenize on whitespace; the wrapper never quotes the verb itself, so a
+    // simple split is enough to read the leading `orx <verb> [<sub>]`.
+    let mut tokens = command.split_whitespace();
+
+    // The binary must be `orx` (bare or a path ending in `/orx`). Reject a
+    // leading env-assignment or a different program.
+    match tokens.next() {
+        Some(bin) if bin == "orx" || bin.ends_with("/orx") => {}
+        _ => return false,
+    }
+
+    // First non-flag token after the binary is the top-level verb.
+    let verb = tokens.by_ref().find(|t| !t.starts_with('-'));
+    let Some(verb) = verb else {
+        // Bare `orx` (or only flags): prints usage — harmless and read-only.
+        return true;
+    };
+
+    if WHOLE_VERB_READS.contains(&verb) {
+        // No subcommand can turn these into a write.
+        return true;
+    }
+
+    match verb {
+        // Verbs with a write subcommand: allow only the read-only subcommand(s).
+        // The next non-flag token is the subcommand.
+        "project" => matches!(subcommand(&mut tokens), Some("view")),
+        "exp" => match subcommand(&mut tokens) {
+            // Pure reads.
+            Some("status" | "wait") => true,
+            // `desc`/`cmd` view the node's notes / run command, but *write* them
+            // with `--set`/`--stdin`. Allow only the read (view) form. The flags
+            // only ever appear on the write form, so a whole-command scan is a
+            // sound discriminator (and `desc --set` etc. are the only writers).
+            Some("desc" | "cmd") => !command.contains("--set") && !command.contains("--stdin"),
+            _ => false,
+        },
+        "report" => matches!(subcommand(&mut tokens), Some("list" | "show" | "download")),
+
+        // Everything else — create-*, instance, login/logout, install-skills,
+        // update, serve, supervise, up, and any unrecognized future verb — is
+        // gated. Allowlist-only: unknown ⇒ not read-only.
+        _ => false,
+    }
+}
+
+/// The next non-flag token, read as a subcommand name.
+fn subcommand<'a>(tokens: &mut impl Iterator<Item = &'a str>) -> Option<&'a str> {
+    tokens.find(|t| !t.starts_with('-'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn payload(command: &str) -> Value {
+        json!({ "tool_name": "Bash", "tool_input": { "command": command } })
+    }
+
+    fn allowed(command: &str) -> bool {
+        decide(&payload(command)).is_some()
+    }
+
+    #[test]
+    fn whole_verb_reads_are_allowed() {
+        for c in [
+            "orx runs",
+            "orx logs r-123 --tail 200",
+            "orx query \"select 1\"",
+            "orx experiments",
+            "orx artifacts r-9",
+            "orx search-logs foo",
+            "orx wandb r-1",
+            "orx chart loss",
+            "orx compute",
+            "orx lit transformers",
+            "orx paper 2301.00001",
+            "orx skill",
+            "orx projects --json",
+            "/usr/local/bin/orx runs",
+            "orx", // bare usage
+        ] {
+            assert!(allowed(c), "should allow: {c}");
+        }
+    }
+
+    #[test]
+    fn read_only_subcommands_are_allowed() {
+        assert!(allowed("orx project view p-1"));
+        assert!(allowed("orx exp status e-1"));
+        // The playbook's core orientation reads (view form).
+        assert!(allowed("orx exp desc e-1"));
+        assert!(allowed("orx exp cmd e-1"));
+        assert!(allowed("orx exp wait e-1"));
+        assert!(allowed("orx report list"));
+        assert!(allowed("orx report show r-1"));
+        assert!(allowed("orx report download r-1 --out x.md"));
+    }
+
+    #[test]
+    fn write_subcommands_are_gated() {
+        // Same verb, write subcommand → not allowed (plan mode gates it).
+        assert!(!allowed("orx project edit p-1 --name x"));
+        assert!(!allowed("orx exp run e-1"));
+        assert!(!allowed("orx exp cancel e-1"));
+        assert!(!allowed("orx report upload r-1 --file x.md"));
+        // `desc`/`cmd` become writes with --set/--stdin → gated.
+        assert!(!allowed("orx exp desc e-1 --set \"found X\""));
+        assert!(!allowed("orx exp desc e-1 --stdin"));
+        assert!(!allowed("orx exp cmd e-1 --set \"python train.py\""));
+    }
+
+    #[test]
+    fn launch_and_write_verbs_are_gated() {
+        for c in [
+            "orx exp run e-1 --backend hf",
+            "orx instance create --gpu a100",
+            "orx create-project --repo x/y",
+            "orx create-experiment --parent e-1",
+            "orx login",
+            "orx logout",
+            "orx install-skills",
+            "orx update",
+            "orx up",
+            "orx serve",
+        ] {
+            assert!(!allowed(c), "should gate: {c}");
+        }
+    }
+
+    #[test]
+    fn unknown_verb_is_gated() {
+        // Allowlist-only: a future verb we haven't classified defaults to gated.
+        assert!(!allowed("orx teleport e-1"));
+    }
+
+    #[test]
+    fn non_orx_commands_defer() {
+        assert!(!allowed("rm -rf /"));
+        assert!(!allowed("git push"));
+        assert!(!allowed("python train.py"));
+        // A program that merely ends in text containing orx is not `orx`.
+        assert!(!allowed("neworx runs"));
+    }
+
+    #[test]
+    fn command_chaining_is_rejected() {
+        // A read-only prefix must not smuggle a second command through.
+        assert!(!allowed("orx runs; orx exp run e-1"));
+        assert!(!allowed("orx runs && rm -rf /"));
+        assert!(!allowed("orx runs | tee /etc/passwd"));
+        assert!(!allowed("orx logs r-1 > /tmp/x"));
+        assert!(!allowed("orx query \"$(rm -rf /)\""));
+        assert!(!allowed("orx runs `whoami`"));
+    }
+
+    #[test]
+    fn non_bash_tools_defer() {
+        let p = json!({ "tool_name": "Edit", "tool_input": { "command": "orx runs" } });
+        assert!(decide(&p).is_none());
+        // Missing command field → defer, not panic.
+        let p = json!({ "tool_name": "Bash", "tool_input": {} });
+        assert!(decide(&p).is_none());
+    }
+
+    #[test]
+    fn allow_decision_has_the_exact_wire_shape() {
+        let out = decide(&payload("orx runs")).unwrap();
+        assert_eq!(
+            out.pointer("/hookSpecificOutput/hookEventName")
+                .and_then(Value::as_str),
+            Some("PreToolUse")
+        );
+        assert_eq!(
+            out.pointer("/hookSpecificOutput/permissionDecision")
+                .and_then(Value::as_str),
+            Some("allow")
+        );
+    }
+
+    /// Drift guard: every whole-verb read on the allowlist must still name a
+    /// real top-level `orx` command. A rename in `main.rs` breaks this test
+    /// (instead of silently un-gating nothing). Catching *additions* of new read
+    /// verbs is the human's job — see the pointer comment on the `Command` enum.
+    #[test]
+    fn readonly_verbs_are_real_commands() {
+        use clap::CommandFactory;
+        let cmd = crate::Cli::command();
+        let real: std::collections::HashSet<&str> =
+            cmd.get_subcommands().map(|s| s.get_name()).collect();
+        for verb in WHOLE_VERB_READS {
+            assert!(
+                real.contains(verb),
+                "allowlisted read verb `{verb}` is not a real orx command \
+                 (renamed in main.rs?)"
+            );
+        }
+        // The verbs with mixed read/write subcommands must also be real.
+        for verb in ["project", "exp", "report"] {
+            assert!(real.contains(verb), "`{verb}` is not a real orx command");
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,10 @@ struct Cli {
 }
 
 #[derive(Subcommand, Debug)]
+// NOTE: `local::harness::plan_gate` keeps a hand-maintained allowlist of the
+// read-only verbs here (what Claude plan mode may run without approval). When
+// you add a *read-only* subcommand, add it there too, or it stays gated in plan
+// mode. `readonly_verbs_are_real_commands` catches renames but not additions.
 enum Command {
     /// Log in via the browser and store a token.
     Login(LoginArgs),
@@ -149,6 +153,12 @@ enum Command {
 
     /// Turn anonymous usage analytics on or off, or show current status.
     Telemetry(TelemetryArgs),
+
+    /// Internal: the Claude plan-mode `PreToolUse` hook body. Reads the hook
+    /// payload on stdin and prints an allow decision for read-only `orx`
+    /// inspection; not a user command.
+    #[command(name = "plan-gate", hide = true)]
+    PlanGate,
 }
 
 #[derive(Args, Debug)]
@@ -732,6 +742,20 @@ async fn main() {
     // `std::process::exit` on their own (e.g. the "not logged in" path) instead
     // of returning here. Never touches stdout or the exit code. Silence it with
     // ORX_NO_UPDATE_CHECK / NO_UPDATE_NOTIFIER.
+    // `plan-gate` is a per-tool-call hook body (fires on every Bash call during
+    // plan mode): it must stay fast and touch neither stdout nor the network, so
+    // skip the update check and telemetry and run it directly.
+    if matches!(command, Command::PlanGate) {
+        // The hook fires on every Bash call during plan mode; it must NEVER
+        // block the turn. Swallow any error to stderr and still exit 0 — a
+        // non-zero exit here would fail every Bash tool call. (`run` is
+        // infallible today; this keeps the invariant if that ever changes.)
+        if let Err(err) = commands::plan_gate::run().await {
+            eprintln!("orx plan-gate: {err}");
+        }
+        return;
+    }
+
     let warning = (!matches!(command, Command::Version(_) | Command::Update(_)))
         .then(updates::UpdateWarning::start);
 
@@ -791,6 +815,7 @@ fn command_name(command: &Command) -> &'static str {
         Command::Supervise(_) => "supervise",
         Command::Up(_) => "up",
         Command::Telemetry(_) => "telemetry",
+        Command::PlanGate => "plan-gate",
     }
 }
 
@@ -830,5 +855,7 @@ async fn dispatch(command: Command) -> error::Result<()> {
             None => commands::up::run(args).await,
         },
         Command::Telemetry(args) => commands::telemetry::run(args).await,
+        // Handled before dispatch (fast path, no telemetry/update check).
+        Command::PlanGate => commands::plan_gate::run().await,
     }
 }


### PR DESCRIPTION
## What

Re-enables **plan mode** for the Claude Code chat harness in `orx up`, with read-only `orx` inspection allowed to run during planning.

Claude Code plan mode works headless (`--print --permission-mode plan`), but plan mode gates `Bash(orx …)` calls — and headless `--print` can't answer the resulting prompt, so they fail. That broke the read-only `orx` inspection (past runs, logs, evidence DB, experiment notes) the agent plans *from*, which is why plan mode was originally dropped.

**Fix:** a `PreToolUse` hook (`orx plan-gate`) returns a `permissionDecision:"allow"` for read-only `orx` invocations, which overrides plan mode's Bash gate. File edits and launches (`orx exp run`, `instance`, `create-*`) stay blocked until the user approves the plan via the existing ExitPlanMode card.

## Per-harness

| Harness | Plan mode |
|---|---|
| **Claude Code** | ✅ re-enabled here (advertises `Plan`; hook allows read-only `orx`) |
| **OpenCode** | ✅ already had a native read-only `plan` agent — no change |
| **Codex** | ❌ left out — headless `collaboration_mode="plan"` is accepted but ignored |

## How it works

- New hidden `orx plan-gate` command is the hook body: reads Claude's hook JSON on stdin, emits an `allow` decision for read-only `orx` invocations, stays silent otherwise (defers to plan mode's gating).
- Allowlist-only classifier in `src/local/harness/plan_gate.rs` — unknown/ambiguous verbs gate (a new write verb can never leak through by default). `exp desc`/`cmd` are reads only *without* `--set`/`--stdin`; `exp wait`, `exp status`, and whole-verb reads (`runs`/`logs`/`query`/…) are allowed.
- The Claude harness advertises `Plan` and writes the `--settings` hook file into the session worktree **only** when in plan mode (reuses `jobs::ssh::sh_quote`, git-excluded under `.openresearch/`).
- Command-chaining is rejected (`; | & \` < > $(` newline) so a read-only prefix can't smuggle a write.
- A drift-guard test + pointer comment on `main.rs`'s `Command` enum keep the allowlist synced with the real command surface.

## Verification

Live-tested against `claude 2.1.197` — full truth table holds:

| Setup | `orx runs --json` | `orx exp run …` |
|---|---|---|
| plan mode **+** hook | ✅ executes | 🚫 denied |
| plan mode, **no** hook | 🚫 denied | 🚫 denied |

The middle row proves the hook is the mechanism (not plan mode being permissive on its own); the last column proves launches stay gated.

CI triad clean locally: `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --locked` (135 pass).

## Review

Two rounds of multi-agent review (round 1: 4 agents — 2 correctness, 2 design; round 2: correctness + design on the post-fix diff). Both converged to no blockers. Round-1 fixes: deduped `shell_quote`, added the missing read-only `exp` verbs, drift guard, doc/exit-0 hardening.

## Notes / out of scope

- No playbook note about plan-mode gating — the playbook is shared across all harnesses, so harness-specific mode mechanics would leak into Codex/Auto contexts. The agent discovers the gate naturally (a launch denial surfaces the plan card).
