### PR TITLE
One persistent Claude Code child per chat session

### DIFF
--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -55,12 +55,7 @@ pub async fn run(args: UpArgs) -> Result<()> {
         harnesses: Arc::new(tokio::sync::Mutex::new(None)),
         data_dir_move_in_progress: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
-    // The claude host mints the mcp-gate token at spawn via the chat host, so it
-    // holds a weak back-reference (the chat host owns the Arc — a strong ref
-    // would cycle).
-    claude.attach(Arc::downgrade(&state.chat));
-    // Plan-mode turns hand this port to the `orx mcp-gate` permission bridge
-    // (also propagated to the claude host, which spawns the bridge child).
+    // Plan-mode turns hand this port to the `orx mcp-gate` permission bridge.
     state.chat.set_up_port(port);
 
     spawn_hf_preflight();

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -48,13 +48,19 @@ pub async fn run(args: UpArgs) -> Result<()> {
     // no eager agent bring-up. (--no-agent is now a no-op kept for compat.)
     let agent = Arc::new(AgentHost::new(args.model.clone()));
     let codex = Arc::new(local::codex::CodexHost::new());
+    let claude = Arc::new(local::claude::ClaudeHost::new());
     let state = AppState {
         agent: agent.clone(),
-        chat: Arc::new(ChatHost::new(agent.clone(), codex.clone())),
+        chat: Arc::new(ChatHost::new(agent.clone(), codex.clone(), claude.clone())),
         harnesses: Arc::new(tokio::sync::Mutex::new(None)),
         data_dir_move_in_progress: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
-    // Plan-mode turns hand this port to the `orx mcp-gate` permission bridge.
+    // The claude host mints the mcp-gate token at spawn via the chat host, so it
+    // holds a weak back-reference (the chat host owns the Arc — a strong ref
+    // would cycle).
+    claude.attach(Arc::downgrade(&state.chat));
+    // Plan-mode turns hand this port to the `orx mcp-gate` permission bridge
+    // (also propagated to the claude host, which spawns the bridge child).
     state.chat.set_up_port(port);
 
     spawn_hf_preflight();
@@ -91,6 +97,7 @@ pub async fn run(args: UpArgs) -> Result<()> {
     }
     agent.shutdown().await;
     codex.shutdown().await;
+    claude.shutdown().await;
     Ok(())
 }
 
@@ -572,6 +579,7 @@ async fn delete_project(State(state): State<AppState>, Path(id): Path<String>) -
         let _ = state.chat.interrupt(&session.id).await;
         state.chat.opencode.kill_session(&session.id).await;
         state.chat.codex.kill_session(&session.id).await;
+        state.chat.claude.kill_session(&session.id).await;
         local::chat::cleanup_session_worktree(&project, &session.id);
     }
     store.delete_local_project(&id)?;

--- a/src/local/chat/mod.rs
+++ b/src/local/chat/mod.rs
@@ -563,7 +563,7 @@ impl ChatHost {
     ) -> Result<PermissionDecision> {
         // The endpoint grants tool permissions, so unlike the rest of the
         // localhost API it authenticates: the bridge must echo the token its
-        // turn was spawned with.
+        // child was spawned with.
         let token_ok = self
             .gate_tokens
             .lock()

--- a/src/local/chat/mod.rs
+++ b/src/local/chat/mod.rs
@@ -391,6 +391,9 @@ pub struct ChatHost {
     pub opencode: Arc<AgentHost>,
     /// Lazy codex app-server manager (only the codex adapter spawns it).
     pub codex: Arc<crate::local::codex::CodexHost>,
+    /// Persistent Claude Code child manager (one resident child per session;
+    /// only the claude adapter spawns it).
+    pub claude: Arc<crate::local::claude::ClaudeHost>,
     http: reqwest::Client,
     events: broadcast::Sender<(&'static str, Value)>,
     /// Sessions with a turn in flight. A key present means busy; the value is
@@ -486,11 +489,16 @@ impl Drop for TurnGuard {
 }
 
 impl ChatHost {
-    pub fn new(opencode: Arc<AgentHost>, codex: Arc<crate::local::codex::CodexHost>) -> Self {
+    pub fn new(
+        opencode: Arc<AgentHost>,
+        codex: Arc<crate::local::codex::CodexHost>,
+        claude: Arc<crate::local::claude::ClaudeHost>,
+    ) -> Self {
         let (events, _) = broadcast::channel(256);
         Self {
             opencode,
             codex,
+            claude,
             http: reqwest::Client::new(),
             events,
             turns: Mutex::new(HashMap::new()),
@@ -504,9 +512,11 @@ impl ChatHost {
     }
 
     /// Record the port `orx up` bound (once, at startup) so plan-mode turns can
-    /// hand it to the `orx mcp-gate` bridge.
+    /// hand it to the `orx mcp-gate` bridge. The claude host mints the bridge
+    /// token at spawn, so it needs the port too.
     pub fn set_up_port(&self, port: u16) {
         let _ = self.up_port.set(port);
+        self.claude.set_up_port(port);
     }
 
     /// The bound `orx up` port, if this host runs under a server (None in
@@ -515,9 +525,15 @@ impl ChatHost {
         self.up_port.get().copied()
     }
 
-    /// Mint (and remember) the bridge token for a session's plan-mode turn.
-    /// One token per session, refreshed each turn; the previous turn's bridge
-    /// child dies with its turn, so overwriting is correct.
+    /// Mint (and remember) the bridge token for a session's plan-mode child.
+    /// One token per *child* now, minted at spawn (not per turn): the resident
+    /// claude child — and its bridge — live across turns, so a live plan child
+    /// keeps its token until a config-change/interrupt/crash respawn mints a new
+    /// one. Overwriting on each mint is still correct (a respawn's old child is
+    /// killed first), but the mint site moved to `claude::spawn_client`;
+    /// re-minting while a plan child is live would strand its held bridge
+    /// requests, since `request_permission` equality-checks the token with no
+    /// expiry.
     pub fn mint_gate_token(&self, session_id: &str) -> String {
         let token = uuid::Uuid::new_v4().to_string();
         self.gate_tokens
@@ -740,6 +756,7 @@ impl ChatHost {
     pub async fn shutdown_harnesses(&self) {
         self.opencode.shutdown().await;
         self.codex.shutdown().await;
+        self.claude.shutdown().await;
     }
 
     pub async fn busy_sessions(&self) -> Vec<String> {
@@ -1006,6 +1023,15 @@ impl ChatHost {
                     // (and settles the turn as "interrupted" in its rollout)
                     // instead of only losing its orx-side listener.
                     self.codex.interrupt_session(session_id).await;
+                } else if session.harness == "claude-code" {
+                    // The load-bearing change: a resident claude child survives
+                    // task-abort/kill_on_drop, so aborting the turn task leaves
+                    // it generating with no listener. Kill it — v1 has no
+                    // reliable native interrupt (the control request gave no
+                    // response). The next turn respawns with `--resume`,
+                    // recovering this session's context (today-identical
+                    // semantics).
+                    self.claude.kill_session(session_id).await;
                 }
             }
         }
@@ -1206,9 +1232,11 @@ impl ChatHost {
     pub async fn delete_session(&self, session_id: &str) -> Result<()> {
         let _ = self.interrupt(session_id).await;
         // A live opencode serve child would keep running in (and lock) the
-        // session's worktree.
+        // session's worktree; the resident claude child's cwd is that worktree
+        // too, so reap it before `cleanup_session_worktree` below.
         self.opencode.kill_session(session_id).await;
         self.codex.kill_session(session_id).await;
+        self.claude.kill_session(session_id).await;
         // Drop the session's respond lock so the map doesn't retain an entry for
         // a session that no longer exists.
         self.respond_locks.lock().await.remove(session_id);
@@ -1504,6 +1532,7 @@ impl TurnCtx {
             host: Arc::new(ChatHost::new(
                 Arc::new(AgentHost::new(None)),
                 Arc::new(crate::local::codex::CodexHost::new()),
+                Arc::new(crate::local::claude::ClaudeHost::new()),
             )),
             session_id: "test-session".into(),
             harness: "test".into(),

--- a/src/local/chat/mod.rs
+++ b/src/local/chat/mod.rs
@@ -421,9 +421,11 @@ pub struct ChatHost {
     /// Outstanding permission-bridge requests, keyed by the prompt part id the
     /// card was surfaced under. Sync mutex, never held across an await.
     pending_permissions: std::sync::Mutex<HashMap<String, PendingPermission>>,
-    /// Per-session bridge token, minted fresh each plan-mode turn. The rest of
-    /// the localhost API is unauthenticated, but this endpoint *grants tool
-    /// permissions*, so the bridge must echo the token the turn was spawned with.
+    /// Per-session bridge token, minted once per plan-mode child spawn (the
+    /// resident bridge carries it for the child's whole life — re-minting
+    /// mid-child would strand it). The rest of the localhost API is
+    /// unauthenticated, but this endpoint *grants tool permissions*, so the
+    /// bridge must echo the token its child was spawned with.
     gate_tokens: std::sync::Mutex<HashMap<String, String>>,
     /// Sessions whose running turn surfaced a bridge card — checked (and
     /// cleared) by the synthesized-plan-card fallback so it never double-cards
@@ -512,11 +514,9 @@ impl ChatHost {
     }
 
     /// Record the port `orx up` bound (once, at startup) so plan-mode turns can
-    /// hand it to the `orx mcp-gate` bridge. The claude host mints the bridge
-    /// token at spawn, so it needs the port too.
+    /// hand it to the `orx mcp-gate` bridge.
     pub fn set_up_port(&self, port: u16) {
         let _ = self.up_port.set(port);
-        self.claude.set_up_port(port);
     }
 
     /// The bound `orx up` port, if this host runs under a server (None in

--- a/src/local/claude.rs
+++ b/src/local/claude.rs
@@ -61,8 +61,11 @@ pub struct SpawnConfig {
 /// Everything needed to spawn (or respawn) a session's child, built per turn by
 /// the harness. `resume` carries the native session id for `--resume` recovery
 /// (crash/restart or config-change respawn); `None` on a session's first spawn.
+/// `chat` is the spawn-time handle for the plan-mode bridge (`up_port` +
+/// `mint_gate_token`) — the spec is transient (built per turn, consumed by
+/// `ensure`), so the strong ref cannot cycle.
 pub struct SpawnSpec {
-    pub host: Arc<ClaudeHost>,
+    pub chat: Arc<crate::local::chat::ChatHost>,
     pub session_id: String,
     pub repo: PathBuf,
     pub playbook: PathBuf,
@@ -333,10 +336,12 @@ async fn spawn_client(spec: &SpawnSpec) -> Result<Arc<ClaudeClient>> {
     }
 
     // Plan-mode extras, iff the child was spawned in Plan. `bridge_active` on the
-    // config records what we ACHIEVED, not what we wanted: a failed write leaves
-    // it false, and the next plan turn respawns to retry — degrading to today's
-    // no-bridge plan gating, never worse.
+    // config records what we ACHIEVED, not what we wanted: forced false here, set
+    // true only on a successful bridge write. A failed write thus leaves it false
+    // — the next plan turn's wanted-true mismatch respawns to retry, degrading to
+    // today's no-bridge plan gating, never worse.
     let mut config = spec.config.clone();
+    config.bridge_active = false;
     if spec.config.permission_mode == Some(PermissionMode::Plan) {
         match write_plan_settings(&spec.repo) {
             Ok(path) => {
@@ -353,8 +358,8 @@ async fn spawn_client(spec: &SpawnSpec) -> Result<Arc<ClaudeClient>> {
         // (e.g. per turn) would strand a live bridge: `request_permission`
         // equality-checks the token with no expiry (chat/mod.rs), so a fresh
         // token invalidates the resident bridge child's held requests.
-        if let Some(port) = spec.host.up_port.get().copied() {
-            let token = spec.host.chat_mint_gate_token(&spec.session_id);
+        if let Some(port) = spec.chat.up_port() {
+            let token = spec.chat.mint_gate_token(&spec.session_id);
             match write_mcp_config(&spec.repo, port, &spec.session_id, &token) {
                 Ok(path) => {
                     cmd.arg("--mcp-config").arg(path);
@@ -443,12 +448,6 @@ pub struct ClaudeHost {
     /// Serializes ensure() spawns; `inner` is never held across a spawn.
     spawn_lock: Mutex<()>,
     inner: Mutex<HashMap<String, Arc<ClaudeClient>>>,
-    /// Back-reference to the chat host, for `mint_gate_token` at spawn time and
-    /// the bound `orx up` port. Set once via `attach` right after both hosts are
-    /// constructed (they reference each other, so neither can hold the other in
-    /// its constructor).
-    chat: std::sync::OnceLock<std::sync::Weak<crate::local::chat::ChatHost>>,
-    up_port: std::sync::OnceLock<u16>,
 }
 
 impl Default for ClaudeHost {
@@ -462,29 +461,6 @@ impl ClaudeHost {
         Self {
             spawn_lock: Mutex::new(()),
             inner: Mutex::new(HashMap::new()),
-            chat: std::sync::OnceLock::new(),
-            up_port: std::sync::OnceLock::new(),
-        }
-    }
-
-    /// Wire the back-reference to the chat host (a `Weak` — the chat host owns
-    /// the `Arc<ClaudeHost>`, so a strong ref would be a cycle). Idempotent.
-    pub fn attach(&self, chat: std::sync::Weak<crate::local::chat::ChatHost>) {
-        let _ = self.chat.set(chat);
-    }
-
-    /// Record the bound `orx up` port so plan-mode spawns can wire the bridge.
-    pub fn set_up_port(&self, port: u16) {
-        let _ = self.up_port.set(port);
-    }
-
-    /// Mint the per-child gate token via the chat host — called at spawn only.
-    fn chat_mint_gate_token(&self, session_id: &str) -> String {
-        match self.chat.get().and_then(std::sync::Weak::upgrade) {
-            Some(chat) => chat.mint_gate_token(session_id),
-            // No chat host attached (shouldn't happen under `orx up`): a random
-            // token still writes a valid config; the bridge simply won't match.
-            None => uuid::Uuid::new_v4().to_string(),
         }
     }
 
@@ -556,18 +532,6 @@ impl ClaudeHost {
         })
         .await
         .map_err(|e| anyhow!("claude bring-up task failed: {e}"))?
-    }
-
-    /// The session's live client, if any (for inline replies).
-    pub async fn client_for(&self, session_id: &str) -> Option<Arc<ClaudeClient>> {
-        let mut guard = self.inner.lock().await;
-        let client = guard.get(session_id)?;
-        if matches!(client.child.lock().await.try_wait(), Ok(None)) {
-            Some(client.clone())
-        } else {
-            guard.remove(session_id);
-            None
-        }
     }
 
     /// Kill and reap one session's child. The load-bearing interrupt/delete

--- a/src/local/claude.rs
+++ b/src/local/claude.rs
@@ -1,0 +1,782 @@
+//! Persistent Claude Code host — one long-lived `claude --print --input-format
+//! stream-json` child per chat session, mirroring `AgentHost`/`CodexHost`. The
+//! child stays resident across turns: a stable `session_id` survives every turn,
+//! stdin never closes, and each user message is one JSON line
+//! (`{"type":"user","message":{"role":"user","content":[…]}}`). This replaces
+//! today's spawn-per-turn + `--resume` fork (`harness/claude.rs`'s old
+//! `run_turn`), whose ~3–6s of per-turn spawn/config/MCP-handshake overhead the
+//! latency probe measured.
+//!
+//! Wire shapes were pinned live against claude CLI 2.1.197. In persistent mode
+//! `--print --input-format stream-json --output-format stream-json` accepts one
+//! user message per stdin line and ends each turn with a `result` event; the
+//! `session_id` is stable across turns in one process, and `--resume <id>`
+//! composes with stream-json input, so a crash/restart or config-change respawn
+//! recovers cheaply. Control requests ride the same stdin stream
+//! (`{"type":"control_request","request_id":…,"request":{"subtype":…}}`) and are
+//! answered by a `control_response`; `set_model` is the only one we use — native
+//! `interrupt` gave no response and is treated as unreliable, so v1 interrupts
+//! by killing the child (`ChatHost::interrupt`'s `claude-code` branch).
+//!
+//! Non-goals (separate tasks): MCP config isolation (`--strict-mcp-config`);
+//! codex/opencode paths; the UI rendering fix.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, Command};
+use tokio::sync::{mpsc, oneshot, Mutex};
+
+use crate::error::{anyhow, Result};
+use crate::local::harness::claude::{
+    claude_permission_mode, find_claude, write_mcp_config, write_plan_settings,
+};
+use crate::local::harness::PermissionMode;
+
+/// Ceiling on a control request's response wait. Control requests (`set_model`)
+/// are quick; a wedged child must never hold the respawn path for long.
+const CONTROL_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// What the resident child was spawned with. Any field that can only be applied
+/// at launch (permission mode, effort, the mcp-gate bridge) forces a respawn
+/// when it changes; `model` is the exception — it retunes live via `set_model`,
+/// so it is updated in place on a successful control request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpawnConfig {
+    pub permission_mode: Option<PermissionMode>,
+    pub effort: Option<String>,
+    pub model: Option<String>,
+    /// Whether the mcp-gate permission bridge was actually wired at spawn (plan
+    /// mode + a bound `orx up` port + a successful config write). A plan turn
+    /// that wanted the bridge but got `false` respawns next turn to try again.
+    pub bridge_active: bool,
+}
+
+/// Everything needed to spawn (or respawn) a session's child, built per turn by
+/// the harness. `resume` carries the native session id for `--resume` recovery
+/// (crash/restart or config-change respawn); `None` on a session's first spawn.
+pub struct SpawnSpec {
+    pub host: Arc<ClaudeHost>,
+    pub session_id: String,
+    pub repo: PathBuf,
+    pub playbook: PathBuf,
+    pub resume: Option<String>,
+    pub config: SpawnConfig,
+}
+
+/// One event delivered to the session's in-flight turn.
+#[derive(Debug)]
+pub enum TurnEvent {
+    /// A stream-json output line (an `assistant`/`user`/`system`/`result`
+    /// object). The turn loop folds these through `apply_event`.
+    Line(Value),
+    /// Child died (EOF on stdout). The turn cannot continue.
+    Closed,
+}
+
+/// One inbound stdout line, classified. Claude interleaves two shapes on the
+/// same stream: `control_response` (settling one of our control requests) and
+/// ordinary stream-json output objects (turn events).
+#[derive(Debug, PartialEq)]
+pub enum ClaudeLine {
+    /// A `control_response` for a request we sent: `request_id` echoed back,
+    /// plus `Ok`/`Err` from the response `subtype`.
+    ControlResponse {
+        request_id: String,
+        result: Result<Value, String>,
+    },
+    /// A stream-json output object (turn event) — routed to the live turn.
+    Event(Value),
+    /// Unparseable, or a control message we don't originate (`control_request`
+    /// from the child). Ignored.
+    Junk,
+}
+
+/// Classify one stdout line. Pure — the reader task and the tests share it.
+pub fn classify_line(line: &str) -> ClaudeLine {
+    let Ok(msg) = serde_json::from_str::<Value>(line) else {
+        return ClaudeLine::Junk;
+    };
+    match msg.get("type").and_then(Value::as_str) {
+        Some("control_response") => {
+            let response = msg.get("response").unwrap_or(&Value::Null);
+            let Some(request_id) = response
+                .get("request_id")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+            else {
+                return ClaudeLine::Junk;
+            };
+            let result = match response.get("subtype").and_then(Value::as_str) {
+                Some("success") => Ok(response.get("response").cloned().unwrap_or(Value::Null)),
+                _ => Err(response
+                    .get("error")
+                    .and_then(Value::as_str)
+                    .unwrap_or("claude control request failed")
+                    .to_string()),
+            };
+            ClaudeLine::ControlResponse { request_id, result }
+        }
+        // A control_request FROM the child (e.g. a permission prompt) rides the
+        // mcp-gate bridge over HTTP, not this stream — we never answer it here.
+        Some("control_request") | None => ClaudeLine::Junk,
+        // Everything else is a stream-json output object: assistant/user/system/
+        // result. The turn loop discriminates on `type`.
+        Some(_) => ClaudeLine::Event(msg),
+    }
+}
+
+/// A live connection to one session's resident `claude` child.
+pub struct ClaudeClient {
+    child: Mutex<Child>,
+    /// Held open for the life of the child: stdin EOF ends the session, so we
+    /// never drop it between turns. One JSON line per user message / control
+    /// request.
+    stdin: Mutex<ChildStdin>,
+    next_id: AtomicI64,
+    /// Our outstanding control requests. Sync mutex: touched from the reader
+    /// task and from `control_request`, held only for map ops, never across an
+    /// await.
+    pending: std::sync::Mutex<HashMap<String, oneshot::Sender<Result<Value, String>>>>,
+    /// The session's in-flight turn, if any (one per session-child). The
+    /// registration guard drops synchronously on task abort, hence sync mutex.
+    turn: std::sync::Mutex<Option<mpsc::UnboundedSender<TurnEvent>>>,
+    /// What this child was spawned with — the reuse/respawn decision reads it,
+    /// and a successful `set_model` updates its `model` in place.
+    config: std::sync::Mutex<SpawnConfig>,
+}
+
+impl ClaudeClient {
+    /// The config this child is currently running under.
+    pub fn config(&self) -> SpawnConfig {
+        self.config.lock().unwrap().clone()
+    }
+
+    /// Send a user message as one stream-json line. The child answers with a
+    /// stream of output objects ending in a `result`.
+    pub async fn send_user_message(&self, text: &str) -> Result<()> {
+        let msg = json!({
+            "type": "user",
+            "message": { "role": "user", "content": [{ "type": "text", "text": text }] },
+        });
+        self.write_line(&msg).await
+    }
+
+    /// Send a control request and await its `control_response`. `Ok(Err(msg))`
+    /// is a *child-reported* failure, `Err(..)` a transport failure (child gone
+    /// / timeout).
+    async fn control_request(&self, request: Value) -> Result<Result<Value, String>> {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let request_id = format!("req_{id}");
+        let (tx, rx) = oneshot::channel();
+        self.pending.lock().unwrap().insert(request_id.clone(), tx);
+        let sent = self
+            .write_line(&json!({
+                "type": "control_request",
+                "request_id": request_id,
+                "request": request,
+            }))
+            .await;
+        if let Err(e) = sent {
+            self.pending.lock().unwrap().remove(&request_id);
+            return Err(e);
+        }
+        match tokio::time::timeout(CONTROL_TIMEOUT, rx).await {
+            Ok(Ok(result)) => Ok(result),
+            Ok(Err(_)) => Err(anyhow!("claude closed during control request")),
+            Err(_) => {
+                self.pending.lock().unwrap().remove(&request_id);
+                Err(anyhow!(
+                    "claude did not answer the control request within {}s",
+                    CONTROL_TIMEOUT.as_secs()
+                ))
+            }
+        }
+    }
+
+    /// Retune the resident child's model in place via `set_model`. On success,
+    /// record the new model in `config` so the reuse decision stays truthful.
+    async fn set_model(&self, model: &str) -> Result<()> {
+        match self
+            .control_request(json!({ "subtype": "set_model", "model": model }))
+            .await?
+        {
+            Ok(_) => {
+                self.config.lock().unwrap().model = Some(model.to_string());
+                Ok(())
+            }
+            Err(msg) => Err(anyhow!("claude set_model failed: {msg}")),
+        }
+    }
+
+    async fn write_line(&self, msg: &Value) -> Result<()> {
+        let mut stdin = self.stdin.lock().await;
+        stdin
+            .write_all(format!("{msg}\n").as_bytes())
+            .await
+            .map_err(|e| anyhow!("claude stdin: {e}"))?;
+        stdin
+            .flush()
+            .await
+            .map_err(|e| anyhow!("claude stdin: {e}"))?;
+        Ok(())
+    }
+
+    /// Register the session's turn event sink. The returned guard deregisters on
+    /// drop (including task abort mid-turn).
+    pub fn register_turn(self: &Arc<Self>, tx: mpsc::UnboundedSender<TurnEvent>) -> TurnRoute {
+        *self.turn.lock().unwrap() = Some(tx.clone());
+        TurnRoute {
+            client: self.clone(),
+            tx,
+        }
+    }
+}
+
+/// RAII turn registration — dropping (normal exit or task abort) detaches the
+/// event sink so a dangling turn can't receive another turn's events. An
+/// aborted task's guard drops *asynchronously*, possibly after a successor turn
+/// has already registered — so drop only detaches its *own* channel, never a
+/// successor's (the codex `same_channel` guard).
+pub struct TurnRoute {
+    client: Arc<ClaudeClient>,
+    tx: mpsc::UnboundedSender<TurnEvent>,
+}
+
+impl Drop for TurnRoute {
+    fn drop(&mut self) {
+        let mut turn = self.client.turn.lock().unwrap();
+        if turn.as_ref().is_some_and(|t| t.same_channel(&self.tx)) {
+            *turn = None;
+        }
+    }
+}
+
+/// Reader task: pump child stdout, route each line. On EOF every pending control
+/// request fails and the live turn (if any) gets [`TurnEvent::Closed`].
+async fn read_loop(client: Arc<ClaudeClient>, stdout: tokio::process::ChildStdout) {
+    let mut lines = BufReader::new(stdout).lines();
+    while let Ok(Some(line)) = lines.next_line().await {
+        match classify_line(&line) {
+            ClaudeLine::ControlResponse { request_id, result } => {
+                if let Some(tx) = client.pending.lock().unwrap().remove(&request_id) {
+                    let _ = tx.send(result);
+                }
+            }
+            ClaudeLine::Event(value) => {
+                // Route to the live turn; dropped if none is listening (a
+                // between-turns line, or an aborted turn's tail).
+                let turn = client.turn.lock().unwrap();
+                if let Some(tx) = turn.as_ref() {
+                    let _ = tx.send(TurnEvent::Line(value));
+                }
+            }
+            ClaudeLine::Junk => {}
+        }
+    }
+    // EOF or read error: the connection is unusable. Kill the child if it is
+    // somehow still alive (a half-dead child left in the registry would fail
+    // every turn until restart), then fail everything still waiting.
+    let _ = client.child.lock().await.kill().await;
+    for (_, tx) in client.pending.lock().unwrap().drain() {
+        let _ = tx.send(Err("claude exited".into()));
+    }
+    if let Some(tx) = client.turn.lock().unwrap().as_ref() {
+        let _ = tx.send(TurnEvent::Closed);
+    }
+}
+
+/// Spawn a resident `claude` child for one session. Mirrors the flag block the
+/// old per-turn `run_turn` built (`harness/claude.rs`), plus the persistent-mode
+/// wiring: `--input-format stream-json` and, on recovery/respawn,
+/// `--resume <native_id>`. No handshake — the first turn's `system`/`init` line
+/// is the health signal.
+async fn spawn_client(spec: &SpawnSpec) -> Result<Arc<ClaudeClient>> {
+    let bin = find_claude().ok_or_else(|| {
+        anyhow!("claude not found on PATH — install Claude Code and run `claude` once to sign in")
+    })?;
+    let mut cmd = Command::new(&bin);
+    cmd.args([
+        "--print",
+        "--input-format",
+        "stream-json",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--permission-mode",
+        claude_permission_mode(spec.config.permission_mode),
+    ])
+    .arg("--append-system-prompt-file")
+    .arg(&spec.playbook)
+    .current_dir(&spec.repo)
+    .stdin(Stdio::piped())
+    .stdout(Stdio::piped())
+    .stderr(Stdio::from(crate::local::chat::harness_log("claude")?))
+    // Backstop only: the child is deliberately kept resident across turns, so
+    // its lifetime is managed by kill_session/shutdown, not by dropping a
+    // per-turn handle. kill_on_drop still reaps it if the whole host is dropped.
+    .kill_on_drop(true);
+    if let Some(model) = &spec.config.model {
+        cmd.args(["--model", model]);
+    }
+    if let Some(effort) = spec.config.effort.as_deref() {
+        cmd.args(["--effort", effort]);
+    }
+    if let Some(native_id) = &spec.resume {
+        cmd.args(["--resume", native_id]);
+    }
+
+    // Plan-mode extras, iff the child was spawned in Plan. `bridge_active` on the
+    // config records what we ACHIEVED, not what we wanted: a failed write leaves
+    // it false, and the next plan turn respawns to retry — degrading to today's
+    // no-bridge plan gating, never worse.
+    let mut config = spec.config.clone();
+    if spec.config.permission_mode == Some(PermissionMode::Plan) {
+        match write_plan_settings(&spec.repo) {
+            Ok(path) => {
+                cmd.arg("--settings").arg(path);
+            }
+            Err(e) => {
+                eprintln!(
+                    "orx up: plan-mode settings not written, orx inspection will be gated: {e}"
+                );
+            }
+        }
+        // The gate token is minted HERE and ONLY here — once per child, riding
+        // the mcp-gate bridge for the child's whole life. Re-minting mid-child
+        // (e.g. per turn) would strand a live bridge: `request_permission`
+        // equality-checks the token with no expiry (chat/mod.rs), so a fresh
+        // token invalidates the resident bridge child's held requests.
+        if let Some(port) = spec.host.up_port.get().copied() {
+            let token = spec.host.chat_mint_gate_token(&spec.session_id);
+            match write_mcp_config(&spec.repo, port, &spec.session_id, &token) {
+                Ok(path) => {
+                    cmd.arg("--mcp-config").arg(path);
+                    cmd.args(["--permission-prompt-tool", "mcp__orx__approve"]);
+                    // Give a held approval an hour before the CLI abandons the
+                    // tool call; orx denies at 55 min, safely inside it.
+                    cmd.env("MCP_TOOL_TIMEOUT", "3600000");
+                    config.bridge_active = true;
+                }
+                Err(e) => {
+                    eprintln!(
+                        "orx up: mcp bridge not configured, gray-area tools will be denied: {e}"
+                    );
+                }
+            }
+        }
+    }
+    crate::local::chat::prepare_env(&mut cmd);
+    // Own process group: a terminal SIGINT reaches orx up alone, which then
+    // tears the resident child down deliberately (kill_session / shutdown). A
+    // shared group would let Ctrl-C kill a persistent child mid-turn.
+    #[cfg(unix)]
+    cmd.process_group(0);
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| anyhow!("Could not spawn {}: {}", bin.display(), e))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow!("claude: no stdout"))?;
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow!("claude: no stdin"))?;
+
+    let client = Arc::new(ClaudeClient {
+        child: Mutex::new(child),
+        stdin: Mutex::new(stdin),
+        next_id: AtomicI64::new(1),
+        pending: std::sync::Mutex::new(HashMap::new()),
+        turn: std::sync::Mutex::new(None),
+        config: std::sync::Mutex::new(config),
+    });
+    tokio::spawn(read_loop(client.clone(), stdout));
+    Ok(client)
+}
+
+/// How a live child reconciles with the turn's wanted config.
+///
+/// * `Reuse` — identical spawn config → hand back the running child (zero cost).
+/// * `SetModel` — only the model changed, to a concrete value → retune in place.
+/// * `Respawn` — mode/effort/bridge changed, or the model was cleared (a launch
+///   flag can't be unset live) → kill and respawn with `--resume`.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ChildAction {
+    Reuse,
+    SetModel(String),
+    Respawn,
+}
+
+/// Pure reuse/respawn decision (unit-tested). `current` is the running child's
+/// config, `wanted` the turn's.
+pub fn child_action(current: &SpawnConfig, wanted: &SpawnConfig) -> ChildAction {
+    // Any launch-only axis differing forces a respawn.
+    if current.permission_mode != wanted.permission_mode
+        || current.effort != wanted.effort
+        || current.bridge_active != wanted.bridge_active
+    {
+        return ChildAction::Respawn;
+    }
+    if current.model == wanted.model {
+        return ChildAction::Reuse;
+    }
+    // Model differs. A change TO a concrete model retunes live; clearing the
+    // model (Some → None) can't be expressed as a flag toggle, so respawn.
+    match &wanted.model {
+        Some(model) => ChildAction::SetModel(model.clone()),
+        None => ChildAction::Respawn,
+    }
+}
+
+/// The `orx up` Claude host: one resident `claude` child per chat session, keyed
+/// by the orx session id. Share as `Arc<ClaudeHost>` in axum state.
+pub struct ClaudeHost {
+    /// Serializes ensure() spawns; `inner` is never held across a spawn.
+    spawn_lock: Mutex<()>,
+    inner: Mutex<HashMap<String, Arc<ClaudeClient>>>,
+    /// Back-reference to the chat host, for `mint_gate_token` at spawn time and
+    /// the bound `orx up` port. Set once via `attach` right after both hosts are
+    /// constructed (they reference each other, so neither can hold the other in
+    /// its constructor).
+    chat: std::sync::OnceLock<std::sync::Weak<crate::local::chat::ChatHost>>,
+    up_port: std::sync::OnceLock<u16>,
+}
+
+impl Default for ClaudeHost {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ClaudeHost {
+    pub fn new() -> Self {
+        Self {
+            spawn_lock: Mutex::new(()),
+            inner: Mutex::new(HashMap::new()),
+            chat: std::sync::OnceLock::new(),
+            up_port: std::sync::OnceLock::new(),
+        }
+    }
+
+    /// Wire the back-reference to the chat host (a `Weak` — the chat host owns
+    /// the `Arc<ClaudeHost>`, so a strong ref would be a cycle). Idempotent.
+    pub fn attach(&self, chat: std::sync::Weak<crate::local::chat::ChatHost>) {
+        let _ = self.chat.set(chat);
+    }
+
+    /// Record the bound `orx up` port so plan-mode spawns can wire the bridge.
+    pub fn set_up_port(&self, port: u16) {
+        let _ = self.up_port.set(port);
+    }
+
+    /// Mint the per-child gate token via the chat host — called at spawn only.
+    fn chat_mint_gate_token(&self, session_id: &str) -> String {
+        match self.chat.get().and_then(std::sync::Weak::upgrade) {
+            Some(chat) => chat.mint_gate_token(session_id),
+            // No chat host attached (shouldn't happen under `orx up`): a random
+            // token still writes a valid config; the bridge simply won't match.
+            None => uuid::Uuid::new_v4().to_string(),
+        }
+    }
+
+    /// Spawn (or reuse) this session's resident child, reconciled to `spec`'s
+    /// config. Idempotent while the child is alive and its config matches; a
+    /// model-only change retunes live, any launch-flag change (or a dead child)
+    /// respawns with `--resume`.
+    ///
+    /// The spawn runs in a *detached* task: the calling turn task is abortable
+    /// (interrupt / delete), and an aborted future would drop its `Arc` while
+    /// the reader task keeps the child alive — an unregistered client would be
+    /// unreachable by every kill path and leak the process for the rest of `orx
+    /// up`'s life. Detached, the bring-up always runs to completion.
+    pub async fn ensure(self: &Arc<Self>, spec: SpawnSpec) -> Result<Arc<ClaudeClient>> {
+        let _spawning = self.spawn_lock.lock().await;
+        let session = spec.session_id.clone();
+        // Reconcile against a live child under the lock.
+        {
+            let mut guard = self.inner.lock().await;
+            if let Some(client) = guard.get(&session) {
+                if matches!(client.child.lock().await.try_wait(), Ok(None)) {
+                    let live = client.clone();
+                    let current = live.config();
+                    match child_action(&current, &spec.config) {
+                        ChildAction::Reuse => return Ok(live),
+                        ChildAction::SetModel(model) => {
+                            drop(guard);
+                            match live.set_model(&model).await {
+                                Ok(()) => return Ok(live),
+                                // set_model failed (transport/child error): fall
+                                // through to a respawn with --resume.
+                                Err(e) => {
+                                    eprintln!("orx up: claude set_model failed, respawning: {e}");
+                                    let _ = live.child.lock().await.kill().await;
+                                    self.inner.lock().await.remove(&session);
+                                }
+                            }
+                        }
+                        ChildAction::Respawn => {
+                            let _ = live.child.lock().await.kill().await;
+                            guard.remove(&session);
+                        }
+                    }
+                } else {
+                    // Dead child: replace it.
+                    guard.remove(&session);
+                }
+            }
+        }
+        let host = self.clone();
+        tokio::spawn(async move {
+            let client = spawn_client(&spec).await?;
+            // Never displace a live entry: if an abandoned bring-up's insert
+            // races a successor's (spawn_lock was released by the abort), the
+            // loser kills its own child and defers to the live one.
+            {
+                let mut guard = host.inner.lock().await;
+                if let Some(existing) = guard.get(&session) {
+                    if matches!(existing.child.lock().await.try_wait(), Ok(None)) {
+                        let existing = existing.clone();
+                        drop(guard);
+                        let _ = client.child.lock().await.kill().await;
+                        return Ok(existing);
+                    }
+                }
+                guard.insert(session.clone(), client.clone());
+            }
+            Ok(client)
+        })
+        .await
+        .map_err(|e| anyhow!("claude bring-up task failed: {e}"))?
+    }
+
+    /// The session's live client, if any (for inline replies).
+    pub async fn client_for(&self, session_id: &str) -> Option<Arc<ClaudeClient>> {
+        let mut guard = self.inner.lock().await;
+        let client = guard.get(session_id)?;
+        if matches!(client.child.lock().await.try_wait(), Ok(None)) {
+            Some(client.clone())
+        } else {
+            guard.remove(session_id);
+            None
+        }
+    }
+
+    /// Kill and reap one session's child. The load-bearing interrupt/delete
+    /// path: a resident child survives task-abort/`kill_on_drop`, so it must be
+    /// killed explicitly; the next turn respawns with `--resume`.
+    pub async fn kill_session(&self, session_id: &str) {
+        if let Some(client) = self.inner.lock().await.remove(session_id) {
+            let _ = client.child.lock().await.kill().await;
+        }
+    }
+
+    /// Kill and reap every child (also happens via kill_on_drop on exit).
+    pub async fn shutdown(&self) {
+        for (_, client) in self.inner.lock().await.drain() {
+            let _ = client.child.lock().await.kill().await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(
+        mode: Option<PermissionMode>,
+        effort: Option<&str>,
+        model: Option<&str>,
+        bridge: bool,
+    ) -> SpawnConfig {
+        SpawnConfig {
+            permission_mode: mode,
+            effort: effort.map(str::to_string),
+            model: model.map(str::to_string),
+            bridge_active: bridge,
+        }
+    }
+
+    #[test]
+    fn child_action_matrix() {
+        // Identical config → reuse.
+        assert_eq!(
+            child_action(
+                &cfg(
+                    Some(PermissionMode::Auto),
+                    Some("high"),
+                    Some("opus"),
+                    false
+                ),
+                &cfg(
+                    Some(PermissionMode::Auto),
+                    Some("high"),
+                    Some("opus"),
+                    false
+                ),
+            ),
+            ChildAction::Reuse
+        );
+        // Model-only change to a concrete value → set_model.
+        assert_eq!(
+            child_action(
+                &cfg(
+                    Some(PermissionMode::Auto),
+                    Some("high"),
+                    Some("opus"),
+                    false
+                ),
+                &cfg(
+                    Some(PermissionMode::Auto),
+                    Some("high"),
+                    Some("sonnet"),
+                    false
+                ),
+            ),
+            ChildAction::SetModel("sonnet".into())
+        );
+        // Clearing the model (Some → None) can't be a live flag toggle → respawn.
+        assert_eq!(
+            child_action(
+                &cfg(
+                    Some(PermissionMode::Auto),
+                    Some("high"),
+                    Some("opus"),
+                    false
+                ),
+                &cfg(Some(PermissionMode::Auto), Some("high"), None, false),
+            ),
+            ChildAction::Respawn
+        );
+        // Setting a model from None is a concrete target → set_model.
+        assert_eq!(
+            child_action(
+                &cfg(Some(PermissionMode::Auto), Some("high"), None, false),
+                &cfg(
+                    Some(PermissionMode::Auto),
+                    Some("high"),
+                    Some("opus"),
+                    false
+                ),
+            ),
+            ChildAction::SetModel("opus".into())
+        );
+        // Permission-mode change → respawn (launch-only).
+        assert_eq!(
+            child_action(
+                &cfg(
+                    Some(PermissionMode::Auto),
+                    Some("high"),
+                    Some("opus"),
+                    false
+                ),
+                &cfg(
+                    Some(PermissionMode::Plan),
+                    Some("high"),
+                    Some("opus"),
+                    false
+                ),
+            ),
+            ChildAction::Respawn
+        );
+        // Effort change → respawn (launch-only).
+        assert_eq!(
+            child_action(
+                &cfg(
+                    Some(PermissionMode::Auto),
+                    Some("high"),
+                    Some("opus"),
+                    false
+                ),
+                &cfg(Some(PermissionMode::Auto), Some("max"), Some("opus"), false),
+            ),
+            ChildAction::Respawn
+        );
+        // Bridge toggling on (a plan turn that got the bridge where the child
+        // didn't have it) → respawn.
+        assert_eq!(
+            child_action(
+                &cfg(Some(PermissionMode::Plan), None, Some("opus"), false),
+                &cfg(Some(PermissionMode::Plan), None, Some("opus"), true),
+            ),
+            ChildAction::Respawn
+        );
+        // Mode-and-model both differing still respawns (launch axis wins over
+        // the model-only set_model shortcut).
+        assert_eq!(
+            child_action(
+                &cfg(Some(PermissionMode::Auto), None, Some("opus"), false),
+                &cfg(Some(PermissionMode::Plan), None, Some("sonnet"), false),
+            ),
+            ChildAction::Respawn
+        );
+    }
+
+    #[test]
+    fn classify_discriminates_control_responses_and_events() {
+        // Success control_response carries the request_id and inner response.
+        assert_eq!(
+            classify_line(
+                r#"{"type":"control_response","response":{"subtype":"success","request_id":"req_1","response":{"ok":true}}}"#
+            ),
+            ClaudeLine::ControlResponse {
+                request_id: "req_1".into(),
+                result: Ok(json!({"ok": true})),
+            }
+        );
+        // Success with no inner response → Ok(Null).
+        assert_eq!(
+            classify_line(
+                r#"{"type":"control_response","response":{"subtype":"success","request_id":"req_2"}}"#
+            ),
+            ClaudeLine::ControlResponse {
+                request_id: "req_2".into(),
+                result: Ok(Value::Null),
+            }
+        );
+        // Error control_response surfaces the message.
+        assert_eq!(
+            classify_line(
+                r#"{"type":"control_response","response":{"subtype":"error","request_id":"req_3","error":"nope"}}"#
+            ),
+            ClaudeLine::ControlResponse {
+                request_id: "req_3".into(),
+                result: Err("nope".into()),
+            }
+        );
+        // A control_response without a request_id is junk, not a panic.
+        assert_eq!(
+            classify_line(r#"{"type":"control_response","response":{"subtype":"success"}}"#),
+            ClaudeLine::Junk
+        );
+        // Ordinary stream-json output objects are Events.
+        assert!(matches!(
+            classify_line(r#"{"type":"system","subtype":"init","session_id":"abc"}"#),
+            ClaudeLine::Event(_)
+        ));
+        assert!(matches!(
+            classify_line(r#"{"type":"assistant","message":{"id":"m1","content":[]}}"#),
+            ClaudeLine::Event(_)
+        ));
+        assert!(matches!(
+            classify_line(r#"{"type":"result","subtype":"success","session_id":"abc"}"#),
+            ClaudeLine::Event(_)
+        ));
+        // A control_request FROM the child (bridge rides HTTP, not this stream).
+        assert_eq!(
+            classify_line(r#"{"type":"control_request","request_id":"x","request":{}}"#),
+            ClaudeLine::Junk
+        );
+        // Junk never panics.
+        assert_eq!(classify_line("not json"), ClaudeLine::Junk);
+        assert_eq!(classify_line("{}"), ClaudeLine::Junk);
+    }
+}

--- a/src/local/claude.rs
+++ b/src/local/claude.rs
@@ -311,6 +311,9 @@ async fn spawn_client(spec: &SpawnSpec) -> Result<Arc<ClaudeClient>> {
         "stream-json",
         "--output-format",
         "stream-json",
+        // Stream text/thinking deltas (stream_event lines) instead of only
+        // complete assistant messages — apply_event paints them token by token.
+        "--include-partial-messages",
         "--verbose",
         "--permission-mode",
         claude_permission_mode(spec.config.permission_mode),

--- a/src/local/harness/claude.rs
+++ b/src/local/harness/claude.rs
@@ -590,6 +590,11 @@ struct TurnState {
     /// The native session id from the latest `system/init` or `result` (the
     /// caller applies it to the store per event).
     native_session_id: Option<String>,
+    /// The in-flight assistant message id from the stream's `message_start` —
+    /// deltas carry only a block `index`, so this is what keys them to the
+    /// same `{mid}-{index}` part ids the final complete `assistant` event
+    /// upserts.
+    stream_mid: Option<String>,
 }
 
 /// Fold one stream-json output object into the turn's transcript + `TurnState`.
@@ -600,6 +605,52 @@ struct TurnState {
 /// job, keeping this store-free.
 fn apply_event(ctx: &mut TurnCtx, state: &mut TurnState, event: &Value) -> bool {
     match event.get("type").and_then(Value::as_str) {
+        // Partial-message deltas (opt-in via --include-partial-messages): the
+        // text/thinking streams token by token instead of landing as one block
+        // when the complete `assistant` event arrives. Deltas build a part
+        // under the same `{mid}-{index}` id that the final event upserts, so
+        // the authoritative full text simply overwrites the accumulated one.
+        Some("stream_event") => {
+            // A subagent's nested stream (parent_tool_use_id set) would
+            // interleave its text into the transcript — main loop only.
+            if !event.get("parent_tool_use_id").is_none_or(|v| v.is_null()) {
+                return false;
+            }
+            let inner = event.get("event").unwrap_or(&Value::Null);
+            match inner.get("type").and_then(Value::as_str) {
+                Some("message_start") => {
+                    if let Some(mid) = inner.pointer("/message/id").and_then(Value::as_str) {
+                        state.stream_mid = Some(mid.to_string());
+                    }
+                }
+                Some("content_block_delta") => {
+                    let (Some(mid), Some(index)) = (
+                        state.stream_mid.as_deref(),
+                        inner.get("index").and_then(Value::as_u64),
+                    ) else {
+                        return false;
+                    };
+                    let id = format!("{mid}-{index}");
+                    let delta = inner.get("delta").unwrap_or(&Value::Null);
+                    let (field, reasoning) = match delta.get("type").and_then(Value::as_str) {
+                        Some("text_delta") => ("text", false),
+                        Some("thinking_delta") => ("thinking", true),
+                        _ => return false,
+                    };
+                    if let Some(text) = delta.get(field).and_then(Value::as_str) {
+                        if !ctx.assistant.parts.iter().any(|p| p.id == id) {
+                            ctx.upsert_part(if reasoning {
+                                WirePart::reasoning(id.clone(), "")
+                            } else {
+                                WirePart::text(id.clone(), "")
+                            });
+                        }
+                        ctx.append_part_text(&id, text);
+                    }
+                }
+                _ => {}
+            }
+        }
         Some("system") => {
             if event.get("subtype").and_then(Value::as_str) == Some("init") {
                 if let Some(sid) = event.get("session_id").and_then(Value::as_str) {
@@ -1096,6 +1147,46 @@ mod tests {
             err.state.as_ref().unwrap().error.as_deref(),
             Some("claude: boom")
         );
+    }
+
+    #[test]
+    fn stream_deltas_paint_parts_and_the_final_event_overwrites_them() {
+        // Deltas accumulate under {mid}-{index}; the complete assistant event
+        // then upserts the authoritative text over the very same part — one
+        // part, no duplicate, final text wins.
+        let transcript = [
+            r#"{"type":"system","subtype":"init","session_id":"sd1"}"#,
+            r#"{"type":"stream_event","event":{"type":"message_start","message":{"id":"m9"}},"parent_tool_use_id":null}"#,
+            r#"{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"hmm"}},"parent_tool_use_id":null}"#,
+            r#"{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Riv"}},"parent_tool_use_id":null}"#,
+            r#"{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"ers flow."}},"parent_tool_use_id":null}"#,
+            r#"{"type":"assistant","message":{"id":"m9","content":[{"type":"thinking","thinking":"hmm"},{"type":"text","text":"Rivers flow."}]}}"#,
+            r#"{"type":"result","subtype":"success","session_id":"sd1","is_error":false}"#,
+        ];
+        let mut ctx = TurnCtx::test_stub();
+        let state = fold(&mut ctx, false, &transcript);
+        let parts = &ctx.assistant.parts;
+        assert_eq!(parts.len(), 2, "{parts:?}");
+        assert_eq!(parts[0].kind, "reasoning");
+        assert_eq!(parts[0].text.as_deref(), Some("hmm"));
+        assert_eq!(parts[1].kind, "text");
+        assert_eq!(parts[1].text.as_deref(), Some("Rivers flow."));
+        // The final assistant event still feeds last_text (plan synthesis).
+        assert_eq!(state.last_text, "Rivers flow.");
+    }
+
+    #[test]
+    fn subagent_stream_deltas_are_ignored() {
+        // A Task subagent's nested stream carries parent_tool_use_id — its
+        // deltas must not paint the main transcript.
+        let transcript = [
+            r#"{"type":"stream_event","event":{"type":"message_start","message":{"id":"sub"}},"parent_tool_use_id":"toolu_1"}"#,
+            r#"{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"nested"}},"parent_tool_use_id":"toolu_1"}"#,
+            r#"{"type":"result","subtype":"success","session_id":"s","is_error":false}"#,
+        ];
+        let mut ctx = TurnCtx::test_stub();
+        fold(&mut ctx, false, &transcript);
+        assert!(ctx.assistant.parts.is_empty(), "{:?}", ctx.assistant.parts);
     }
 
     #[test]

--- a/src/local/harness/claude.rs
+++ b/src/local/harness/claude.rs
@@ -354,10 +354,11 @@ pub(crate) fn write_plan_settings(repo: &std::path::Path) -> Result<PathBuf> {
     Ok(path)
 }
 
-/// Write the per-turn `--mcp-config` file pointing Claude at `orx mcp-gate`
+/// Write the per-spawn `--mcp-config` file pointing Claude at `orx mcp-gate`
 /// (this same binary) and return its path. The bridge's env block carries the
-/// `orx up` port, the session id, and a fresh per-turn token — everything the
-/// child needs to relay permission requests back to the running server.
+/// `orx up` port, the session id, and a fresh per-child token minted at spawn —
+/// everything the resident bridge needs to relay permission requests back to
+/// the running server for the child's whole life.
 pub(crate) fn write_mcp_config(
     repo: &std::path::Path,
     up_port: u16,
@@ -393,7 +394,7 @@ pub(crate) fn write_mcp_config(
 /// Session reasoning id → Claude Code `--effort` value. The composer only
 /// offers ids from `CLAUDE_EFFORT_LEVELS`, so an unrecognized/absent value just
 /// omits the flag and lets the CLI apply its own default (`high`).
-pub(crate) fn claude_effort(level: Option<&str>) -> Option<&str> {
+fn claude_effort(level: Option<&str>) -> Option<&str> {
     let level = level?;
     CLAUDE_EFFORT_LEVELS
         .iter()
@@ -792,7 +793,7 @@ async fn run_turn(ctx: &mut TurnCtx) -> Result<()> {
     // reused child costs nothing, a model-only change retunes live, a launch-flag
     // change (or a crash) respawns with `--resume`.
     let spec = SpawnSpec {
-        host: ctx.host.claude.clone(),
+        chat: ctx.host.clone(),
         session_id: ctx.session_id.clone(),
         repo,
         playbook,
@@ -1095,6 +1096,37 @@ mod tests {
             err.state.as_ref().unwrap().error.as_deref(),
             Some("claude: boom")
         );
+    }
+
+    #[test]
+    fn result_without_is_error_falls_back_to_subtype() {
+        // The CLI can omit `is_error`; a non-"success" subtype must still fail
+        // the turn (the `.unwrap_or(subtype != "success")` fallback).
+        let transcript = [
+            r#"{"type":"system","subtype":"init","session_id":"s2"}"#,
+            r#"{"type":"result","subtype":"error_during_execution","result":"boom"}"#,
+        ];
+        let mut ctx = TurnCtx::test_stub();
+        let state = fold(&mut ctx, false, &transcript);
+        assert!(state.saw_result);
+        assert!(state.turn_errored);
+    }
+
+    #[test]
+    fn errored_tool_result_flips_the_tool_part_to_error() {
+        let transcript = [
+            r#"{"type":"system","subtype":"init","session_id":"s3"}"#,
+            r#"{"type":"assistant","message":{"id":"m1","content":[{"type":"tool_use","id":"call_1","name":"Bash","input":{"command":"false"}}]}}"#,
+            r#"{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"call_1","is_error":true,"content":"exit 1"}]}}"#,
+            r#"{"type":"result","subtype":"success","session_id":"s3","is_error":false}"#,
+        ];
+        let mut ctx = TurnCtx::test_stub();
+        let state = fold(&mut ctx, false, &transcript);
+        assert!(!state.turn_errored, "a failed tool is not a failed turn");
+        let tool = ctx.assistant.parts[0].state.as_ref().unwrap();
+        assert_eq!(tool.status, "error");
+        assert_eq!(tool.error.as_deref(), Some("exit 1"));
+        assert_eq!(tool.output, None);
     }
 
     #[test]

--- a/src/local/harness/claude.rs
+++ b/src/local/harness/claude.rs
@@ -610,6 +610,10 @@ fn apply_event(ctx: &mut TurnCtx, state: &mut TurnState, event: &Value) -> bool 
         // when the complete `assistant` event arrives. Deltas build a part
         // under the same `{mid}-{index}` id that the final event upserts, so
         // the authoritative full text simply overwrites the accumulated one.
+        // That overwrite (and part ordering) leans on two stream-protocol
+        // invariants: the stream's message id equals the final assistant
+        // event's, and a block's `index` is its position in the final content
+        // array, with blocks streamed in ascending order.
         Some("stream_event") => {
             // A subagent's nested stream (parent_tool_use_id set) would
             // interleave its text into the transcript — main loop only.

--- a/src/local/harness/claude.rs
+++ b/src/local/harness/claude.rs
@@ -1,33 +1,34 @@
 //! Claude Code harness.
 //!
-//! Chat: one `claude --print` process per turn, stream-json on stdout,
-//! multi-turn via `--resume` against Claude Code's own session store. The
+//! Chat: one *resident* `claude --print --input-format stream-json` child per
+//! chat session (`local::claude::ClaudeHost`), reused across turns — each turn
+//! sends one user message and folds the child's stream-json output until a
+//! `result` event. The child persists (stable `session_id`, stdin held open),
+//! collapsing the old spawn-per-turn overhead; a config change (permission mode
+//! / effort / bridge), interrupt, or crash respawns it with `--resume`. The
 //! playbook rides `--append-system-prompt-file`; the permission mode is
 //! `--permission-mode` from the session's setting (`auto`/`bypass` — see
 //! `options`). AskUserQuestion / ExitPlanMode surface as interactive cards: the
-//! turn ends on them and the user's answer resumes the session — except in
-//! plan mode, where the mcp-gate bridge holds both open mid-turn and the
-//! answer continues the same turn.
+//! turn ends on them and the user's answer resumes the session — except in plan
+//! mode, where the mcp-gate bridge holds both open mid-turn and the answer
+//! continues the same turn.
 //!
 //! Detection: `~/.claude.json` carries the signed-in OAuth account (no secrets
 //! read); `ANTHROPIC_API_KEY` is the api-key fallback.
 
 use std::path::PathBuf;
-use std::process::Stdio;
 
 use async_trait::async_trait;
 use serde_json::Value;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::process::Command;
 
 use super::detect::{bin_version, find_on_path, nonempty_str, read_json, HarnessInfo};
 use super::options::{HarnessOptions, PermissionMode};
 use super::{Harness, ResumeAction};
 use crate::error::{anyhow, Result};
 use crate::local::chat::{
-    prepare_env, PromptAnswer, ResumeCtx, TurnCtx, WirePart, WirePrompt, WireQuestionOption,
-    WireToolState,
+    PromptAnswer, ResumeCtx, TurnCtx, WirePart, WirePrompt, WireQuestionOption, WireToolState,
 };
+use crate::local::claude::{SpawnConfig, SpawnSpec, TurnEvent};
 use crate::local::opencode::ensure_playbook;
 
 /// Each harness runs directly (its own CLI, the user's own login), so its
@@ -52,7 +53,7 @@ const CLAUDE_EFFORT_LEVELS: [(&str, &str); 5] = [
 pub struct ClaudeCode;
 
 /// `claude` on PATH, else the common install drop locations.
-pub fn find_claude() -> Option<PathBuf> {
+pub(crate) fn find_claude() -> Option<PathBuf> {
     find_on_path("claude").or_else(|| {
         let home = dirs::home_dir()?;
         [".claude/local/claude", ".local/bin/claude"]
@@ -296,7 +297,7 @@ impl Harness for ClaudeCode {
 /// harness-agnostic (`ask`/`accept-edits`/`bypass`), so this is where the enum
 /// is spelled back into Claude's own CLI vocabulary; `Auto` is the default when
 /// the session hasn't picked a mode.
-fn claude_permission_mode(mode: Option<PermissionMode>) -> &'static str {
+pub(crate) fn claude_permission_mode(mode: Option<PermissionMode>) -> &'static str {
     match mode.unwrap_or(PermissionMode::Auto) {
         PermissionMode::Ask => "default",
         PermissionMode::AcceptEdits => "acceptEdits",
@@ -325,7 +326,7 @@ const MCP_CONFIG_REL: &str = ".openresearch/agent/claude-mcp.json";
 ///
 /// The hook command is this executable's absolute path, so it resolves without
 /// depending on `orx` being on Claude's `PATH`.
-fn write_plan_settings(repo: &std::path::Path) -> Result<PathBuf> {
+pub(crate) fn write_plan_settings(repo: &std::path::Path) -> Result<PathBuf> {
     let orx = std::env::current_exe()
         .map_err(|e| anyhow!("cannot resolve orx binary path for plan-mode hook: {e}"))?;
     let hook = serde_json::json!([{
@@ -357,7 +358,7 @@ fn write_plan_settings(repo: &std::path::Path) -> Result<PathBuf> {
 /// (this same binary) and return its path. The bridge's env block carries the
 /// `orx up` port, the session id, and a fresh per-turn token — everything the
 /// child needs to relay permission requests back to the running server.
-fn write_mcp_config(
+pub(crate) fn write_mcp_config(
     repo: &std::path::Path,
     up_port: u16,
     session_id: &str,
@@ -392,7 +393,7 @@ fn write_mcp_config(
 /// Session reasoning id → Claude Code `--effort` value. The composer only
 /// offers ids from `CLAUDE_EFFORT_LEVELS`, so an unrecognized/absent value just
 /// omits the flag and lets the CLI apply its own default (`high`).
-fn claude_effort(level: Option<&str>) -> Option<&str> {
+pub(crate) fn claude_effort(level: Option<&str>) -> Option<&str> {
     let level = level?;
     CLAUDE_EFFORT_LEVELS
         .iter()
@@ -564,306 +565,330 @@ fn result_text(content: &Value) -> String {
     }
 }
 
+/// The per-turn state `apply_event` folds each stream-json line into. Kept
+/// store-free so the caller (not the fold) owns every side effect — the native
+/// session id is applied per event by `run_turn`, and every flush happens there
+/// too, which is what lets the fold run against a bare `TurnCtx::test_stub()` in
+/// the fixture tests.
+#[derive(Default)]
+struct TurnState {
+    /// Whether this child was spawned with the mcp-gate bridge active. With the
+    /// bridge on, ExitPlanMode / AskUserQuestion come from the bridge (held,
+    /// mid-turn-answerable), so their `tool_use` renders nothing.
+    bridge_active: bool,
+    /// The `result` event has landed — the turn is over.
+    saw_result: bool,
+    /// An interactive card was surfaced this turn (suppresses the synthesized
+    /// plan card — see `should_synthesize_plan`).
+    saw_prompt: bool,
+    /// The turn ended with a genuine failure (drives the error path).
+    turn_errored: bool,
+    /// The last non-empty assistant text block — the plan, if the model wrote
+    /// one as plain text.
+    last_text: String,
+    /// The native session id from the latest `system/init` or `result` (the
+    /// caller applies it to the store per event).
+    native_session_id: Option<String>,
+}
+
+/// Fold one stream-json output object into the turn's transcript + `TurnState`.
+/// Pure w.r.t. the store — touches only `ctx.assistant.parts` (via the TurnCtx
+/// helpers) and `state` — so it is fixture-tested against `TurnCtx::test_stub()`.
+/// Returns `true` when this event is the terminal `result` (the caller stops
+/// the recv loop). Native-session-id application and flushing are the caller's
+/// job, keeping this store-free.
+fn apply_event(ctx: &mut TurnCtx, state: &mut TurnState, event: &Value) -> bool {
+    match event.get("type").and_then(Value::as_str) {
+        Some("system") => {
+            if event.get("subtype").and_then(Value::as_str) == Some("init") {
+                if let Some(sid) = event.get("session_id").and_then(Value::as_str) {
+                    state.native_session_id = Some(sid.to_string());
+                }
+            }
+        }
+        Some("assistant") => {
+            let mid = event
+                .pointer("/message/id")
+                .and_then(Value::as_str)
+                .unwrap_or("m")
+                .to_string();
+            let blocks = event
+                .pointer("/message/content")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default();
+            for (i, block) in blocks.iter().enumerate() {
+                match block.get("type").and_then(Value::as_str) {
+                    Some("text") => {
+                        let text = block.get("text").and_then(Value::as_str).unwrap_or("");
+                        if !text.trim().is_empty() {
+                            state.last_text = text.to_string();
+                        }
+                        ctx.upsert_part(WirePart::text(format!("{mid}-{i}"), text));
+                    }
+                    Some("thinking") => {
+                        let text = block.get("thinking").and_then(Value::as_str).unwrap_or("");
+                        ctx.upsert_part(WirePart::reasoning(format!("{mid}-{i}"), text));
+                    }
+                    Some("tool_use") => {
+                        let id = block
+                            .get("id")
+                            .and_then(Value::as_str)
+                            .unwrap_or(&format!("{mid}-{i}"))
+                            .to_string();
+                        let name = block.get("name").and_then(Value::as_str).unwrap_or("");
+                        let input = block.get("input");
+                        // ExitPlanMode / AskUserQuestion surface as interactive
+                        // prompt cards instead of plain tool rows, and the user's
+                        // choice resumes the session. With the bridge active,
+                        // BOTH cards come from the bridge instead (held,
+                        // mid-turn-answerable) and the tool_use renders NOTHING:
+                        // a tool row would duplicate the card — and the denial
+                        // that carries the user's answer back would paint it as a
+                        // spurious error row once the tool_result lands.
+                        if state.bridge_active && matches!(name, "ExitPlanMode" | "AskUserQuestion")
+                        {
+                            continue;
+                        }
+                        if let Some(prompt) =
+                            plan_prompt(name, input).or_else(|| question_prompt(name, input))
+                        {
+                            state.saw_prompt = true;
+                            ctx.upsert_part(WirePart::prompt(id, prompt));
+                        } else {
+                            ctx.upsert_part(WirePart {
+                                id,
+                                kind: "tool".into(),
+                                text: None,
+                                tool: Some(name.to_string()),
+                                state: Some(WireToolState {
+                                    status: "running".into(),
+                                    input: input.map(normalize_input),
+                                    output: None,
+                                    error: None,
+                                    title: None,
+                                }),
+                                prompt: None,
+                            });
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Some("user") => {
+            // Synthetic tool-result turns: complete the matching tool part.
+            let blocks = event
+                .pointer("/message/content")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default();
+            for block in &blocks {
+                if block.get("type").and_then(Value::as_str) != Some("tool_result") {
+                    continue;
+                }
+                let Some(tool_id) = block.get("tool_use_id").and_then(Value::as_str) else {
+                    continue;
+                };
+                let is_error = block
+                    .get("is_error")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                let text = block.get("content").map(result_text).unwrap_or_default();
+                if let Some(part) = ctx.assistant.parts.iter_mut().find(|p| p.id == tool_id) {
+                    if let Some(state) = part.state.as_mut() {
+                        state.status = if is_error { "error" } else { "completed" }.into();
+                        if is_error {
+                            state.error = Some(text.clone());
+                        } else {
+                            state.output = Some(text.clone());
+                        }
+                    }
+                }
+            }
+        }
+        Some("result") => {
+            state.saw_result = true;
+            // Resume mints a fresh session id per turn — track the latest.
+            if let Some(sid) = event.get("session_id").and_then(Value::as_str) {
+                state.native_session_id = Some(sid.to_string());
+            }
+            // We deliberately do NOT turn `permission_denials` into approve-me
+            // cards. Headless has no interactive approval, and of the modes we
+            // offer, only Plan produces denials — and those are *expected*
+            // (read-only by design). Surfacing an "Allow" that re-ran the turn
+            // under bypass would silently defeat plan mode. The model already
+            // narrates the block in text; the recourse is approving the plan
+            // (the ExitPlanMode card), which leaves plan mode. Auto/Bypass never
+            // deny in the first place.
+            //
+            // A plan pause is NOT a failure: the CLI records the blocked tools
+            // in `permission_denials` but still reports `subtype: "success"` /
+            // `is_error: false`. So drive the error path off the result status
+            // alone — a genuine failure is still surfaced.
+            let subtype = event.get("subtype").and_then(Value::as_str).unwrap_or("");
+            let is_error = event
+                .get("is_error")
+                .and_then(Value::as_bool)
+                .unwrap_or(subtype != "success");
+            if is_error {
+                state.turn_errored = true;
+                let detail = event
+                    .get("result")
+                    .and_then(Value::as_str)
+                    .unwrap_or(subtype)
+                    .to_string();
+                ctx.push_error(format!("claude: {detail}"));
+            }
+            return true;
+        }
+        _ => {}
+    }
+    false
+}
+
+/// The reasoning-level → `--effort` value the spawn config carries. Split out so
+/// the harness and the host agree on exactly what the child was launched with.
+fn spawn_config(ctx: &TurnCtx) -> SpawnConfig {
+    SpawnConfig {
+        permission_mode: ctx.permission_mode,
+        effort: claude_effort(ctx.reasoning_level.as_deref()).map(str::to_string),
+        model: ctx.model.clone(),
+        // The turn WANTS the bridge iff it's plan mode under a bound `orx up`
+        // port; whether the bridge was actually achieved is recorded on the
+        // spawned child's config (a failed write leaves it false and the next
+        // plan turn respawns). Keeping the wanted value here means a plan turn
+        // reconciles against a child that already has the bridge and reuses it.
+        bridge_active: ctx.permission_mode == Some(PermissionMode::Plan)
+            && ctx.host.up_port().is_some(),
+    }
+}
+
 async fn run_turn(ctx: &mut TurnCtx) -> Result<()> {
-    let bin = find_claude().ok_or_else(|| {
-        anyhow!("claude not found on PATH — install Claude Code and run `claude` once to sign in")
-    })?;
     let project = ctx.project.clone();
     let session_id = ctx.session_id.clone();
     // The modular orx skills land in the harness's session-skills dir, fresh,
-    // for this session's agent to auto-load — source of truth is the trait.
+    // for this session's agent to auto-load — source of truth is the trait. Run
+    // per turn (worktree + skills refresh); the resident child re-reads the
+    // playbook only on respawn, same tradeoff as codex (see opencode.rs's
+    // playbook-freshness comment).
     let skills_dir = ClaudeCode.session_skills_dir();
     let (repo, playbook) =
         tokio::task::spawn_blocking(move || ensure_playbook(&project, &session_id, skills_dir))
             .await
             .map_err(|e| anyhow!("playbook task failed: {e}"))??;
 
-    let mut cmd = Command::new(&bin);
-    cmd.args([
-        "--print",
-        "--output-format",
-        "stream-json",
-        "--verbose",
-        "--permission-mode",
-        claude_permission_mode(ctx.permission_mode),
-    ])
-    // AskUserQuestion and ExitPlanMode are now surfaced to the user as
-    // interactive cards (see plan_prompt / question_prompt) instead of being
-    // disallowed; the turn ends on them and the answer resumes the session —
-    // unless the plan-mode bridge is active, which holds them open mid-turn.
-    .arg("--append-system-prompt-file")
-    .arg(&playbook)
-    .current_dir(&repo)
-    .stdin(Stdio::piped())
-    .stdout(Stdio::piped())
-    .stderr(Stdio::from(crate::local::chat::harness_log("claude")?))
-    .kill_on_drop(true);
-    if let Some(model) = &ctx.model {
-        cmd.args(["--model", model]);
-    }
-    // Reasoning level maps directly to Claude Code's `--effort` flag.
-    if let Some(effort) = claude_effort(ctx.reasoning_level.as_deref()) {
-        cmd.args(["--effort", effort]);
-    }
-    if let Some(native_id) = &ctx.native_session_id {
-        cmd.args(["--resume", native_id]);
-    }
-    // In plan mode, two per-turn files change what the CLI gates:
-    //  * `--settings` wires the `orx plan-gate` PreToolUse hook — read-only
-    //    inspection allowed, ExitPlanMode forced to `ask` (headless would
-    //    self-approve it otherwise).
-    //  * `--mcp-config` + `--permission-prompt-tool` wire the `orx mcp-gate`
-    //    bridge: every permission the CLI would have prompted for interactively
-    //    is relayed to `orx up`, which surfaces a card and holds the call open
-    //    until the user answers — desktop-style mid-turn approvals.
-    // Both are best-effort: without them plan mode degrades to its default
-    // gating (denials) rather than failing the turn. On CLI versions without
-    // `--permission-prompt-tool` the flag is silently ignored (verified), so no
-    // version gate is needed.
-    let mut bridge_active = false;
-    if ctx.permission_mode == Some(PermissionMode::Plan) {
-        match write_plan_settings(&repo) {
-            Ok(path) => {
-                cmd.arg("--settings").arg(path);
-            }
-            Err(e) => {
-                eprintln!(
-                    "orx up: plan-mode settings not written, orx inspection will be gated: {e}"
-                );
-            }
-        }
-        // Without a bound port (not under `orx up`) there's no HTTP surface to
-        // relay approvals to — skip the bridge.
-        if let Some(port) = ctx.host.up_port() {
-            let token = ctx.host.mint_gate_token(&ctx.session_id);
-            match write_mcp_config(&repo, port, &ctx.session_id, &token) {
-                Ok(path) => {
-                    cmd.arg("--mcp-config").arg(path);
-                    cmd.args(["--permission-prompt-tool", "mcp__orx__approve"]);
-                    // Give a held approval an hour before the CLI abandons
-                    // the tool call; orx denies at 55 min, safely inside it.
-                    cmd.env("MCP_TOOL_TIMEOUT", "3600000");
-                    bridge_active = true;
-                }
-                Err(e) => {
-                    eprintln!(
-                        "orx up: mcp bridge not configured, gray-area tools will be denied: {e}"
-                    );
-                }
-            }
-        }
-    }
-    prepare_env(&mut cmd);
-
-    let mut child = cmd
-        .spawn()
-        .map_err(|e| anyhow!("Could not spawn {}: {}", bin.display(), e))?;
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin.write_all(ctx.text.as_bytes()).await?;
-        // Dropped here: EOF is what tells --print the prompt is complete.
-    }
-    let stdout = child.stdout.take().ok_or_else(|| anyhow!("no stdout"))?;
-    let mut lines = BufReader::new(stdout).lines();
-    let mut saw_result = false;
-    // Synthesized-plan-card tracking (see `should_synthesize_plan`): whether
-    // any interactive card was surfaced, whether the turn errored, and the
-    // last non-empty text block — the plan, if the model wrote one as text.
-    // Clear any bridge-card flag a previous aborted turn left behind so it
-    // can't suppress this turn's fallback.
     let plan_mode = ctx.permission_mode == Some(PermissionMode::Plan);
+    // Clear any bridge-card flag a previous aborted turn left behind so it can't
+    // suppress this turn's fallback.
     let _ = ctx.host.take_bridge_prompted(&ctx.session_id);
     // Sweep zombie HELD cards (native_id) a crashed/restarted process left
-    // unresolved: they can never be answered again, and once this turn makes
-    // the session busy one could capture the composer's typed-text routing.
-    // End-turn cards are deliberately left alone — they resume via --resume.
+    // unresolved: they can never be answered again, and once this turn makes the
+    // session busy one could capture the composer's typed-text routing. End-turn
+    // cards are deliberately left alone — they resume via --resume.
     let _ = ctx.host.resolve_stale_prompts(&ctx.session_id, true).await;
-    let mut saw_prompt = false;
-    let mut turn_errored = false;
-    let mut last_text = String::new();
 
-    while let Some(line) = lines.next_line().await? {
-        let Ok(event) = serde_json::from_str::<Value>(&line) else {
-            continue;
+    // Ensure the session's resident child, reconciled to this turn's config: a
+    // reused child costs nothing, a model-only change retunes live, a launch-flag
+    // change (or a crash) respawns with `--resume`.
+    let spec = SpawnSpec {
+        host: ctx.host.claude.clone(),
+        session_id: ctx.session_id.clone(),
+        repo,
+        playbook,
+        resume: ctx.native_session_id.clone(),
+        config: spawn_config(ctx),
+    };
+    let client = ctx.host.claude.ensure(spec).await?;
+    // The child records what bridge state it ACHIEVED — a failed mcp-config write
+    // leaves it false even in plan mode. Drive card suppression off that, not the
+    // wanted value.
+    let bridge_active = client.config().bridge_active;
+
+    // Route events to this turn before sending the message — nothing is missed.
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let _route = client.register_turn(tx);
+    if let Err(e) = client.send_user_message(&ctx.text).await {
+        // The child is unusable (stdin gone). Kill it so the next turn respawns
+        // with `--resume` and recovers this session's context.
+        ctx.host.claude.kill_session(&ctx.session_id).await;
+        return Err(anyhow!(
+            "claude stdin write failed: {e}; see {}",
+            crate::store::data_dir().join("agent-claude.log").display()
+        ));
+    }
+
+    let mut state = TurnState {
+        bridge_active,
+        ..Default::default()
+    };
+    // Fold events until the turn's `result`. The caller (here) applies the
+    // native session id and flushes per event, keeping `apply_event` store-free.
+    loop {
+        let Some(event) = rx.recv().await else {
+            // The route channel closed without a Closed marker — treat as a
+            // dropped turn; the next turn respawns via `--resume`.
+            break;
         };
-        match event.get("type").and_then(Value::as_str) {
-            Some("system") => {
-                if event.get("subtype").and_then(Value::as_str) == Some("init") {
-                    if let Some(sid) = event.get("session_id").and_then(Value::as_str) {
-                        ctx.set_native_session_id(sid);
-                    }
-                }
-            }
-            Some("assistant") => {
-                let mid = event
-                    .pointer("/message/id")
-                    .and_then(Value::as_str)
-                    .unwrap_or("m")
-                    .to_string();
-                let blocks = event
-                    .pointer("/message/content")
-                    .and_then(Value::as_array)
-                    .cloned()
-                    .unwrap_or_default();
-                for (i, block) in blocks.iter().enumerate() {
-                    match block.get("type").and_then(Value::as_str) {
-                        Some("text") => {
-                            let text = block.get("text").and_then(Value::as_str).unwrap_or("");
-                            if !text.trim().is_empty() {
-                                last_text = text.to_string();
-                            }
-                            ctx.upsert_part(WirePart::text(format!("{mid}-{i}"), text));
-                        }
-                        Some("thinking") => {
-                            let text = block.get("thinking").and_then(Value::as_str).unwrap_or("");
-                            ctx.upsert_part(WirePart::reasoning(format!("{mid}-{i}"), text));
-                        }
-                        Some("tool_use") => {
-                            let id = block
-                                .get("id")
-                                .and_then(Value::as_str)
-                                .unwrap_or(&format!("{mid}-{i}"))
-                                .to_string();
-                            let name = block.get("name").and_then(Value::as_str).unwrap_or("");
-                            let input = block.get("input");
-                            // ExitPlanMode / AskUserQuestion surface as interactive
-                            // prompt cards instead of plain tool rows, and the
-                            // user's choice resumes the session. With the bridge
-                            // active, BOTH cards come from the bridge instead
-                            // (held, mid-turn-answerable) and the tool_use
-                            // renders NOTHING: a tool row would duplicate the
-                            // card — and the denial that carries the user's
-                            // answer back would paint it as a spurious error
-                            // row once the tool_result lands.
-                            if bridge_active && matches!(name, "ExitPlanMode" | "AskUserQuestion") {
-                                continue;
-                            }
-                            if let Some(prompt) =
-                                plan_prompt(name, input).or_else(|| question_prompt(name, input))
-                            {
-                                saw_prompt = true;
-                                ctx.upsert_part(WirePart::prompt(id, prompt));
-                            } else {
-                                ctx.upsert_part(WirePart {
-                                    id,
-                                    kind: "tool".into(),
-                                    text: None,
-                                    tool: Some(name.to_string()),
-                                    state: Some(WireToolState {
-                                        status: "running".into(),
-                                        input: input.map(normalize_input),
-                                        output: None,
-                                        error: None,
-                                        title: None,
-                                    }),
-                                    prompt: None,
-                                });
-                            }
-                        }
-                        _ => {}
-                    }
+        match event {
+            TurnEvent::Line(value) => {
+                let done = apply_event(ctx, &mut state, &value);
+                if let Some(sid) = state.native_session_id.take() {
+                    ctx.set_native_session_id(&sid);
                 }
                 ctx.maybe_flush();
-            }
-            Some("user") => {
-                // Synthetic tool-result turns: complete the matching tool part.
-                let blocks = event
-                    .pointer("/message/content")
-                    .and_then(Value::as_array)
-                    .cloned()
-                    .unwrap_or_default();
-                for block in &blocks {
-                    if block.get("type").and_then(Value::as_str) != Some("tool_result") {
-                        continue;
-                    }
-                    let Some(tool_id) = block.get("tool_use_id").and_then(Value::as_str) else {
-                        continue;
-                    };
-                    let is_error = block
-                        .get("is_error")
-                        .and_then(Value::as_bool)
-                        .unwrap_or(false);
-                    let text = block.get("content").map(result_text).unwrap_or_default();
-                    if let Some(part) = ctx.assistant.parts.iter_mut().find(|p| p.id == tool_id) {
-                        if let Some(state) = part.state.as_mut() {
-                            state.status = if is_error { "error" } else { "completed" }.into();
-                            if is_error {
-                                state.error = Some(text.clone());
-                            } else {
-                                state.output = Some(text.clone());
-                            }
-                        }
-                    }
+                if done {
+                    break;
                 }
-                ctx.maybe_flush();
             }
-            Some("result") => {
-                saw_result = true;
-                // Resume mints a fresh session id per turn — track the latest.
-                if let Some(sid) = event.get("session_id").and_then(Value::as_str) {
-                    ctx.set_native_session_id(sid);
+            TurnEvent::Closed => {
+                // Child died mid-turn (EOF on stdout). The next turn respawns via
+                // `--resume`; surface the failure like the old exit path did.
+                if let Some(sid) = state.native_session_id.take() {
+                    ctx.set_native_session_id(&sid);
                 }
-                // We deliberately do NOT turn `permission_denials` into approve-me
-                // cards. Headless has no interactive approval, and of the modes we
-                // offer, only Plan produces denials — and those are *expected*
-                // (read-only by design). Surfacing an "Allow" that re-ran the turn
-                // under bypass would silently defeat plan mode. The model already
-                // narrates the block in text; the recourse is approving the plan
-                // (the ExitPlanMode card), which leaves plan mode. Auto/Bypass
-                // never deny in the first place.
-                //
-                // A plan pause is NOT a failure: the CLI records the blocked tools
-                // in `permission_denials` but still reports `subtype: "success"` /
-                // `is_error: false`. So drive the error path off the result status
-                // alone — a genuine failure is still surfaced.
-                let subtype = event.get("subtype").and_then(Value::as_str).unwrap_or("");
-                let is_error = event
-                    .get("is_error")
-                    .and_then(Value::as_bool)
-                    .unwrap_or(subtype != "success");
-                if is_error {
-                    turn_errored = true;
-                    let detail = event
-                        .get("result")
-                        .and_then(Value::as_str)
-                        .unwrap_or(subtype)
-                        .to_string();
-                    ctx.push_error(format!("claude: {detail}"));
-                }
-                ctx.maybe_flush();
+                ctx.host.claude.kill_session(&ctx.session_id).await;
+                let _ = ctx.flush();
+                return Err(anyhow!(
+                    "claude exited mid-turn; see {}",
+                    crate::store::data_dir().join("agent-claude.log").display()
+                ));
             }
-            _ => {}
         }
     }
 
-    // The model sometimes ends a plan-mode turn with its plan as plain text
-    // and no ExitPlanMode call. Headless leaves no way out of plan mode then —
-    // only a plan-card answer switches the resume mode, so a chat "yes" would
-    // resume still read-only. Synthesize a card from the final text so
-    // approval always has a handle. A plan/permission card the bridge surfaced
-    // mid-turn counts as "saw a prompt" (e.g. keep-planning continued this
-    // same turn); a mid-turn *question* deliberately does not — its answer is
-    // no exit recourse, and the turn may still end with a texty plan.
-    let saw_prompt = saw_prompt || ctx.host.take_bridge_prompted(&ctx.session_id);
-    if should_synthesize_plan(plan_mode, saw_prompt, turn_errored, &last_text) {
+    // A channel-end without a `result` means the child closed between turns or
+    // the turn was dropped — respawn next turn and report the miss.
+    if !state.saw_result {
+        ctx.host.claude.kill_session(&ctx.session_id).await;
+        let _ = ctx.flush();
+        return Err(anyhow!(
+            "claude ended the turn without a result; see {}",
+            crate::store::data_dir().join("agent-claude.log").display()
+        ));
+    }
+
+    // The model sometimes ends a plan-mode turn with its plan as plain text and
+    // no ExitPlanMode call. Headless leaves no way out of plan mode then — only
+    // a plan-card answer switches the resume mode, so a chat "yes" would resume
+    // still read-only. Synthesize a card from the final text so approval always
+    // has a handle. A plan/permission card the bridge surfaced mid-turn counts
+    // as "saw a prompt" (e.g. keep-planning continued this same turn); a mid-turn
+    // *question* deliberately does not — its answer is no exit recourse, and the
+    // turn may still end with a texty plan.
+    let saw_prompt = state.saw_prompt || ctx.host.take_bridge_prompted(&ctx.session_id);
+    if should_synthesize_plan(plan_mode, saw_prompt, state.turn_errored, &state.last_text) {
         ctx.upsert_part(WirePart::prompt(
             format!("plan-synth-{}", ctx.assistant.id),
             WirePrompt {
                 kind: "plan".into(),
-                plan: Some(last_text),
+                plan: Some(std::mem::take(&mut state.last_text)),
                 synthesized: true,
                 ..Default::default()
             },
         ));
-        ctx.maybe_flush();
     }
-
-    let status = child.wait().await?;
-    if !status.success() && !saw_result {
-        return Err(anyhow!(
-            "claude exited with {status}; see {}",
-            crate::store::data_dir().join("agent-claude.log").display()
-        ));
-    }
+    let _ = ctx.flush();
     Ok(())
 }
 
@@ -990,5 +1015,151 @@ mod tests {
         // A Codex-only id like a bare "medium" is fine (shared), but junk is not.
         assert_eq!(claude_effort(Some("ultra")), None);
         assert_eq!(claude_effort(None), None);
+    }
+
+    /// Fold a hand-written stream-json transcript through `apply_event` against a
+    /// bare `TurnCtx::test_stub()` — the store-free property. Returns the final
+    /// state; asserts the fold stops on the `result` event and no earlier.
+    fn fold(ctx: &mut TurnCtx, bridge_active: bool, lines: &[&str]) -> TurnState {
+        let mut state = TurnState {
+            bridge_active,
+            ..Default::default()
+        };
+        for line in lines {
+            let event: Value = serde_json::from_str(line).expect("valid stream-json line");
+            let done = apply_event(ctx, &mut state, &event);
+            assert_eq!(
+                done,
+                event.get("type").and_then(Value::as_str) == Some("result"),
+                "only the result event ends the fold: {line}"
+            );
+            if done {
+                break;
+            }
+        }
+        state
+    }
+
+    #[test]
+    fn plain_turn_folds_text_thinking_and_tool_lifecycle() {
+        let transcript = [
+            r#"{"type":"system","subtype":"init","session_id":"sess-abc"}"#,
+            r#"{"type":"assistant","message":{"id":"m1","content":[{"type":"thinking","thinking":"pondering"},{"type":"text","text":"Reading the file."}]}}"#,
+            r#"{"type":"assistant","message":{"id":"m1","content":[{"type":"tool_use","id":"call_1","name":"Read","input":{"file_path":"/x/y.rs"}}]}}"#,
+            r#"{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"call_1","content":"fn main() {}"}]}}"#,
+            r#"{"type":"result","subtype":"success","session_id":"sess-abc","is_error":false}"#,
+        ];
+        let mut ctx = TurnCtx::test_stub();
+        let state = fold(&mut ctx, false, &transcript);
+
+        assert!(state.saw_result);
+        assert!(!state.turn_errored);
+        assert!(!state.saw_prompt);
+        assert_eq!(state.native_session_id.as_deref(), Some("sess-abc"));
+        assert_eq!(state.last_text, "Reading the file.");
+
+        let parts = &ctx.assistant.parts;
+        // thinking (m1-0), text (m1-1), tool (call_1) — three distinct parts.
+        assert_eq!(parts.len(), 3, "{parts:?}");
+        assert_eq!(parts[0].kind, "reasoning");
+        assert_eq!(parts[0].text.as_deref(), Some("pondering"));
+        assert_eq!(parts[1].kind, "text");
+        assert_eq!(parts[1].text.as_deref(), Some("Reading the file."));
+        // The tool_result completed the tool part in place, with the input
+        // normalized (file_path → filePath for the UI summary).
+        assert_eq!(parts[2].kind, "tool");
+        let tool = parts[2].state.as_ref().unwrap();
+        assert_eq!(tool.status, "completed");
+        assert_eq!(tool.output.as_deref(), Some("fn main() {}"));
+        assert_eq!(tool.input.as_ref().unwrap()["filePath"], "/x/y.rs");
+    }
+
+    #[test]
+    fn error_result_flags_the_turn_and_pushes_an_error_part() {
+        let transcript = [
+            r#"{"type":"system","subtype":"init","session_id":"s1"}"#,
+            r#"{"type":"result","subtype":"error_during_execution","is_error":true,"result":"boom"}"#,
+        ];
+        let mut ctx = TurnCtx::test_stub();
+        let state = fold(&mut ctx, false, &transcript);
+        assert!(state.saw_result);
+        assert!(state.turn_errored);
+        // The error part carries the CLI's detail, prefixed.
+        let err = ctx
+            .assistant
+            .parts
+            .iter()
+            .find(|p| p.tool.as_deref() == Some("error"))
+            .expect("error part");
+        assert_eq!(
+            err.state.as_ref().unwrap().error.as_deref(),
+            Some("claude: boom")
+        );
+    }
+
+    #[test]
+    fn plan_mode_texty_plan_flags_synthesize() {
+        // Plan mode, no ExitPlanMode call — the model just wrote its plan as
+        // text. saw_prompt stays false and the text is captured, so the run_turn
+        // fallback (should_synthesize_plan) would synthesize a plan card.
+        let transcript = [
+            r#"{"type":"system","subtype":"init","session_id":"p1"}"#,
+            r#"{"type":"assistant","message":{"id":"m1","content":[{"type":"text","text":"Here is my plan: step one, step two."}]}}"#,
+            r#"{"type":"result","subtype":"success","session_id":"p1","is_error":false}"#,
+        ];
+        let mut ctx = TurnCtx::test_stub();
+        let state = fold(&mut ctx, false, &transcript);
+        assert!(!state.saw_prompt);
+        assert!(!state.turn_errored);
+        assert!(should_synthesize_plan(
+            true,
+            state.saw_prompt,
+            state.turn_errored,
+            &state.last_text
+        ));
+
+        // An ExitPlanMode call instead sets saw_prompt and suppresses the card.
+        let with_card = [
+            r#"{"type":"assistant","message":{"id":"m2","content":[{"type":"tool_use","id":"c1","name":"ExitPlanMode","input":{"plan":"do it"}}]}}"#,
+            r#"{"type":"result","subtype":"success","session_id":"p1","is_error":false}"#,
+        ];
+        let mut ctx = TurnCtx::test_stub();
+        let state = fold(&mut ctx, false, &with_card);
+        assert!(state.saw_prompt);
+        assert!(!should_synthesize_plan(
+            true,
+            state.saw_prompt,
+            state.turn_errored,
+            &state.last_text
+        ));
+        // The ExitPlanMode surfaced as a plan prompt card, not a tool row.
+        let card = ctx
+            .assistant
+            .parts
+            .iter()
+            .find(|p| p.kind == "prompt")
+            .unwrap();
+        assert_eq!(card.prompt.as_ref().unwrap().kind, "plan");
+    }
+
+    #[test]
+    fn bridge_active_suppresses_exitplanmode_and_question_rows() {
+        // With the bridge on, the CLI relays ExitPlanMode / AskUserQuestion as
+        // held bridge cards; their tool_use must render NOTHING (a duplicate row,
+        // then a spurious error row when the answer-denial's tool_result lands).
+        let transcript = [
+            r#"{"type":"assistant","message":{"id":"m1","content":[{"type":"tool_use","id":"c1","name":"ExitPlanMode","input":{"plan":"p"}}]}}"#,
+            r#"{"type":"assistant","message":{"id":"m2","content":[{"type":"tool_use","id":"c2","name":"AskUserQuestion","input":{"questions":[{"question":"which?","header":"h","options":[]}]}}]}}"#,
+            r#"{"type":"assistant","message":{"id":"m3","content":[{"type":"tool_use","id":"c3","name":"Bash","input":{"command":"ls"}}]}}"#,
+            r#"{"type":"result","subtype":"success","session_id":"b1","is_error":false}"#,
+        ];
+        let mut ctx = TurnCtx::test_stub();
+        let state = fold(&mut ctx, true, &transcript);
+        assert!(state.saw_result);
+        // Only the Bash tool part survives; the two bridge-owned calls render
+        // nothing, and neither sets saw_prompt (the bridge tracks that itself).
+        assert!(!state.saw_prompt);
+        assert_eq!(ctx.assistant.parts.len(), 1, "{:?}", ctx.assistant.parts);
+        assert_eq!(ctx.assistant.parts[0].tool.as_deref(), Some("Bash"));
     }
 }

--- a/src/local/harness/codex.rs
+++ b/src/local/harness/codex.rs
@@ -2665,6 +2665,7 @@ mod tests {
             host: std::sync::Arc::new(crate::local::chat::ChatHost::new(
                 std::sync::Arc::new(crate::local::opencode::AgentHost::new(None)),
                 std::sync::Arc::new(crate::local::codex::CodexHost::new()),
+                std::sync::Arc::new(crate::local::claude::ClaudeHost::new()),
             )),
             session_id: "s".into(),
             native_session_id: None,

--- a/src/local/harness/mod.rs
+++ b/src/local/harness/mod.rs
@@ -17,7 +17,7 @@
 //! in `registry()`; the dispatch, the ID list, the detection sweep, and the
 //! skill installer all pick it up with no further edits.
 
-mod claude;
+pub(crate) mod claude;
 pub(crate) mod codex;
 mod cursor;
 mod detect;

--- a/src/local/mod.rs
+++ b/src/local/mod.rs
@@ -11,6 +11,7 @@
 
 pub mod agent_skills;
 pub mod chat;
+pub mod claude;
 pub mod codex;
 pub mod datadir;
 pub mod experiments;

--- a/src/local/opencode.rs
+++ b/src/local/opencode.rs
@@ -131,9 +131,10 @@ fn playbook_md_with_memory(project: &LocalProject, memory: &str) -> String {
     });
     // The default compute target (Settings → Compute) is read fresh on every
     // playbook rewrite, but how soon a rewrite reaches a live agent varies:
-    // claude re-injects the playbook per turn; codex only on thread
-    // start/resume; a live opencode server keeps its playbook until respawn
-    // (`AgentHost::ensure` early-returns for a running child). Launch-time
+    // claude reads it at child spawn, so a rewrite reaches the agent on the next
+    // respawn (config change / interrupt / crash), not every turn; codex only on
+    // thread start/resume; a live opencode server keeps its playbook until
+    // respawn (`AgentHost::ensure` early-returns for a running child). Launch-time
     // resolution in `exp run` stays authoritative either way: the agent is
     // told to OMIT `--backend`, never to echo the default back, so even a
     // stale prompt launches on the current default.


### PR DESCRIPTION
## What

Replaces the Claude Code harness's spawn-per-turn model (`claude --print` + `--resume` fork every turn) with **one resident `claude --print --input-format stream-json` child per chat session**, mirroring the codex app-server host shape — and turns on **token-by-token streaming** of text/thinking.

- New `src/local/claude.rs`: `ClaudeHost`/`ClaudeClient` — per-session child registry (spawn-lock + detached-spawn race guard, central stdout reader routing events to the in-flight turn, `kill_session`/`shutdown`), a pure `child_action` reconcile, and `spawn_client` carrying the old per-turn flag block plus stream-json input.
- `run_turn` rewritten around a pure, store-free `apply_event` (fixture-tested like codex's `apply_notification`); resume/synthesis helpers untouched.
- Respawn policy: permission-mode/effort/bridge change → kill + respawn with `--resume` (today-identical semantics); model-only change → `set_model` control request; same config → reuse (zero spawn cost).
- `ChatHost::interrupt` gains a `claude-code` branch that kills the child (a resident child survives task-abort); next turn resumes via `--resume`. Delete/shutdown/project-delete paths reap the child before worktree cleanup.
- Plan-mode bridge: the `orx mcp-gate` token is now minted once **per child spawn** (a per-turn re-mint would strand the resident bridge — equality-checked, no expiry).
- **Streaming**: `--include-partial-messages` + a `stream_event` arm in `apply_event`. Deltas accumulate into a part under the same `{message_id}-{block_index}` id the final complete `assistant` event upserts, so the authoritative text overwrites the streamed accumulation; a Task subagent's nested stream (`parent_tool_use_id`) is ignored. Previously text/thinking landed as one block per message — the CLI emits no deltas without the flag.

## Why

Measured on real sessions: median **5.9s of dead time per turn** before the first token (worst 21.6s), ~3s of it a fixed spawn floor (process start + config + MCP handshakes + `--resume` transcript fork). Wire behavior was live-probed on claude CLI 2.1.197 before the design: persistent stream-json mode holds a stable session id across turns, `--resume` composes with it, and `--include-partial-messages` adds `stream_event` delta lines — so recovery (crash, restart, config change) is cheap and streaming is native.

## Verification

- `cargo fmt --check`, `clippy -D warnings`, `cargo test --locked` (231 passed; 11 new tests: `child_action` matrix, `classify_line` variants, 8 `apply_event` fixtures incl. delta-overwrite and subagent-stream-skip).
- Live smoke on dev slot 8 (isolated `ORX_DATA_DIR`): consecutive turns reuse one child PID with recall intact; **warm-turn first token ~2.9s (pure model latency — the ~3s spawn floor is gone)**; model switch retunes live; effort switch respawns with `--effort … --resume …` and keeps context; interrupt kills the child and the next turn recovers on a fresh `--resume` child; exactly one resident child per session.
- 2 rounds of 4-agent review on the core (round 2 unanimously clean) + a 2-agent round on the streaming commit (clean). Not live-tested: the plan-mode bridge flow (covered by the respawn path + fixture tests).