### PR TITLE
Plan gate: read-only git verbs, pipelines into pure consumers, 2>&1

### DIFF
--- a/src/local/harness/plan_gate.rs
+++ b/src/local/harness/plan_gate.rs
@@ -1,29 +1,31 @@
-//! Claude plan-mode gate for `orx` shell commands.
+//! Claude plan-mode gate for read-only shell commands.
 //!
 //! Claude Code's `--permission-mode plan` auto-approves its built-in read-only
-//! tools (file reads, `grep`, `git log`, …) but treats an arbitrary `Bash(orx …)`
-//! as a write it must gate — and headless `--print` can't answer that prompt, so
-//! the call just fails. That breaks planning, because the agent plans by
+//! tools (file reads, `grep`, …) but treats an arbitrary `Bash(orx …)` as a
+//! write it must gate — and headless `--print` can't answer that prompt, so the
+//! call just fails. That breaks planning, because the agent plans by
 //! *inspecting* prior runs, logs, and the evidence DB via read-only `orx`
-//! subcommands.
+//! subcommands — and by reading experiment code that often lives only on git
+//! branches (`git show <ref>:<file>`, `git ls-tree`), typically piped through
+//! `head`/`grep` with a `2>&1`.
 //!
 //! The fix is a `PreToolUse` hook (wired only in plan mode — see
 //! `claude::write_plan_settings`) that runs `orx plan-gate`: it reads the hook's
-//! JSON off stdin, and if the tool is a Bash call invoking a *read-only* `orx`
-//! subcommand it prints an `"allow"` decision so the command runs. For anything
+//! JSON off stdin, and if the tool is a Bash call invoking a *read-only*
+//! command it prints an `"allow"` decision so the command runs. For anything
 //! else — a write/launch `orx` verb (`exp run`, `instance`, `create-*`, …), a
-//! non-`orx` command, or an unparseable one — it stays silent (exit 0, no
-//! stdout), so plan mode's normal gating applies and launches remain blocked
-//! until the user approves the plan.
+//! git write, an unknown program, or an unparseable command — it stays silent
+//! (exit 0, no stdout), so plan mode's normal gating applies and launches
+//! remain blocked until the user approves the plan.
 //!
 //! Classification is deliberately *allowlist-only*: an unknown or ambiguous
-//! subcommand is treated as NOT read-only (gated), so a newly added write verb
+//! command is treated as NOT read-only (gated), so a newly added write verb
 //! can never leak through by default. The flip side is a maintenance
-//! obligation: the allowlist is a hand-kept mirror of the read-only `orx` verbs
-//! in `main.rs`'s `Command` enum. A newly added *read* verb stays gated until
-//! it's added here — `readonly_verbs_are_real_commands` guards against a rename
-//! silently un-gating nothing, but adding a new read verb is a manual step
-//! (there's a pointer comment on the `Command` enum).
+//! obligation: the `orx` allowlist is a hand-kept mirror of the read-only
+//! verbs in `main.rs`'s `Command` enum. A newly added *read* verb stays gated
+//! until it's added here — `readonly_verbs_are_real_commands` guards against a
+//! rename silently un-gating nothing, but adding a new read verb is a manual
+//! step (there's a pointer comment on the `Command` enum).
 
 use serde_json::{json, Value};
 
@@ -50,16 +52,54 @@ const WHOLE_VERB_READS: &[&str] = &[
     "version",
 ];
 
-/// Shell no-ops allowed as glue between read-only `orx` segments in a batch —
+/// Shell no-ops allowed as glue between read-only segments in a batch —
 /// separators and labels the planning agent prints, e.g. `echo ====`. They take
 /// arbitrary args but can't have a side effect here (redirection/substitution
 /// are rejected before we get this far), so a program-name match is enough.
 const READONLY_GLUE: &[&str] = &["echo", "true", ":"];
 
-/// Decide whether a `PreToolUse` hook payload describes a read-only `orx`
-/// invocation that plan mode should let through. Returns the JSON to print on
-/// stdout (an `allow` decision) or `None` to stay silent and defer to plan
-/// mode's default gating.
+/// Programs a read-only producer may pipe into: pure stream consumers that
+/// never write without a redirect (and redirects are rejected per-token).
+/// Deliberately excluded: `tee` (writes files), `xargs` (spawns commands),
+/// `sed`/`awk` (in-place edits, `w`/`system()` escape hatches).
+const PURE_CONSUMERS: &[&str] = &[
+    "head", "tail", "grep", "egrep", "fgrep", "wc", "cat", "sort", "uniq", "cut", "tr", "nl",
+    "column",
+];
+
+/// `git` verbs that are read-only in every arg form, subject to the argument
+/// guards in [`is_readonly_git`] (`--output` writes a file from `log`/`show`/
+/// `diff`; `-O`/`--open-files-in-pager` executes a pager from `grep`).
+/// Verbs with mixed read/write forms (`branch`, `tag`, `stash`, `remote`,
+/// `worktree`, `reflog`) are handled conditionally; `config` is excluded
+/// entirely (its read/write grammar is too fiddly to classify safely).
+const GIT_WHOLE_VERB_READS: &[&str] = &[
+    "status",
+    "log",
+    "show",
+    "diff",
+    "grep",
+    "ls-tree",
+    "ls-files",
+    "rev-parse",
+    "rev-list",
+    "cat-file",
+    "blame",
+    "shortlog",
+    "describe",
+    "name-rev",
+    "merge-base",
+    "show-ref",
+    "for-each-ref",
+    "count-objects",
+    "diff-tree",
+    "whatchanged",
+];
+
+/// Decide whether a `PreToolUse` hook payload describes a read-only command
+/// that plan mode should let through. Returns the JSON to print on stdout (an
+/// `allow` decision) or `None` to stay silent and defer to plan mode's default
+/// gating.
 ///
 /// The payload shape is Claude Code's hook contract: `tool_name` names the tool
 /// and `tool_input.command` carries the Bash command line.
@@ -72,7 +112,7 @@ pub fn decide(payload: &Value) -> Option<Value> {
         .pointer("/tool_input/command")
         .and_then(Value::as_str)?;
 
-    if !is_readonly_orx(command) {
+    if !command_is_readonly(command) {
         return None;
     }
 
@@ -81,88 +121,142 @@ pub fn decide(payload: &Value) -> Option<Value> {
             "hookEventName": "PreToolUse",
             "permissionDecision": "allow",
             "permissionDecisionReason":
-                "read-only orx inspection is allowed during plan mode",
+                "read-only inspection is allowed during plan mode",
         }
     }))
 }
 
-/// True iff `command` is a read-only `orx` inspection that plan mode may run.
+/// True iff `command` is a read-only inspection that plan mode may run.
 ///
-/// A single `orx <read-verb>` is allowed. So is a *sequence* of them joined by
-/// `;` or `&&` and interleaved with harmless glue (`echo`, `true`, `:`) — the
-/// batching the planning agent uses to fetch several nodes in one call, e.g.
-/// `orx exp desc A; echo ====; orx exp desc B`. The whole line is allowed only
-/// if **every** segment is independently read-only; one unknown or write
-/// segment gates the entire command (allowlist-only — see [`is_readonly_orx`]'s
-/// caller). This keeps the security property: a read-only prefix can never
-/// smuggle a write through as a later segment.
+/// A single read-only invocation (`orx <read-verb>`, `git <read-verb>`, a pure
+/// consumer, or glue) is allowed. So is a *sequence* of them joined by `;` or
+/// `&&` — the batching the planning agent uses to fetch several nodes in one
+/// call, e.g. `orx exp desc A; echo ====; orx exp desc B` — and a *pipeline*
+/// whose first stage is a read-only producer and every later stage a pure
+/// consumer, e.g. `git log --oneline | head -20` or `orx runs 2>&1 | grep err`.
+/// The whole line is allowed only if **every** segment and **every** pipeline
+/// stage independently passes; one unknown or write stage gates the entire
+/// command (allowlist-only). This keeps the security property: a read-only
+/// prefix can never smuggle a write through as a later segment or stage.
 ///
-/// Only `;` and `&&` are recognized as separators. Pipes (`|`), redirection
-/// (`>`/`<`), backticks, `$(…)`, background `&`, and newlines are rejected
-/// outright: they can capture, redirect, or spawn work outside the per-segment
-/// check, so they never appear in legitimate read-only batching.
+/// Only `;` and `&&` are recognized as separators and `|` as a pipe.
+/// Redirection (`>`/`<`), backticks, `$(…)`, background `&`, and newlines are
+/// rejected — with one carve-out: a standalone `2>&1` token (stderr-merge into
+/// the pipe) is dropped before the check, since agents habitually write
+/// `cmd 2>&1 | head` and the merge itself has no side effect.
 ///
-/// The split is not quote-aware, so a `;`/`&&` *inside* a quoted argument (e.g.
-/// `orx query "select … where a && b"`) is still treated as a separator and
-/// gates the line. This over-gates rather than under-allows — it fails safe —
-/// so such a command just falls back to plan mode's normal gate; run it outside
-/// a batch to have it auto-allowed.
-fn is_readonly_orx(command: &str) -> bool {
+/// The split is not quote-aware, so a separator *inside* a quoted argument
+/// (e.g. `orx query "select … where a && b"`) is still treated as a separator
+/// and gates the line. This over-gates rather than under-allows — it fails
+/// safe — so such a command just falls back to plan mode's normal gate; run it
+/// outside a batch to have it auto-allowed.
+///
+/// `pub` because the MCP permission bridge reuses the same classifier for its
+/// auto-allow policy.
+pub fn command_is_readonly(command: &str) -> bool {
     let command = command.trim();
 
-    // Reject metacharacters that a per-segment scan can't reason about. `&` is
-    // excluded here because it's part of the `&&` separator; a stray *single*
-    // `&` (background execution) is caught per-segment below, after the split.
-    if command.contains(['|', '`', '>', '<', '\n']) || command.contains("$(") {
+    // Metacharacters no per-stage scan can make safe: command substitution can
+    // run anything even inside an argument, `<` reads arbitrary files into a
+    // command we didn't classify, and multi-line scripts defeat the splitter.
+    if command.contains(['`', '<', '\n']) || command.contains("$(") {
         return false;
     }
 
     // Split on the two sequencing separators. Splitting on `&&` first, then `;`,
-    // yields the individual commands; each must stand on its own as read-only.
-    // An empty segment (leading/trailing/doubled separator) is treated as a
-    // no-op and allowed, matching the shell's own tolerance for `orx runs;`.
+    // yields the individual segments; each must stand on its own as read-only.
     command
         .split("&&")
         .flat_map(|part| part.split(';'))
-        .all(is_readonly_orx_segment)
+        .all(is_readonly_segment)
 }
 
-/// True iff a single command segment (no `;`/`&&` separators) is either a
-/// read-only `orx` invocation or harmless glue. Empty/whitespace segments and
-/// the shell no-ops `echo`/`true`/`:` are allowed so they can punctuate a batch;
-/// everything else must be an `orx` read verb.
-fn is_readonly_orx_segment(command: &str) -> bool {
-    let command = command.trim();
-
-    // Empty segment (from a leading/trailing/doubled separator): a shell no-op.
-    if command.is_empty() {
+/// True iff a single command segment (no `;`/`&&` separators) is a read-only
+/// pipeline: a read-only producer optionally piped through pure consumers.
+/// Empty/whitespace segments (from a leading/trailing/doubled separator) are
+/// shell no-ops and allowed, matching the shell's own tolerance for `orx runs;`.
+fn is_readonly_segment(segment: &str) -> bool {
+    let segment = segment.trim();
+    if segment.is_empty() {
         return true;
     }
 
-    // `split("&&")` consumed every `&&`, so any `&` reaching a segment cannot be
-    // part of a separator: it's background execution (`orx runs &`) or a
-    // malformed `&&&` — reject it outright.
-    if command.contains('&') {
+    let mut stages = segment.split('|');
+    // `split` always yields at least one item.
+    let first = stages.next().unwrap_or_default();
+    if !is_readonly_producer(first) {
         return false;
     }
+    // Every later stage must be a pure consumer. An empty stage means `||`,
+    // `| |`, or a trailing pipe — never legitimate read-only batching.
+    stages.all(|stage| match stage_tokens(stage) {
+        Some(tokens) if !tokens.is_empty() => is_pure_consumer(&tokens),
+        _ => false,
+    })
+}
 
-    // Tokenize on whitespace; the wrapper never quotes the verb itself, so a
-    // simple split is enough to read the leading `orx <verb> [<sub>]`.
-    let mut tokens = command.split_whitespace();
-
-    // The program is the first token. `READONLY_GLUE` commands are harmless
-    // punctuation and take arbitrary args, so a program-name match is enough.
-    // Otherwise it must be the `orx` binary (bare or a path ending in `/orx`) —
-    // reject a leading env-assignment or any other program.
-    match tokens.next() {
-        Some(prog) if READONLY_GLUE.contains(&prog) => return true,
-        Some(bin) if bin == "orx" || bin.ends_with("/orx") => {}
-        _ => return false,
+/// Tokenize one pipeline stage. Drops standalone `2>&1` tokens (a harmless
+/// stderr-merge), then rejects the stage (`None`) if any remaining token still
+/// carries `>` or `&` — the segment split consumed every `&&`, so a surviving
+/// `&` is background execution or a malformed `&&&`, and any `>` is
+/// redirection.
+fn stage_tokens(stage: &str) -> Option<Vec<&str>> {
+    let mut tokens = Vec::new();
+    for token in stage.split_whitespace() {
+        if token == "2>&1" {
+            continue;
+        }
+        if token.contains(['>', '&']) {
+            return None;
+        }
+        tokens.push(token);
     }
+    Some(tokens)
+}
+
+/// True iff a pipeline's first stage is read-only: glue, a read-only `orx`
+/// invocation, a read-only `git` invocation, or a pure consumer (so `wc -l f`
+/// or `head -50 f` stand alone too).
+fn is_readonly_producer(stage: &str) -> bool {
+    let Some(tokens) = stage_tokens(stage) else {
+        return false;
+    };
+    // The program is the first token. Reject a leading env-assignment or any
+    // unlisted program.
+    let Some(&program) = tokens.first() else {
+        return false; // empty first stage: `| head` — not a real pipeline
+    };
+    if READONLY_GLUE.contains(&program) {
+        return true;
+    }
+    if program == "orx" || program.ends_with("/orx") {
+        return is_readonly_orx(&tokens, stage);
+    }
+    if program == "git" || program.ends_with("/git") {
+        return is_readonly_git(&tokens);
+    }
+    is_pure_consumer(&tokens)
+}
+
+/// True iff the stage runs one of the [`PURE_CONSUMERS`]. Args are arbitrary:
+/// redirection/substitution/background were already rejected per-token, and
+/// none of these programs writes without a redirect.
+fn is_pure_consumer(tokens: &[&str]) -> bool {
+    match tokens.first() {
+        Some(program) => PURE_CONSUMERS.contains(program),
+        None => false,
+    }
+}
+
+/// True iff a tokenized `orx …` invocation is read-only. `stage` is the raw
+/// stage text, kept for the `--set`/`--stdin` substring scan (those flags only
+/// ever appear on the write forms of `exp desc`/`exp cmd`, so a whole-stage
+/// scan is a sound discriminator).
+fn is_readonly_orx(tokens: &[&str], stage: &str) -> bool {
+    let mut rest = tokens.iter().skip(1).copied();
 
     // First non-flag token after the binary is the top-level verb.
-    let verb = subcommand(&mut tokens);
-    let Some(verb) = verb else {
+    let Some(verb) = subcommand(&mut rest) else {
         // Bare `orx` (or only flags): prints usage — harmless and read-only.
         return true;
     };
@@ -174,23 +268,136 @@ fn is_readonly_orx_segment(command: &str) -> bool {
 
     match verb {
         // Verbs with a write subcommand: allow only the read-only subcommand(s).
-        // The next non-flag token is the subcommand.
-        "project" => matches!(subcommand(&mut tokens), Some("view")),
-        "exp" => match subcommand(&mut tokens) {
+        "project" => matches!(subcommand(&mut rest), Some("view")),
+        "exp" => match subcommand(&mut rest) {
             // Pure reads.
             Some("status" | "wait") => true,
-            // `desc`/`cmd` view the node's notes / run command, but *write* them
-            // with `--set`/`--stdin`. Allow only the read (view) form. The flags
-            // only ever appear on the write form, so a whole-command scan is a
-            // sound discriminator (and `desc --set` etc. are the only writers).
-            Some("desc" | "cmd") => !command.contains("--set") && !command.contains("--stdin"),
+            // `desc`/`cmd` view the node's notes / run command, but *write*
+            // them with `--set`/`--stdin`. Allow only the read (view) form.
+            Some("desc" | "cmd") => !stage.contains("--set") && !stage.contains("--stdin"),
             _ => false,
         },
-        "report" => matches!(subcommand(&mut tokens), Some("list" | "show" | "download")),
+        "report" => matches!(subcommand(&mut rest), Some("list" | "show" | "download")),
 
         // Everything else — create-*, instance, login/logout, install-skills,
         // update, serve, supervise, up, and any unrecognized future verb — is
         // gated. Allowlist-only: unknown ⇒ not read-only.
+        _ => false,
+    }
+}
+
+/// True iff a tokenized `git …` invocation is read-only. Allowlist-only, with
+/// argument guards on the escape hatches a read verb can carry.
+fn is_readonly_git(tokens: &[&str]) -> bool {
+    // Global flags between `git` and the verb: only the harmless pager/cwd
+    // ones. Anything else — `-c key=val`, `--exec-path`, `--git-dir`,
+    // `--config-env`, … — can change what git *executes* (pager, alias, and
+    // hook overrides are arbitrary-command vectors), so it gates.
+    let mut i = 1;
+    while i < tokens.len() && tokens[i].starts_with('-') {
+        match tokens[i] {
+            "-P" | "--no-pager" => i += 1,
+            "-C" => i += 2, // consumes its <path> argument
+            _ => return false,
+        }
+    }
+    let Some(&verb) = tokens.get(i) else {
+        // Bare `git` prints usage, but there's no reason to batch it — gate.
+        return false;
+    };
+    let args = &tokens[i + 1..];
+
+    if GIT_WHOLE_VERB_READS.contains(&verb) {
+        // The write escapes a read verb can carry: `--output[=<file>]` writes a
+        // file from log/show/diff, and grep's `-O`/`--open-files-in-pager`
+        // executes an arbitrary pager.
+        return !args
+            .iter()
+            .any(|a| a.starts_with("--output") || a.starts_with("-O") || a.starts_with("--open-"));
+    }
+
+    // A positional arg on `branch`/`tag` creates unless a list-query flag makes
+    // positionals mean patterns; the write flags always gate.
+    let has_positional = |args: &[&str]| args.iter().any(|a| !a.starts_with('-'));
+    let has_flag = |args: &[&str], flags: &[&str]| {
+        args.iter().any(|a| {
+            flags
+                .iter()
+                .any(|f| a == f || a.starts_with(&format!("{f}=")))
+        })
+    };
+
+    match verb {
+        "branch" => {
+            const WRITES: &[&str] = &[
+                "-d",
+                "-D",
+                "-m",
+                "-M",
+                "-c",
+                "-C",
+                "-f",
+                "-u",
+                "--delete",
+                "--move",
+                "--copy",
+                "--force",
+                "--edit-description",
+                "--set-upstream-to",
+                "--unset-upstream",
+                "--create-reflog",
+                "--track",
+                "--no-track",
+            ];
+            const LISTS: &[&str] = &[
+                "--list",
+                "--show-current",
+                "--contains",
+                "--no-contains",
+                "--merged",
+                "--no-merged",
+                "--points-at",
+            ];
+            !has_flag(args, WRITES) && (!has_positional(args) || has_flag(args, LISTS))
+        }
+        "tag" => {
+            const WRITES: &[&str] = &[
+                "-a",
+                "-s",
+                "-u",
+                "-F",
+                "-m",
+                "-d",
+                "-f",
+                "-e",
+                "--annotate",
+                "--sign",
+                "--file",
+                "--message",
+                "--delete",
+                "--force",
+                "--edit",
+            ];
+            const LISTS: &[&str] = &[
+                "-l",
+                "--list",
+                "--contains",
+                "--no-contains",
+                "--merged",
+                "--no-merged",
+                "--points-at",
+            ];
+            !has_flag(args, WRITES) && (!has_positional(args) || has_flag(args, LISTS))
+        }
+        "stash" => matches!(subcommand(&mut args.iter().copied()), Some("list" | "show")),
+        "remote" => matches!(
+            subcommand(&mut args.iter().copied()),
+            None | Some("show") | Some("get-url")
+        ),
+        "worktree" => matches!(subcommand(&mut args.iter().copied()), Some("list")),
+        "reflog" => matches!(subcommand(&mut args.iter().copied()), None | Some("show")),
+
+        // Everything else — commit, push, checkout, fetch, config, … — gates.
         _ => false,
     }
 }
@@ -303,7 +510,7 @@ mod tests {
         assert!(!allowed("orx runs; orx exp run e-1")); // write segment
         assert!(!allowed("orx runs && rm -rf /")); // non-orx segment
         assert!(!allowed("orx runs; echo hi; orx create-project --repo x/y")); // write in a batch
-        assert!(!allowed("orx runs | tee /etc/passwd")); // pipe
+        assert!(!allowed("orx runs | tee /etc/passwd")); // pipe into a writer
         assert!(!allowed("orx logs r-1 > /tmp/x")); // redirection
         assert!(!allowed("orx query \"$(rm -rf /)\"")); // command substitution
         assert!(!allowed("orx runs `whoami`")); // backtick substitution
@@ -329,6 +536,115 @@ mod tests {
         // A read/view form batched with its own write form still gates: the
         // `--set` segment is a write.
         assert!(!allowed("orx exp desc e-1; orx exp desc e-1 --set \"x\""));
+    }
+
+    #[test]
+    fn readonly_pipelines_are_allowed() {
+        // The other pattern plan mode kept failing on: reads piped through pure
+        // consumers, with the customary stderr-merge.
+        assert!(allowed("orx runs 2>&1 | head -50"));
+        assert!(allowed("orx logs r-1 2>&1 | grep -i error | tail -5"));
+        assert!(allowed("orx runs r-1 2>&1"));
+        assert!(allowed("git log --oneline | head -20"));
+        assert!(allowed("git ls-tree -r HEAD | grep -i py"));
+        assert!(allowed("git show origin/b:mem2gen/orx_run.py | head -100"));
+        // Consumers stand alone and pipe among themselves.
+        assert!(allowed("wc -l README.md"));
+        assert!(allowed("cat notes.md | grep TODO | sort | uniq"));
+        // Pipelines and sequences compose.
+        assert!(allowed("orx runs | head -5; echo ok && git status"));
+        // No-space pipes parse the same way the shell parses them.
+        assert!(allowed("orx runs 2>&1|head -5"));
+    }
+
+    #[test]
+    fn nonreadonly_pipelines_are_gated() {
+        assert!(!allowed("orx runs | xargs rm")); // consumer that spawns commands
+        assert!(!allowed("orx runs | sed -i s/x/y/ f")); // sed excluded (writes)
+        assert!(!allowed("orx runs | awk '{system(\"id\")}'")); // awk excluded
+        assert!(!allowed("orx runs | head > /tmp/x")); // redirect in a stage
+        assert!(!allowed("orx runs || rm -rf /")); // `||` is not a pipe
+        assert!(!allowed("orx runs |")); // trailing pipe
+        assert!(!allowed("| head")); // no producer
+        assert!(!allowed("cargo metadata | head")); // unknown producer
+        assert!(!allowed("head -1 f | orx runs")); // orx is not a consumer
+    }
+
+    #[test]
+    fn git_reads_are_allowed() {
+        for c in [
+            "git status",
+            "git log --oneline -20",
+            "git show HEAD~1:src/main.rs",
+            "git diff --stat main..feature",
+            "git grep -n TODO",
+            "git ls-tree -r --name-only origin/main",
+            "git ls-files",
+            "git rev-parse HEAD",
+            "git rev-list --count HEAD",
+            "git cat-file -p HEAD:README.md",
+            "git blame src/main.rs",
+            "git describe --tags",
+            "git merge-base main feature",
+            "git -P log -5",
+            "git --no-pager diff",
+            "git -C /some/repo log --oneline",
+            "git branch -a",
+            "git branch --list 'daniel/*'",
+            "git branch --show-current",
+            "git tag",
+            "git tag -l 'v*'",
+            "git stash list",
+            "git stash show",
+            "git remote -v",
+            "git remote show origin",
+            "git remote get-url origin",
+            "git worktree list",
+            "git reflog",
+            "/usr/bin/git status",
+        ] {
+            assert!(allowed(c), "should allow: {c}");
+        }
+    }
+
+    #[test]
+    fn git_writes_are_gated() {
+        for c in [
+            "git push",
+            "git commit -m x",
+            "git checkout main",
+            "git switch -c feat",
+            "git add .",
+            "git reset --hard HEAD~1",
+            "git fetch origin",
+            "git pull",
+            "git merge feature",
+            "git rebase main",
+            "git branch foo",                           // creates
+            "git branch -d foo",                        // deletes
+            "git branch -m old new",                    // renames
+            "git branch --set-upstream-to=origin/main", // config write
+            "git tag v1.0",                             // creates
+            "git tag -d v1.0",                          // deletes
+            "git tag -a v1 -m msg",                     // creates annotated
+            "git stash",                                // bare stash = push
+            "git stash pop",
+            "git remote add origin url",
+            "git remote set-url origin url",
+            "git worktree add /tmp/wt",
+            "git worktree remove /tmp/wt",
+            "git reflog expire --all",
+            "git config user.name x", // excluded wholesale
+            "git",                    // bare usage: no reason to allow
+            // Escape hatches on otherwise-read verbs.
+            "git -c core.pager='!id' log", // -c injects executable config
+            "git --git-dir=/x/.git log",   // repo redirection
+            "git log --output=/tmp/exfil", // writes a file
+            "git grep -Oless TODO",        // executes a pager
+            "git grep --open-files-in-pager TODO",
+        ] {
+            assert!(!allowed(c), "should gate: {c}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What

Extends the plan-mode Bash gate so the inspection patterns planning agents actually use stop hard-failing:

- **Pipelines**: `orx runs <id> 2>&1 | head -50`, `git log --oneline | head -20` — segments now split into pipe stages; stage 0 must be a read-only producer, later stages must be pure consumers (`head tail grep wc cat sort uniq cut tr nl column`; `tee`/`xargs`/`sed`/`awk` deliberately excluded).
- **`2>&1`**: standalone stderr-merge tokens are dropped before the metachar check; any other token carrying `>`/`&` still gates.
- **Read-only git**: experiment code often lives only on `orx/*` branches, so `git show <ref>:<file>`, `git ls-tree`, `log`, `diff`, `blame`, etc. are now allowlisted — with escape-hatch guards (`--output`, `-O`/`--open-files-in-pager`, `-c` config injection rejected; `branch`/`tag` only in list-query forms; `config` excluded wholesale).
- `command_is_readonly()` exported for reuse by the upcoming MCP permission bridge (next PR).

Fail-safe property preserved: unknown programs/verbs/forms gate the entire command; one bad stage gates the whole line.

## Why

Observed in a real plan-mode session: every `git show branch:file`, `git ls-tree`, and `orx … 2>&1 | head` was denied with nobody able to approve, leaving the planning agent unable to read the code it was planning against.

## Tests

All existing cases kept verbatim; new tables for allowed pipelines/git reads and gated pipelines/git writes (30+ cases). `cargo fmt --check` / `clippy -D warnings` / `cargo test --locked` all green (152 passed).