### PR TITLE
orx up --remote: run remote orx under POSIX sh -c on any login shell + PATH/CARGO_HOME (v0.1.59)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,7 +928,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openresearch-cli"
-version = "0.1.58"
+version = "0.1.59"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openresearch-cli"
-version = "0.1.58"
+version = "0.1.59"
 edition = "2021"
 description = "OpenResearch CLI (orx) — Rust port"
 repository = "https://github.com/alphaXiv/openresearch-cli"

--- a/src/commands/up_remote.rs
+++ b/src/commands/up_remote.rs
@@ -38,7 +38,9 @@ pub async fn run(host: &str, args: UpArgs) -> Result<()> {
     // and would be misreported as an unreachable host.
     match crate::jobs::ssh::ssh_run(
         &target,
-        "if command -v orx >/dev/null 2>&1; then echo ORX_OK; else echo ORX_MISSING; fi",
+        &remote_shell(
+            "if command -v orx >/dev/null 2>&1; then echo ORX_OK; else echo ORX_MISSING; fi",
+        ),
         None,
     )
     .await
@@ -55,8 +57,10 @@ pub async fn run(host: &str, args: UpArgs) -> Result<()> {
         }
         Ok(out) if !out.contains("ORX_OK") => {
             return Err(anyhow!(
-                "`orx` isn't installed on '{host}' (or not on its non-interactive \
-                 PATH). Install it there, then re-run `orx up --remote {host}`."
+                "`orx` isn't installed on '{host}' (we look on PATH plus \
+                 ~/.cargo/bin and ~/.local/bin). Install it there \
+                 (curl -LsSf https://openresearch.sh/install.sh | sh), then \
+                 re-run `orx up --remote {host}`."
             ));
         }
         Ok(_) => {}
@@ -194,7 +198,20 @@ fn host_is_ip_literal(dest: &str) -> bool {
 /// The remote command: start `orx up` bound to the remote's loopback, no
 /// browser there (we open ours), on the port we forward.
 fn remote_up_cmd(port: u16) -> String {
-    format!("orx up --no-browser --port {port}")
+    remote_shell(&format!("orx up --no-browser --port {port}"))
+}
+
+/// Wrap a remote command so `orx` is found even though ssh runs it in a
+/// *non-interactive* shell that skips the box's `~/.bashrc`/`~/.profile`.
+///
+/// The near-universal installers put `orx` in `~/.cargo/bin` (the `cargo`
+/// install) or `~/.local/bin`, and on a minimal image (RunPod's Ubuntu, etc.)
+/// neither is on the default non-interactive `PATH` — so a bare `command -v orx`
+/// / `orx up` fails even when `which orx` works when you're logged in. We prepend
+/// those two dirs to `PATH` for the command. `$HOME` is left for the remote shell
+/// to expand, so it works whatever the remote user is (root or `runpod`).
+fn remote_shell(cmd: &str) -> String {
+    format!(r#"export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"; {cmd}"#)
 }
 
 /// The `-L` forward value. Local bind pinned to `127.0.0.1` (see the call site).
@@ -290,7 +307,21 @@ mod tests {
     #[test]
     fn forward_and_remote_cmd_use_the_same_port() {
         assert_eq!(forward_spec(4899), "127.0.0.1:4899:localhost:4899");
-        assert_eq!(remote_up_cmd(4899), "orx up --no-browser --port 4899");
+        // The remote command carries the port and starts orx headless…
+        assert!(remote_up_cmd(4899).contains("orx up --no-browser --port 4899"));
+        // …behind a PATH prelude so a non-interactive shell still finds orx in
+        // ~/.cargo/bin (the common installer target on minimal RunPod images).
+        assert!(remote_up_cmd(4899).contains(r#"PATH="$HOME/.cargo/bin"#));
+    }
+
+    #[test]
+    fn remote_shell_prepends_install_dirs_without_expanding_home_locally() {
+        let wrapped = remote_shell("orx up");
+        // Both common install dirs are on PATH, and $HOME stays literal for the
+        // remote shell to expand (so it works for root or the `runpod` user).
+        assert!(wrapped.contains("$HOME/.cargo/bin"));
+        assert!(wrapped.contains("$HOME/.local/bin"));
+        assert!(wrapped.ends_with("orx up"));
     }
 
     #[test]

--- a/src/commands/up_remote.rs
+++ b/src/commands/up_remote.rs
@@ -38,7 +38,7 @@ pub async fn run(host: &str, args: UpArgs) -> Result<()> {
     // and would be misreported as an unreachable host.
     match crate::jobs::ssh::ssh_run(
         &target,
-        &remote_shell(
+        &remote_orx_cmd(
             "if command -v orx >/dev/null 2>&1; then echo ORX_OK; else echo ORX_MISSING; fi",
         ),
         None,
@@ -55,12 +55,29 @@ pub async fn run(host: &str, args: UpArgs) -> Result<()> {
                  its key changed (a reused IP), clear it with `ssh-keygen -R`."
             ));
         }
-        Ok(out) if !out.contains("ORX_OK") => {
+        Ok(out) if out.contains("ORX_MISSING") => {
             return Err(anyhow!(
                 "`orx` isn't installed on '{host}' (we look on PATH plus \
                  ~/.cargo/bin and ~/.local/bin). Install it there \
                  (curl -LsSf https://openresearch.sh/install.sh | sh), then \
                  re-run `orx up --remote {host}`."
+            ));
+        }
+        Ok(out) if !out.contains("ORX_OK") => {
+            // Neither marker, yet ssh exited 0: the probe ran but its stdout
+            // carried neither answer — e.g. a box that echoes something on every
+            // command and swallowed the marker, or `sh` itself was unavailable.
+            // Not "unreachable" and not a clean "missing", so echo what we saw.
+            let out = out.trim();
+            let saw = if out.is_empty() {
+                String::new()
+            } else {
+                format!(" (got: {out:?})")
+            };
+            return Err(anyhow!(
+                "couldn't confirm `orx` on '{host}': the check returned no clear \
+                 answer{saw}. Make sure you can `ssh {host}` and that `orx` is \
+                 installed there."
             ));
         }
         Ok(_) => {}
@@ -195,23 +212,48 @@ fn host_is_ip_literal(dest: &str) -> bool {
     host.parse::<IpAddr>().is_ok()
 }
 
+/// Dirs prepended to the remote `PATH` so `orx` is found on a non-interactive
+/// shell. These are *POSIX shell words* expanded on the remote (`$CARGO_HOME`,
+/// `$HOME`), not locally — so they adapt to the remote user and a relocated
+/// `CARGO_HOME`, whether that's `root` or `runpod`.
+///
+/// `${CARGO_HOME:-$HOME/.cargo}/bin` is where our installer lands `orx`
+/// (dist-workspace.toml sets `install-path = "CARGO_HOME"`, i.e. `~/.cargo/bin`
+/// unless the box overrides `$CARGO_HOME`); `$HOME/.local/bin` covers pip/uv-style
+/// drops. The "not installed" error above names these as `~/.cargo/bin` and
+/// `~/.local/bin` — keep the two in step.
+const REMOTE_ORX_PATH: &str = "${CARGO_HOME:-$HOME/.cargo}/bin:$HOME/.local/bin";
+
 /// The remote command: start `orx up` bound to the remote's loopback, no
 /// browser there (we open ours), on the port we forward.
 fn remote_up_cmd(port: u16) -> String {
-    remote_shell(&format!("orx up --no-browser --port {port}"))
+    remote_orx_cmd(&format!("orx up --no-browser --port {port}"))
 }
 
-/// Wrap a remote command so `orx` is found even though ssh runs it in a
-/// *non-interactive* shell that skips the box's `~/.bashrc`/`~/.profile`.
+/// Wrap a remote command so `orx` is found even though ssh runs it in a shell
+/// that skips the box's `~/.bashrc`/`~/.profile`, and so it runs under POSIX
+/// `sh` regardless of the remote user's login shell.
 ///
-/// The near-universal installers put `orx` in `~/.cargo/bin` (the `cargo`
-/// install) or `~/.local/bin`, and on a minimal image (RunPod's Ubuntu, etc.)
-/// neither is on the default non-interactive `PATH` — so a bare `command -v orx`
-/// / `orx up` fails even when `which orx` works when you're logged in. We prepend
-/// those two dirs to `PATH` for the command. `$HOME` is left for the remote shell
-/// to expand, so it works whatever the remote user is (root or `runpod`).
-fn remote_shell(cmd: &str) -> String {
-    format!(r#"export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"; {cmd}"#)
+/// Two problems this solves, both hit on real boxes:
+/// 1. **PATH.** ssh runs the command non-interactively, so `~/.bashrc`/`~/.profile`
+///    aren't sourced; on a minimal image (RunPod's Ubuntu, etc.) `orx`'s install
+///    dir isn't on the default `PATH`, so a bare `command -v orx` / `orx up` fails
+///    even when `which orx` works when you're logged in. We prepend
+///    [`REMOTE_ORX_PATH`].
+/// 2. **Login shell.** ssh runs the command under the remote user's *login* shell,
+///    which may be csh/tcsh/fish — none of which understand `export VAR=val`. We
+///    hand the whole POSIX body to `sh -c` so it's interpreted by `/bin/sh`
+///    whatever the login shell is. (This mirrors how the job backends run their
+///    payload through an explicit `bash`/`sh`, never the bare login shell.)
+///
+/// The PATH dirs are left as literal `$…`/`${…}` shell words for the *inner* `sh`
+/// to expand on the remote, so they adapt to that box's user and `CARGO_HOME`.
+fn remote_orx_cmd(cmd: &str) -> String {
+    let body = format!(r#"export PATH="{REMOTE_ORX_PATH}:$PATH"; {cmd}"#);
+    // `sh -c '<body>'`: the login shell sees three plain words and execs /bin/sh,
+    // which parses the POSIX body. sh_quote wraps the body so its own quotes,
+    // `$…`, and `;` reach `sh` intact rather than being eaten by the login shell.
+    format!("sh -c {}", crate::jobs::ssh::sh_quote(&body))
 }
 
 /// The `-L` forward value. Local bind pinned to `127.0.0.1` (see the call site).
@@ -310,18 +352,36 @@ mod tests {
         // The remote command carries the port and starts orx headless…
         assert!(remote_up_cmd(4899).contains("orx up --no-browser --port 4899"));
         // …behind a PATH prelude so a non-interactive shell still finds orx in
-        // ~/.cargo/bin (the common installer target on minimal RunPod images).
-        assert!(remote_up_cmd(4899).contains(r#"PATH="$HOME/.cargo/bin"#));
+        // the installer dir (the common target on minimal RunPod images).
+        assert!(remote_up_cmd(4899).contains(r#"PATH="${CARGO_HOME:-$HOME/.cargo}/bin"#));
     }
 
     #[test]
-    fn remote_shell_prepends_install_dirs_without_expanding_home_locally() {
-        let wrapped = remote_shell("orx up");
-        // Both common install dirs are on PATH, and $HOME stays literal for the
-        // remote shell to expand (so it works for root or the `runpod` user).
-        assert!(wrapped.contains("$HOME/.cargo/bin"));
+    fn remote_orx_cmd_forces_posix_sh_and_keeps_expansions_literal() {
+        let wrapped = remote_orx_cmd("orx up");
+        // Runs under an explicit POSIX `sh -c`, not the remote's login shell —
+        // so a csh/tcsh/fish login shell can't choke on `export VAR=val`.
+        assert!(wrapped.starts_with("sh -c "));
+        // The installer dir (CARGO_HOME-aware) and ~/.local/bin are both on PATH,
+        // and every `$…`/`${…}` stays LITERAL for the *remote* sh to expand — so
+        // it adapts to the box's user (root or `runpod`) and its CARGO_HOME. The
+        // presence of the raw tokens proves nothing was expanded on the laptop.
+        assert!(wrapped.contains("${CARGO_HOME:-$HOME/.cargo}/bin"));
         assert!(wrapped.contains("$HOME/.local/bin"));
-        assert!(wrapped.ends_with("orx up"));
+        assert!(wrapped.contains("orx up"));
+    }
+
+    #[test]
+    fn preflight_probe_is_also_wrapped() {
+        // The reachability/installed probe MUST go through remote_orx_cmd too —
+        // else a box with orx only in ~/.cargo/bin false-negatives as "missing".
+        // This mirrors the exact string run() hands to ssh_run at the call site.
+        let probe = remote_orx_cmd(
+            "if command -v orx >/dev/null 2>&1; then echo ORX_OK; else echo ORX_MISSING; fi",
+        );
+        assert!(probe.starts_with("sh -c "));
+        assert!(probe.contains("${CARGO_HOME:-$HOME/.cargo}/bin"));
+        assert!(probe.contains("ORX_OK") && probe.contains("ORX_MISSING"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Follow-up to #74. `orx up --remote` fails with **`orx isn't installed on '<host>'`** on a box where `orx` is clearly installed and `which orx` works when you're logged in.

Cause: `orx up --remote` runs its preflight (`command -v orx`) and the launch (`orx up …`) over a **non-interactive** ssh command, which does **not** source the box's `~/.bashrc`/`~/.profile`. The `cargo`/openresearch installer puts `orx` in `~/.cargo/bin`, and on a minimal image (RunPod's Ubuntu, etc.) that dir isn't on the default non-interactive `PATH`. So `orx` is invisible to `--remote` even though it's installed.

Real repro (RunPod box):
```
$ which orx
/root/.cargo/bin/orx          # works interactively
$ orx up --remote root@1.2.3.4:11089
`orx` isn't installed on 'root@1.2.3.4:11089' …   # fails
```

## Fix

Both remote commands (the preflight probe and the `orx up` launch) are now built by a single `remote_orx_cmd()` helper that produces:

```sh
sh -c 'export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$HOME/.local/bin:$PATH"; <command>'
```

Three things this gets right, so it works on **any** box you can `ssh` into — not just RunPod:

1. **PATH.** Prepends the installer's target dir so a non-interactive shell (which skips `~/.bashrc`/`~/.profile`) still finds `orx`. `$HOME`/`$CARGO_HOME` are left literal for the remote shell to expand, so it adapts to whatever the remote user is (`root`, `runpod`, …).

2. **POSIX shell, not the login shell.** ssh runs the command under the remote user's **login** shell, which can be csh/tcsh/fish — none of which understand `export VAR=val`. On those boxes the old `export PATH=...; cmd` was a *syntax error*, and it got misreported as "unreachable" / "not installed." Handing the POSIX body to `sh -c` (single-quoted via the backend's `sh_quote`) means `/bin/sh` interprets it whatever the login shell is. This mirrors how the job backends run their payload through an explicit shell rather than the bare login shell.

3. **Relocated `CARGO_HOME`.** dist-workspace.toml sets `install-path = "CARGO_HOME"`, so the installer honors `$CARGO_HOME`. Searching `${CARGO_HOME:-$HOME/.cargo}/bin` (instead of a hardcoded `~/.cargo/bin`) means a box that relocates cargo still resolves `orx`.

The preflight outcome is also split for honesty: `ORX_MISSING` → a clear "not installed" with the install command; ssh-exited-0-but-neither-marker → a distinct message that echoes what we actually saw, instead of lumping it into "not installed."

## Verification

Ran the exact command string `remote_orx_cmd` emits through real shells and confirmed each case:

| Scenario | Result |
| --- | --- |
| `orx` only in `~/.cargo/bin`, stripped `PATH`, under `/bin/sh` and `bash` | `ORX_OK` |
| relocated `CARGO_HOME` (`orx` only in `$CARGO_HOME/bin`) | `ORX_OK` |
| **tcsh** login shell (old `export …` form would be a syntax error) | `ORX_OK` |
| `orx` genuinely absent | `ORX_MISSING` → clean "not installed" |

## Tests

`remote_orx_cmd_forces_posix_sh_and_keeps_expansions_literal` (runs under `sh -c`, both dirs on PATH, `$…`/`${…}` stay literal for the remote to expand), `preflight_probe_is_also_wrapped` (the probe goes through the same wrapper — else a `~/.cargo/bin`-only box false-negatives), and `forward_and_remote_cmd_use_the_same_port` (launch carries the port behind the prelude). `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --locked` all green (147 tests).

Bumps 0.1.58 → **0.1.59**.
