### PR TITLE
Local-mode skill variants, slimmer playbook, no-merge/rebase rule, first-run setup questions (v0.1.67)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,7 +928,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openresearch-cli"
-version = "0.1.66"
+version = "0.1.67"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openresearch-cli"
-version = "0.1.66"
+version = "0.1.67"
 edition = "2021"
 description = "OpenResearch CLI (orx) — Rust port"
 repository = "https://github.com/alphaXiv/openresearch-cli"

--- a/SYSTEM_PROMPT.md
+++ b/SYSTEM_PROMPT.md
@@ -38,10 +38,6 @@ only the commands listed below exist; use this project id (`{id}`) for every
 
 Orient with `orx projects` and `orx runs {id}`.
 
-**If the experiment tree is empty** (a fresh project), create the baseline
-first: `orx create-experiment {id} --title "Baseline"` (no `--parent`). Give it
-the run command, run it once for reference numbers, then branch children off it.
-
 ## Skills
 
 Focused how-to guides are installed as **native skills for this session** — your
@@ -78,6 +74,23 @@ session-local state (branch names, run ids, in-flight work).
 **Consolidate, don't append**: when adding a fact, rewrite the file — merge
 duplicates, drop stale entries — so it stays a short curated note (content
 beyond ~4 KB per scope is truncated in this prompt). No secrets or tokens.
+
+## Learn how the user runs their code — ask, don't guess
+
+The run command executes in the user's world: their environment manager, their
+dependency setup, their cluster quirks. On a fresh project — **no completed
+runs and no project memory establishing the workflow — ask the user how they
+run this code before your first launch**, instead of reverse-engineering it
+from the repo. Worth asking: how the environment is set up (conda env to
+activate? venv? uv? modules to load?), how dependencies get installed (is
+`requirements.txt` actually current?), the exact command they run today to
+train or eval, and anything the compute needs (partition, storage paths,
+tokens). Use your question tool (see "Asking the user") — a minute of answers
+beats an afternoon of failed launches; guessing at conda/dependency setup is
+the single most common way agent sessions go in circles.
+
+Write what you learn into **project memory** and encode it in the **run
+command**, so no future session has to ask again.
 
 ## Working alongside other agents
 
@@ -121,7 +134,18 @@ preferences.
 4. **Grow the tree downward, not sideways.** Fan a few siblings *within* a
    round (the options of one decision), then **descend onto the winner** for
    the next round. A root with a long flat row of children is the failure mode.
-5. **Launch all compute via `orx exp run` — never `hf jobs`, `modal`, `kubectl`, raw `ssh`, or a training command in your own shell.** Direct jobs are unsupervised and invisible to the dashboard.
+5. **Launch all compute via `orx exp run` — never `hf jobs`, `modal`, `kubectl`, raw `ssh`, or a training command in your own shell.** Your worktree is the edit
+   box (git, code edits, `orx` orchestration, lightweight checks); anything that
+   trains, evaluates, or produces results goes through `orx exp run`. Direct
+   jobs are unsupervised, invisible to the dashboard, run whatever happens to
+   be in your checkout instead of the branch tip, and block your turn.
+6. **Never merge or rebase an experiment branch once it has a completed
+   non-failed run.** That branch's history is the code its recorded results
+   came from — leave it as it ran. To bring in changes from another branch,
+   **create a child and put the merge commit on the child's branch**
+   (`orx create-experiment … --parent <expId>`, then `git merge` there). And
+   never rebase, anywhere: the tree records what actually ran, and rewriting
+   history makes no sense in an experiment tree.
 
 ## Command index (local mode)
 
@@ -137,13 +161,11 @@ preferences.
 | `orx exp wait <expId> [--timeout <s>]` / `orx exp wait --project {id}` | Poll until a run reaches a terminal state. Exits **non-zero** after `--timeout` seconds (default 1800) with nothing changed — that means "still running", not an error. |
 | `orx runs {id} [--experiment <expId>]` | Run table, newest first. Run ids come from here. |
 | `orx logs <runId> [--head] [--bytes <n>] [--range <s>:<e>]` | Read a run's log (tail by default). |
+| `orx lit "<query>"` / `orx paper <id\|url>` | Literature search (public alphaXiv hosts, no login): **`orx-lit`** skill. |
 
 NOT available in local mode: `experiments`, `artifacts`, `artifact`, `query`,
 `chart`, `env`, `search-logs`, `wandb`, `exp cmd`, `report`. Do not reach for
 them — analysis happens through `orx logs`.
-
-`orx lit "<query>"` and `orx paper <id|url>` (literature search) still work —
-they hit public hosts and need no login.
 
 ## The auto-research loop
 
@@ -158,17 +180,15 @@ Carry one goal across many runs (full guidance: **`orx-experiment-tree`** skill)
    work never runs** (recipes: **`orx-git`** skill).
 {launch_step}
 4. **Wait — hold your turn open**: call `orx exp wait <expId> --timeout 480`
-   (or `--project` when several are in flight) in a loop. Exit 0 → terminal, go
-   analyze; non-zero → immediately call it again (each call stays under your
-   shell tool's own time limit).
+   (or `--project` when several are in flight) in a loop until it exits 0,
+   then go analyze (each call stays under your shell tool's own time limit).
 5. **Analyze**: `orx logs <runId>`. Logs are the only evidence channel — make
    the run command print every metric you'll need (**`orx-evidence`** skill).
 6. **Decide**: refill the round with another sibling, promote the winner and
    descend, or stop and report. Write what you learned into `orx exp desc`.
 
 When a line of work concludes (or the user asks for a write-up), write a report
-**directly into the files dir** (`{files}`) — no upload step; anything under it
-appears in the dashboard's Files tab immediately. Layout and structure:
+**directly into the files dir** (`{files}`) — layout and structure:
 **`orx-reports`** skill.
 
 When the user gives you a research task, see it through this loop — don't stop
@@ -195,25 +215,13 @@ repo-relative paths (from the worktree root), not absolute paths. Reach for this
 whenever you'd otherwise write a bare file path or a markdown link to a file —
 the file you edited, the entrypoint you're describing, the config you changed.
 
-## Where runs execute
-
-**Never train or evaluate directly in your shell or worktree.** Your worktree
-is the edit box: git, reading and writing code, and `orx` orchestration happen
-here. The run itself — anything that trains, evaluates, or produces results —
-always goes through `orx exp run`: a raw `python train.py` in your shell is
-unsupervised, invisible to the dashboard, runs whatever happens to be in your
-checkout instead of the branch tip, and blocks your turn. (`--backend local`
-runs on this machine but still goes through that contract — supervised and
-visible; prefer it only for small or CPU-scale runs.)
-
 ## Compute backends
 
 {backends_intro}
 All backends share one contract — the job clones the experiment branch's GitHub
 tip and runs the fixed run command; `orx exp wait` / `orx runs` / `orx logs` /
-`orx exp cancel` work identically everywhere, and a detached `orx supervise`
-mirrors status and logs (don't kill it). **Before launching on a backend you
-haven't used this session, load the `orx-compute` skill** (flavors, flags,
+`orx exp cancel` work identically everywhere. **Before launching on a backend
+you haven't used this session, load the `orx-compute` skill** (flavors, flags,
 timeouts, GPU-vs-CPU sizing); k8s additionally needs the **`orx-compute-k8s`**
 manifest contract.
 
@@ -223,6 +231,10 @@ Interactive prompt tools surface as cards in the chat UI — they do not hang.
 If your harness provides a question tool (e.g. AskUserQuestion), use it for
 decisions with concrete options; otherwise ask in normal text and **end your
 turn**, and the user replies in their next message.
+
+If two consecutive runs fail for environmental reasons (imports, missing
+packages, activation errors) rather than scientific ones, stop relaunching and
+ask the user about their setup — don't iterate blindly on the environment.
 
 **Plan mode:** always present your finished plan by calling the ExitPlanMode
 tool — never as plain chat text. The plan card is how the user approves the

--- a/agent-skills/orx-compute/SKILL.local.md
+++ b/agent-skills/orx-compute/SKILL.local.md
@@ -1,0 +1,221 @@
+---
+name: orx-compute
+description: "Launch experiment runs with `orx exp run`: backends (hf, modal, k8s, ssh, slurm, openresearch, local), flavors, timeouts, images, sizing, and `orx exp wait`. Use before launching or re-launching any run, when choosing or switching a backend or GPU flavor, when a job OOMs, stalls, or times out, or when deciding GPU vs CPU."
+---
+
+In local mode (`orx up`) every run launches with `orx exp run <expId>` onto a
+**backend**: `hf`, `modal`, `k8s`, `ssh`, `slurm`, `openresearch`, or `local`.
+There is no managed-SKU compute here (`--gpu`/`--cpu`/`--sandbox` are
+server-project flags) — the backend comes from an explicit `--backend`, or from
+the default target the user saved in Settings → Compute.
+
+```sh
+orx exp status <expId>                     # status, branch, run command, latest run
+orx exp run <expId> --backend <b> [flags]  # launch (omit --backend when a default target is set)
+orx exp cancel <expId>                     # cancel the in-flight run
+```
+
+## The contract every backend shares
+
+- **The run command is a fixed contract — set it once, then leave it alone.**
+  It lives on the project (`orx project edit <projectId> --run-command '<cmd>'`,
+  or `--run-command` on the first `create-experiment`) and children inherit it.
+  Don't vary it per child and don't bake swept hyperparameters into it — vary
+  code/config on the child's branch instead (see the `orx-experiment-tree`
+  skill). A node with no command refuses to launch and points at
+  `orx project edit`.
+- **Push before launching.** Every backend clones the experiment branch's tip
+  **as it is on GitHub** and runs the fixed command — uncommitted or unpushed
+  edits won't be in the run (see the `orx-git` skill).
+- **`orx exp run` queues the run and returns immediately** — it does not wait.
+  Follow progress with `orx runs <projectId>` and `orx logs <runId>`, or block
+  with `orx exp wait` (below).
+- **Everything downstream is identical on every backend**: `orx exp wait` /
+  `orx runs` / `orx logs` / `orx exp cancel` work unchanged, and a detached
+  `orx supervise` process mirrors status and logs — never kill it.
+
+## Choosing a backend, and the default target
+
+The user may set a **default compute target** in the dashboard (Settings →
+Compute → Make default); it is machine-wide and applies to every local project.
+When one is set, `orx exp run <expId>` with no `--backend` launches there with
+the saved default flavor — omitting the flag is how you use it (flavor-required
+backends still need `--flavor` if no default flavor is saved; ssh always needs
+`--host`). When none is set, the backend choice is the **user's**: if the task
+doesn't name one and the user hasn't picked one in this conversation, ask
+before launching. A connected token (HF, Modal, …) is NOT a signal to pick that
+backend — it just means the option exists.
+
+## Hugging Face Jobs — `--backend hf`
+
+Runs on the user's own HF account (needs `HF_TOKEN` in the environment), billed
+there per minute.
+
+```sh
+orx exp run <expId> --backend hf --flavor a10g-small
+orx exp run <expId> --backend hf --flavor a100-large --timeout 8h
+orx exp run <expId> --backend hf --flavor cpu-upgrade --image python:3.12
+```
+
+- **`--flavor` is required.** Common flavors: `t4-small`, `a10g-small`,
+  `a10g-large`, `l4x1`, `l40sx1`, `a100-large`, `h100`, `h200` (and `x2/x4/x8`
+  multiples); CPU: `cpu-basic`, `cpu-upgrade`. Prefer the smallest that fits.
+- **Set `--timeout` to cover the whole run** (default `4h`) — HF kills the job
+  at the timeout, and a killed job reads as a failed run.
+- `--image` overrides the container (default: a CUDA pytorch image on GPU
+  flavors, `python:3.12` on CPU). Pick an image with your deps baked in when
+  pip-install time dominates the run.
+
+## Modal — `--backend modal`
+
+Runs in a Modal **Sandbox** (an ephemeral container that scales to zero when
+the run ends) on the user's own Modal account, billed per second. Needs
+`MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET` in the environment (or
+`modal token new`); orx auto-provisions its managed `modal` environment on the
+first launch.
+
+```sh
+orx exp run <expId> --backend modal --flavor a10g
+orx exp run <expId> --backend modal --flavor h100:2 --timeout 8h
+orx exp run <expId> --backend modal --flavor cpu --image python:3.12
+```
+
+- **`--flavor` is required**: `t4`, `l4`, `a10g`, `a100`, `a100-80gb`, `l40s`,
+  `h100`, `h200` (append `:N` for a count, e.g. `h100:2`), or `cpu` /
+  `cpu-large` for CPU-only.
+- `--timeout` (default `4h`) and `--image` behave exactly as on hf.
+
+## Your Kubernetes cluster — `--backend k8s`
+
+The run's shape is a Kubernetes manifest committed on the experiment branch
+(default `.orx/k8s.yaml`) — no flavors, no `--image`. The full manifest
+contract lives in the **`orx-compute-k8s`** skill; load it before your first
+k8s launch.
+
+## Your own box — `--backend ssh`
+
+A detached process on a host from your `~/.ssh/config` — no scheduler, no
+container, the host's environment as-is.
+
+```sh
+orx exp run <expId> --backend ssh --host my-gpu-box
+```
+
+- **`--host <alias>` is required on every launch** — a machine, not a hardware
+  shape, so there is no `--flavor`, `--image`, or `--timeout` (the process runs
+  until it exits or is cancelled). Hosts are managed in Settings → Compute →
+  SSH (each has a "Test" button checking reachability + git).
+- Auth is your own ssh keys/agent — orx never reads a key, it just shells out
+  to `ssh <alias>`. The host needs `git` and `bash`; private repos clone via
+  the `GITHUB_TOKEN` passed in the run's env. The run lives under
+  `~/.orx/runs/<runId>/` on the host; cancel kills the remote process group.
+
+## Your Slurm cluster — `--backend slurm`
+
+Submitted as a batch job via `sbatch` on the login node, reached over ssh — the
+cluster's own environment (modules, conda, whatever the login profile
+provides), no container.
+
+```sh
+orx exp run <expId> --backend slurm --host login-node --flavor h100:2 --timeout 4h
+orx exp run <expId> --backend slurm                    # CPU-only, settings default host
+```
+
+- **`--host` is the login node's `~/.ssh/config` alias**; omit it to use the
+  default from Settings → Compute → Slurm. **`--flavor` is a GRES GPU request**
+  (`h100:2` = two H100s); omit it for a CPU-only job. There is no `--image`;
+  `--timeout` (default `4h`) applies — size it to cover the whole run.
+
+## An OpenResearch box — `--backend openresearch`
+
+Provisions an **ephemeral OpenResearch machine billed to the user's org** —
+created for this run and deleted when it ends — with a fixed CUDA + PyTorch +
+uv image. Needs `orx login` and a registered SSH key.
+
+```sh
+orx exp run <expId> --backend openresearch --flavor h100_sxm:2 --timeout 4h
+orx exp run <expId> --backend openresearch --flavor cpu5c:32 --org <orgId>
+```
+
+- **`--flavor` is a GPU id from `orx compute`** (`h100_sxm`, `h100_sxm:2` for a
+  count) or a CPU flavor (`cpu5c` / `cpu5g` / `cpu5m`, with `:vcpus` like
+  `cpu5c:32`). Optional: `--org <id>`, `--disk <GB>`, `--provider <P>`. No
+  `--image` — the platform's image is fixed.
+- The box is deleted when the run ends either way — nothing persists on it, so
+  everything you need must be in the log. `--timeout` (default `4h`) applies.
+
+## This machine — `--backend local`
+
+A detached, supervised process on the machine running `orx up` — no scheduler,
+no container, this machine's environment as-is.
+
+```sh
+orx exp run <expId> --backend local
+```
+
+- **No flags** — no `--flavor`, `--host`, `--image`, or `--timeout` (the
+  process runs until it exits or is cancelled); the hardware is whatever this
+  machine has. It shares CPU/RAM/GPU with the dashboard and your editing:
+  prefer it for small or CPU-scale runs and a remote backend for anything
+  heavy.
+- Still the full run contract: it clones the branch tip into its own run dir
+  (never your checkout), supervised and visible in the dashboard — never run
+  training directly in your shell instead. The run lives under
+  `<orx data dir>/local-runs/<runId>/`; cancel TERMs the process group.
+
+## Waiting on runs — `orx exp wait`
+
+Block until a run changes state — useful when driving a research loop and you
+want to act as soon as a run finishes. Two modes, picked by argument:
+
+```sh
+orx exp wait <expId>                    # level trigger: poll this experiment's latest run
+                                        #   until it reaches a terminal state (done/failed/cancelled)
+orx exp wait --project <projectId>      # edge trigger: return when the FIRST run in the
+                                        #   project COMPLETES (transitions into done/failed/cancelled)
+orx exp wait <expId> --interval 10 --timeout 3600   # tune polling
+```
+
+- Pass **exactly one** of `<expId>` or `--project` (not both, not neither).
+- `--project` is the **budget-loop** primitive: it wakes only on a
+  **completion** (a run reaching `done`/`failed`/`cancelled`) — i.e. a freed
+  slot. Run *starts*, new queued runs, and `queued→running` transitions are
+  intentionally ignored, so it won't wake you on non-events. It returns on the
+  **first** completion — call it in a loop, one return per tick, and you (not
+  the CLI) decide what to do with each freed slot. See the per-completion loop
+  in the `orx-experiment-tree` skill.
+- **It's a sleep-until-change signal, not the source of truth.** It reports
+  only completions it saw *during that one call*; a run that finishes between
+  calls is already terminal next time and won't be reported. On every return,
+  re-read `orx runs <projectId>` and act on *all* newly-terminal runs — don't
+  treat the printed line as the complete set, and don't replace `exp wait`
+  with a tight `orx runs` poll either (use `exp wait` to sleep, `orx runs` to
+  reconcile).
+- Call `--project` **while runs are in flight** (right after launching). If
+  every run is already terminal, there's nothing left to complete, so it
+  returns immediately printing `drained: no runs in flight` (exit 0) — your
+  loop's termination signal.
+- `--interval` is seconds between polls (default `5`); `--timeout` gives up
+  after N seconds (default `1800`) and exits **non-zero** so callers can branch
+  on it. For long training runs, raise `--timeout` (or treat a timeout exit as
+  "nothing changed yet, loop again") so a wait that simply outlasts the
+  interval isn't mistaken for an error.
+- Progress lines go to **stderr**; the final completion line(s) go to
+  **stdout**, each as `<runId> <prev> -> <status>` (or `<runId> <status>
+  (new)`), or the single line `drained: no runs in flight` when nothing was in
+  flight.
+- **When a run is `failed`, read `orx logs <runId>`** — the traceback, OOM, or
+  setup error lives there (`orx runs` prints a failure reason under the table
+  when one is known). Provider spin-up failures are usually transient and
+  retryable: re-launch, or pick a different flavor or backend, rather than
+  treating the experiment as a dead end.
+
+## Sizing compute
+
+- **Decide GPU vs CPU first.** API-driven evals, data prep, and CPU-bound
+  papers run fine (and far cheaper) on a CPU flavor.
+- **Pick the smallest flavor that fits** the model and a minimal batch; don't
+  reflexively grab the biggest.
+- **Let a real failure escalate you.** OOM or hopelessly-slow → move up a
+  tier. That's expected, not a mistake.
+- Raise `--timeout` (`--timeout 1d`) only for genuinely long runs.

--- a/agent-skills/orx-experiment-tree/SKILL.local.md
+++ b/agent-skills/orx-experiment-tree/SKILL.local.md
@@ -1,0 +1,183 @@
+---
+name: orx-experiment-tree
+description: "The experiment-tree model and the auto-research loop: shape the tree (stacked bushes), branch/launch/wait/promote, and `orx exp desc` notes. Use before creating, planning, or reorganizing experiments, when deciding what to try next, when a round of runs finishes, or whenever you're unsure how work maps onto the tree."
+---
+
+A project is a **tree of experiment nodes**. The root (**baseline**) holds the
+starting code and a **run command** — the single shell command that trains or
+evaluates the node and prints its results to the run log. Every other node is a
+**child** branched off a parent, inheriting its code and its run command. The two
+rules this depends on — **never edit the baseline** and **the run command + env is
+a fixed contract** — are the cardinal rules; everything below assumes them.
+
+## Shape the tree — stacked bushes, not a flat fan or a noodle
+
+The single most common way to drive a project badly is to get the **shape** wrong.
+There are two opposite failures, and the right shape sits between them:
+
+```
+FLAT FAN (wrong)            NOODLE (wrong)            STACKED BUSHES (right)
+root                        root                      root
+├ a ├ b ├ c ... ├ n         └ a                       └ lr-head        ┐ round 1:
+                              └ b                        ├ lr 2e-5     │ a small fan of
+                                └ c                      └ lr 3e-5     ┘ co-equal options
+                                  └ d ...                   └ winner ── arch-head   ┐ round 2
+                                                               ├ arch-A             │ descends onto
+                                                               └ arch-B             ┘ round 1's winner
+```
+
+- **Flat fan** (your whole sweep hanging off the root): every result is measured
+  against the *start*, so wins never accumulate and the tree never makes progress.
+- **Noodle** (a long single-child chain): depth manufactured for its own sake —
+  each step doesn't actually build on the one above it.
+- **Stacked bushes** (correct): a *small fan within a round* (the options of one
+  decision), then **descend onto that round's winner** for the next round.
+
+**The one rule that produces this shape.** Before you make X a child of Y, name
+what Y established that X builds on:
+
+- **You can name it** ("Y is the LR winner; X keeps that LR and changes the
+  architecture") → real depth. X is a **child** of Y. Descend.
+- **You can't — X and Y are co-equal options you're trying at the same time**
+  (lr 2e-5 vs lr 3e-5) → they don't build on each other. They're **siblings** in
+  the same bush. Fan, don't chain.
+
+So: **width = the open options of one decision** (fan freely — a 3-way LR sweep
+*should* be three siblings under a common head); **depth = decisions already
+resolved, stacked** (one level down per winner kept). A new *round* never hangs off
+the root — it hangs off the previous round's winner. That keeps the tree moving
+**downward** as research progresses, without stringing unrelated nodes into a line.
+
+Re-read the tree each round — `orx project view <projectId>` lists every node
+(id, title, branch; roots marked `[root]`) — and check the shape: a wide row of
+direct children off the root with no grandchildren means you're fanning when you
+should be descending; a long depth-N chain with no branching means you're chaining
+co-equal variants that should have been siblings.
+
+## The auto-research loop
+
+To drive a project toward a goal (e.g. "best convergence for d=8"), this is the
+intended flow — do **not** edit the baseline or rewrite the run command:
+
+1. **Read the baseline's code.** You already sit in a private git worktree of the
+   project's repo — `git fetch origin && git checkout <branch>` and read it with
+   your normal tools (see the `orx-git` skill). See the node's run command with
+   `orx exp status <expId>` and find where the knobs live (config files,
+   hyperparameters, model defs).
+2. **Form one round's worth of hypotheses** — the co-equal options of a *single*
+   decision (which LR? which schedule? which init?), each a concrete change you can
+   make and measure against the others in this round. Don't mix decisions from
+   different rounds into one batch — that's what produces the flat fan.
+3. **Create the round as a bush, and pick its parent deliberately.** All of this
+   round's options are **siblings under one parent** — the title is the idea, the
+   description is the concrete change you'll make on that node's branch. The parent is:
+   - the **baseline**, only for the very first round (nothing has been won yet); or
+   - the **previous round's confirmed winner**, for every round after — so this
+     round's changes build *on top of* the last gain instead of resetting to the
+     start. This is what walks the tree downward (see "Shape the tree" above).
+
+   ```sh
+   # Round 1 — one decision (the LR), its options fanned off the baseline:
+   orx create-experiment <projectId> --parent <baseId> --title "LR 2e-5" \
+     --description "Set the LR in config.yaml to 2e-5; change nothing else."
+   orx create-experiment <projectId> --parent <baseId> --title "LR 3e-5" \
+     --description "Set the LR in config.yaml to 3e-5; change nothing else."
+
+   # Round 2 — LR 3e-5 won → the next decision (architecture) descends onto it:
+   orx create-experiment <projectId> --parent <lr3e5WinnerId> --title "Wider MLP" \
+     --description "On top of the LR-3e-5 winner, widen the MLP hidden dim 1024→2048 in model.py."
+   ```
+   The child inherits its parent's run command automatically — you don't set it,
+   and you never give siblings different commands or env vars (cardinal rule 2).
+4. **Implement each child's change on its git branch** — `orx create-experiment`
+   prints the child's branch (`orx/<slug>`); in your worktree:
+   ```sh
+   git fetch origin && git checkout orx/<child-slug>
+   #   …edit only the files that idea touches…
+   git commit -am "cosine LR + warmup" && git push
+   ```
+   **Leave the run command alone.** While you're in the code, **make the run
+   print the evidence you'll need to judge it** — final metrics, a compact
+   summary block, the key config it actually used — because in local mode the
+   run log is the only evidence channel (see the `orx-evidence` skill). A run
+   whose output isn't in its log is lost.
+5. **Launch the round's ready children**: `orx exp run <childId> --backend <b>`
+   (or omit `--backend` when a default target is set — flags and flavors: the
+   `orx-compute` skill). Remote backends can run siblings in parallel;
+   `--backend local` shares this machine's CPU/RAM/GPU, so run those one or
+   two at a time.
+6. **Keep the round moving — drive a per-completion loop, not a wait-for-all
+   barrier.** You want control back the moment *any one* run finishes so you can
+   analyze it and either refill its slot or stop — not after the whole batch
+   drains. `orx exp wait --project <projectId>` is built for exactly this: it
+   returns on the **first** completion. Treat it as one **tick** of a loop, where
+   *you* are the loop body:
+
+   ```
+   # after launching your runs, loop until the project is drained:
+   loop:
+     orx exp wait --project <projectId>   # sleeps; returns on the first completion
+     orx runs <projectId>                 # SOURCE OF TRUTH: re-read all run states
+     # for each run now terminal that you haven't handled yet:
+     #   - read its results (step 7) and decide: launch a refill? promote it? stop?
+     #   - launch the next queued child to refill the freed slot (step 5)
+     # if `exp wait` printed "drained: no runs in flight"  → batch is done, break
+   ```
+
+   Three things make this robust — follow all of them:
+   - **`exp wait --project` is a sleep-until-change signal, not the source of
+     truth.** It only reports completions it observed *during that one call*. A
+     run that finishes while you're analyzing the previous one is already terminal
+     by the next call and **won't be reported**. So on every wake, re-read
+     `orx runs <projectId>` and reconcile against the set of runs you've already
+     handled — act on *every* newly-terminal run, not just the line `exp wait`
+     printed. (This is the one time you do look at `orx runs` in a loop — as the
+     reconcile after each wake, **not** as a tight poll in place of `exp wait`.)
+   - **Re-issue `exp wait` each tick.** One completion → one return → you decide →
+     you call it again. Don't expect a single `exp wait` to block until everything
+     is done; that's the failure mode this loop avoids.
+   - **Terminate on drained.** When no runs are in flight, `exp wait --project`
+     returns immediately printing `drained: no runs in flight`. That — or seeing
+     every run terminal in `orx runs` with no more children to launch — is your
+     exit condition. Don't keep calling it into a timeout.
+7. **Analyze each finish as it lands, then iterate.** Do the per-completion read
+   *inside the loop above*, not deferred to the end — when a run finishes,
+   **actually read its results**: `orx logs <runId>` (see the `orx-evidence`
+   skill). To see exactly what a finished node changed, diff its branch against
+   its parent's (see the `orx-git` skill). Don't infer from status alone. Each
+   completion is a decision point with three moves:
+   - **Refill** — result is mediocre or inconclusive: launch the next queued child to
+     keep the round moving (step 5).
+   - **Promote** — result is a clear win: this node becomes the **parent for the next
+     round**. The next batch of children branch off *it*, not the baseline, so the win
+     carries forward and the next ideas stack on top of it. This is the move that makes
+     the tree grow deeper; skipping it is what produces a flat, sweep-only tree.
+   - **Stop** — goal met, or the branch is exhausted.
+
+   The baseline stays untouched throughout — promotion moves the *focal parent* down the
+   tree, it never edits the root.
+
+Stop when the goal is met, or after ~3 consecutive failed or regressed runs.
+When you stop, write up the tree as a report in the project's files dir — see
+the `orx-reports` skill for the folder layout and section structure.
+
+## Experiment description / notes — `orx exp desc`
+
+Each experiment node carries a free-form **description** (markdown) — the same
+field set by `create-experiment --description`. Use it for notes: observations,
+hypotheses, or a running summary. It is a whole-document field: writing
+overwrites whatever was there.
+
+```sh
+orx exp desc <expId>                          # print the description to stdout (empty → hint on stderr)
+orx exp desc <expId> --set "tried lr=3e-4, diverged at step 4k"   # overwrite with a short note
+cat notes.md | orx exp desc <expId> --stdin   # overwrite from stdin (long markdown)
+```
+
+- **Read** prints the text to **stdout** (pipe/redirect-friendly); when empty, a
+  hint is printed to **stderr** and stdout stays empty.
+- **Write** with exactly one of `--set` (inline) or `--stdin` (whole of stdin).
+  Passing both is an error. Writing **replaces** the entire description — to
+  append, read first, edit, and write back.
+- `<expId>` comes from `orx create-experiment` output or `orx project view
+  <projectId>` (the experiment id, not a run or project id).

--- a/agent-skills/orx-git/SKILL.md
+++ b/agent-skills/orx-git/SKILL.md
@@ -63,6 +63,11 @@ Rules and notes:
 - **Push before you run.** `orx exp run` launches from the branch's pushed tip on
   GitHub — uncommitted or unpushed edits won't be in the run. Commit and push
   first.
+- **Never merge or rebase a branch that has a completed non-failed run** (cardinal
+  rule): its history is the code those results came from. To bring in changes
+  from another branch, create a **child** experiment and put the merge commit on
+  the child's branch. And never rebase, anywhere — the tree records what actually
+  ran, and rewriting history makes no sense in an experiment tree.
 - **Reading another node's code** without disturbing your checkout: that branch is
   already in the clone after a fetch — `git -C "$DIR" show origin/orx/<slug>:<path>`.
 

--- a/src/local/agent_skills.rs
+++ b/src/local/agent_skills.rs
@@ -18,10 +18,11 @@
 //!   an agent's global skills dir (the dedicated cloud box).
 //!
 //! The two sets share the same public skill *names* so docs and references stay
-//! stable; a few modules swap their **body** between a local-mode form
-//! (logs-only evidence, files-dir reports) and a full/cloud form (artifacts +
-//! query + chart; `orx report` upload). The `orx-` prefix on every dir name
-//! makes them unmistakable in an agent's skill listing.
+//! stable; several modules swap their **body** between a local-mode form
+//! (backend-based launches, logs-only evidence, files-dir reports, worktree
+//! git flow) and a full/cloud form (managed-SKU compute, artifacts + query +
+//! chart, `orx report` upload). The `orx-` prefix on every dir name makes them
+//! unmistakable in an agent's skill listing.
 
 use std::path::Path;
 
@@ -52,9 +53,12 @@ pub enum SkillSet {
 // `SKILL.local.md` siblings are the local-mode body variants under the same
 // public skill name) ----------------------------------------------------------
 
-const COMPUTE: &str = include_str!("../../agent-skills/orx-compute/SKILL.md");
+const COMPUTE_LOCAL: &str = include_str!("../../agent-skills/orx-compute/SKILL.local.md");
+const COMPUTE_CLOUD: &str = include_str!("../../agent-skills/orx-compute/SKILL.md");
 const COMPUTE_K8S: &str = include_str!("../../agent-skills/orx-compute-k8s/SKILL.md");
-const EXPERIMENT_TREE: &str = include_str!("../../agent-skills/orx-experiment-tree/SKILL.md");
+const EXPERIMENT_TREE_LOCAL: &str =
+    include_str!("../../agent-skills/orx-experiment-tree/SKILL.local.md");
+const EXPERIMENT_TREE_CLOUD: &str = include_str!("../../agent-skills/orx-experiment-tree/SKILL.md");
 const GIT_EDITING: &str = include_str!("../../agent-skills/orx-git/SKILL.md");
 const LIT: &str = include_str!("../../agent-skills/orx-lit/SKILL.md");
 const CREATE: &str = include_str!("../../agent-skills/orx-create/SKILL.md");
@@ -69,20 +73,36 @@ const EVIDENCE_CLOUD: &str = include_str!("../../agent-skills/orx-evidence/SKILL
 // works blind). Keep each ≤400 chars — Codex's ambient budget is ~8k across
 // the whole set.
 
-const S_COMPUTE: AgentSkill = AgentSkill {
+// The compute and experiment-tree descriptions are shared by the local and
+// cloud body variants (same public name, same triggers — only the body
+// changes), so they live in one const each.
+const D_COMPUTE: &str = "Launch experiment runs with `orx exp run`: backends (hf, modal, k8s, ssh, slurm, openresearch, local), flavors, timeouts, images, sizing, and `orx exp wait`. Use before launching or re-launching any run, when choosing or switching a backend or GPU flavor, when a job OOMs, stalls, or times out, or when deciding GPU vs CPU.";
+const D_EXPERIMENT_TREE: &str = "The experiment-tree model and the auto-research loop: shape the tree (stacked bushes), branch/launch/wait/promote, and `orx exp desc` notes. Use before creating, planning, or reorganizing experiments, when deciding what to try next, when a round of runs finishes, or whenever you're unsure how work maps onto the tree.";
+
+const S_COMPUTE_LOCAL: AgentSkill = AgentSkill {
     name: "orx-compute",
-    description: "Launch experiment runs with `orx exp run`: backends (hf, modal, k8s, ssh, slurm, openresearch, local), flavors, timeouts, images, sizing, and `orx exp wait`. Use before launching or re-launching any run, when choosing or switching a backend or GPU flavor, when a job OOMs, stalls, or times out, or when deciding GPU vs CPU.",
-    content: COMPUTE,
+    description: D_COMPUTE,
+    content: COMPUTE_LOCAL,
+};
+const S_COMPUTE_CLOUD: AgentSkill = AgentSkill {
+    name: "orx-compute",
+    description: D_COMPUTE,
+    content: COMPUTE_CLOUD,
 };
 const S_COMPUTE_K8S: AgentSkill = AgentSkill {
     name: "orx-compute-k8s",
     description: "Run an experiment on your own Kubernetes cluster (`orx exp run --backend k8s`): the committed-manifest contract orx enforces at submit. Use when the user names k8s, kubernetes, or a cluster, before writing or editing `.orx/k8s.yaml`, for multi-node or Indexed Jobs, or when a k8s submit is rejected.",
     content: COMPUTE_K8S,
 };
-const S_EXPERIMENT_TREE: AgentSkill = AgentSkill {
+const S_EXPERIMENT_TREE_LOCAL: AgentSkill = AgentSkill {
     name: "orx-experiment-tree",
-    description: "The experiment-tree model and the auto-research loop: shape the tree (stacked bushes), branch/launch/wait/promote, and `orx exp desc` notes. Use before creating, planning, or reorganizing experiments, when deciding what to try next, when a round of runs finishes, or whenever you're unsure how work maps onto the tree.",
-    content: EXPERIMENT_TREE,
+    description: D_EXPERIMENT_TREE,
+    content: EXPERIMENT_TREE_LOCAL,
+};
+const S_EXPERIMENT_TREE_CLOUD: AgentSkill = AgentSkill {
+    name: "orx-experiment-tree",
+    description: D_EXPERIMENT_TREE,
+    content: EXPERIMENT_TREE_CLOUD,
 };
 const S_GIT: AgentSkill = AgentSkill {
     name: "orx-git",
@@ -121,13 +141,14 @@ const S_EVIDENCE_CLOUD: AgentSkill = AgentSkill {
 };
 
 /// The modules for a given set, in a stable order. Local and Full share names;
-/// `reports`/`evidence` swap bodies, and `create` is Full-only.
+/// `experiment-tree`/`compute`/`reports`/`evidence` swap bodies, and `create`
+/// is Full-only.
 pub fn skills(set: SkillSet) -> Vec<&'static AgentSkill> {
     match set {
         SkillSet::Local => vec![
-            &S_EXPERIMENT_TREE,
+            &S_EXPERIMENT_TREE_LOCAL,
             &S_GIT,
-            &S_COMPUTE,
+            &S_COMPUTE_LOCAL,
             &S_COMPUTE_K8S,
             &S_EVIDENCE_LOCAL,
             &S_REPORTS_LOCAL,
@@ -135,9 +156,9 @@ pub fn skills(set: SkillSet) -> Vec<&'static AgentSkill> {
         ],
         SkillSet::Full => vec![
             &S_CREATE,
-            &S_EXPERIMENT_TREE,
+            &S_EXPERIMENT_TREE_CLOUD,
             &S_GIT,
-            &S_COMPUTE,
+            &S_COMPUTE_CLOUD,
             &S_COMPUTE_K8S,
             &S_EVIDENCE_CLOUD,
             &S_REPORTS_CLOUD,


### PR DESCRIPTION
## What

### Local-mode bodies for `orx-compute` and `orx-experiment-tree`

The Local skill set previously served the shared Full/cloud bodies, which teach commands and flows that don't exist in local mode. New `SKILL.local.md` variants (same public names, same descriptions — the existing reports/evidence mechanism):

- **orx-compute** (19.8 KB → 11.4 KB): drops the managed-SKU preamble (`--gpu`/`--cpu`/`--sandbox`) and `orx instance create`; `orx project edit --run-command` instead of the locally-unavailable `orx exp cmd --set`; removes the unchanged-branch/`--force` guard claim (local mode has no such guard); dedupes the shared-contract boilerplate the cloud body repeats per-backend into one section.
- **orx-experiment-tree**: session-worktree git flow instead of the cache-dir clone; `orx project view` / `orx exp status` / `orx logs` instead of `orx experiments` / `orx exp cmd` / `orx artifacts` / `orx chart` / `orx query`; backend-based launch examples. Every referenced command now exists in local mode.

`agent_skills.rs` serves them via `_LOCAL`/`_CLOUD` consts sharing one description const each; Full set unchanged; existing drift-guard tests cover the new files.

### Playbook (SYSTEM_PROMPT.md) slimmed and extended

- Cuts of content now carried by skills: "Where runs execute" folded into cardinal rule 5; baseline-creation para (rule 1 + loop step 0 cover it); lit para → command-index row; report-layout and `orx supervise` details.
- **New cardinal rule 6**: never merge or rebase an experiment branch once it has a completed non-failed run — create a child and put the merge commit there; never rebase anywhere. Echoed in `orx-git`'s rules list (appended as rule 6, not inserted, because skill bodies cross-reference "cardinal rule 2" by number).
- **New "Learn how the user runs their code" section** + a two-env-failures circuit breaker under "Asking the user": on a fresh project (no runs, no project memory) ask about env manager / deps / the real run command before the first launch, and save answers to project memory. Addresses the reported loop where an agent burned a session guessing at a user's conda setup.

## Testing

`cargo fmt --all --check` / `cargo clippy --all-targets -- -D warnings` / `cargo test --locked` (221 passed) all green.