### PR TITLE
README: bullet-point intro and demo video embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,7 @@
 - **Private by default** — everything binds to loopback; nothing leaves your
   machine except the compute and paper-search calls you initiate.
 
-<!-- TODO(video): replace the line below with the user-attachments URL GitHub
-generates when orx-demo-1080p.mp4 is dragged into a comment box on this PR. -->
-VIDEO_PLACEHOLDER_URL
+https://github.com/user-attachments/assets/33b62182-0795-490d-9366-0fb0b4bd49fd
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 **Run autoresearch on your machine.**
 
-- **Run research agents in parallel** — one per research direction
+- **Run research agents in parallel**. Spins up agents in different worktrees
+  so you can investigate several different directions at once.
 - **Works with Claude Code, Codex, and OpenCode**
-- **Launches experiments on your compute** — or on managed GPUs
-- **Give it a goal** — it proposes, runs, and analyzes experiments
-- **Local and private** — everything runs on your machine
+- **Bring your own compute**. Works with SSH, Slurm, Kubernetes, Modal,
+  HuggingFace and more.
+- **Give it a goal**. Can run the entire autoresearch loop from literature
+  review to experiment analysis.
+- **Local and private**. Your code and your data stays on your machine.
 
 https://github.com/user-attachments/assets/33b62182-0795-490d-9366-0fb0b4bd49fd
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,22 @@
 
 **Run autoresearch on your machine.**
 
-`orx up` starts a local dashboard where you give each research direction its
-own agent. Agents work in parallel in isolated git worktrees, propose and edit
-experiments, launch runs on GPU compute, and analyze the results — using your
-existing tools, accounts, and compute.
+- **Research agents, in parallel** — `orx up` opens a local dashboard where
+  each research direction gets its own agent, working in an isolated git
+  worktree with your existing tools, accounts, and compute.
+- **Experiments as git branches** — every experiment is a runnable snapshot of
+  your code, measured against its baseline, so lineage stays explicit.
+- **Runs on your compute** — launch on Modal, Hugging Face Jobs, Kubernetes,
+  Slurm, any SSH box, your own machine, or OpenResearch managed GPUs, with
+  live logs, diffs, and W&B runs streaming into the dashboard.
+- **Autoresearch** — describe a goal and let the agent propose, launch, and
+  analyze experiments autonomously until it gets there.
+- **Private by default** — everything binds to loopback; nothing leaves your
+  machine except the compute and paper-search calls you initiate.
+
+<!-- TODO(video): replace the line below with the user-attachments URL GitHub
+generates when orx-demo-1080p.mp4 is dragged into a comment box on this PR. -->
+VIDEO_PLACEHOLDER_URL
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # OpenResearch CLI (`orx`)
 
+> [!IMPORTANT]
+> If you are an OpenResearch user or someone who is interested in autoresearch,
+> we'd love to chat with you. Please email
+> [contact@alphaxiv.org](mailto:contact@alphaxiv.org) if interested.
+
 **Run autoresearch on your machine.**
 
 - **Run research agents in parallel**. Spins up agents in different worktrees

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > we'd love to chat with you. Please email
 > [contact@alphaxiv.org](mailto:contact@alphaxiv.org) if interested.
 
-## Run autoresearch on your machine
+### Run autoresearch on your machine
 
 - **Run research agents in parallel**. Spins up agents in different worktrees
   so you can investigate several different directions at once.

--- a/README.md
+++ b/README.md
@@ -2,18 +2,11 @@
 
 **Run autoresearch on your machine.**
 
-- **Research agents, in parallel** — `orx up` opens a local dashboard where
-  each research direction gets its own agent, working in an isolated git
-  worktree with your existing tools, accounts, and compute.
-- **Experiments as git branches** — every experiment is a runnable snapshot of
-  your code, measured against its baseline, so lineage stays explicit.
-- **Runs on your compute** — launch on Modal, Hugging Face Jobs, Kubernetes,
-  Slurm, any SSH box, your own machine, or OpenResearch managed GPUs, with
-  live logs, diffs, and W&B runs streaming into the dashboard.
-- **Autoresearch** — describe a goal and let the agent propose, launch, and
-  analyze experiments autonomously until it gets there.
-- **Private by default** — everything binds to loopback; nothing leaves your
-  machine except the compute and paper-search calls you initiate.
+- **Run research agents in parallel** — one per research direction
+- **Works with Claude Code, Codex, and OpenCode**
+- **Launches experiments on your compute** — or on managed GPUs
+- **Give it a goal** — it proposes, runs, and analyzes experiments
+- **Local and private** — everything runs on your machine
 
 https://github.com/user-attachments/assets/33b62182-0795-490d-9366-0fb0b4bd49fd
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > we'd love to chat with you. Please email
 > [contact@alphaxiv.org](mailto:contact@alphaxiv.org) if interested.
 
-**Run autoresearch on your machine.**
+## Run autoresearch on your machine
 
 - **Run research agents in parallel**. Spins up agents in different worktrees
   so you can investigate several different directions at once.


### PR DESCRIPTION
## What

- Rewrites the README introduction as a scannable bullet list (parallel research agents, experiments as git branches, compute backends, autoresearch, privacy) so the first screen conveys what `orx` offers.
- Embeds the demo screen recording (compressed to 1080p H.264, 54 MB) right below the bullets — verified to render as an inline video player.

`cargo fmt --check`, `clippy -D warnings`, and `cargo test --locked` all pass.