### PR TITLE
Route run-completion notifications to the launching chat session (v0.1.75)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,7 +928,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openresearch-cli"
-version = "0.1.74"
+version = "0.1.75"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openresearch-cli"
-version = "0.1.74"
+version = "0.1.75"
 edition = "2021"
 description = "OpenResearch CLI (orx) — Rust port"
 repository = "https://github.com/alphaXiv/openresearch-cli"

--- a/src/local/chat/mod.rs
+++ b/src/local/chat/mod.rs
@@ -1836,9 +1836,8 @@ fn is_terminal(status: &str) -> bool {
 /// The chat session a completed run should notify: the one that *launched* it
 /// (recorded on the run), provided it still exists and has history. Returns
 /// `None` for an orphan run (no owning session — CLI-launched or pre-migration)
-/// or a launcher that was since deleted/emptied. Store-only and agent-free, so
-/// the routing decision is unit-testable in isolation. The busy check and the
-/// actual send stay in `watch_runs`.
+/// or a launcher since deleted/emptied. Store-only (the busy check and send stay
+/// in `watch_runs`), which also keeps the routing decision unit-testable.
 fn notify_target(store: &Store, run: &crate::store::StoredRun) -> Option<String> {
     let session_id = run.chat_session_id.clone()?;
     let session = store.get_chat_session(&session_id).ok().flatten()?;
@@ -1875,9 +1874,7 @@ pub async fn watch_runs(chat: Arc<ChatHost>) {
             if first || !newly_terminal {
                 continue;
             }
-            // The session to poke — the one that launched the run, if it still
-            // exists with history. `None` skips (orphan run, or a session that
-            // was deleted). Never a project-wide guess.
+            // The launching session (see `notify_target`); `None` skips.
             let Some(session_id) = notify_target(&store, &run) else {
                 continue;
             };

--- a/src/local/chat/mod.rs
+++ b/src/local/chat/mod.rs
@@ -1833,11 +1833,31 @@ fn is_terminal(status: &str) -> bool {
     matches!(status, "done" | "failed" | "cancelled")
 }
 
-/// Poke a project's chat when a run completes while no turn is in flight —
-/// the local stand-in for the cloud agent staying online inside a blocking
-/// `orx exp wait`. The first pass only seeds the cursor, so a server restart
-/// doesn't replay old completions. Busy sessions are skipped (the agent is
-/// awake — likely in its wait loop — and will see the completion itself).
+/// The chat session a completed run should notify: the one that *launched* it
+/// (recorded on the run), provided it still exists and has history. Returns
+/// `None` for an orphan run (no owning session — CLI-launched or pre-migration)
+/// or a launcher that was since deleted/emptied. Store-only and agent-free, so
+/// the routing decision is unit-testable in isolation. The busy check and the
+/// actual send stay in `watch_runs`.
+fn notify_target(store: &Store, run: &crate::store::StoredRun) -> Option<String> {
+    let session_id = run.chat_session_id.clone()?;
+    let session = store.get_chat_session(&session_id).ok().flatten()?;
+    let has_history = store
+        .list_chat_messages(&session.id)
+        .map(|m| !m.is_empty())
+        .unwrap_or(false);
+    has_history.then_some(session.id)
+}
+
+/// Poke the chat session that *launched* a run when it completes while no turn
+/// is in flight — the local stand-in for the cloud agent staying online inside
+/// a blocking `orx exp wait`. Routing is by the run's recorded
+/// `chat_session_id` (stamped from the harness child's `ORX_CHAT_SESSION_ID`),
+/// never a project-wide guess, so a second idle agent in the same project is
+/// never handed another agent's run. The first pass only seeds the cursor, so a
+/// server restart doesn't replay old completions. A busy owner is skipped (the
+/// agent is awake — likely in its wait loop — and will see the completion
+/// itself); a run with no owning session (CLI-launched) pokes nothing.
 pub async fn watch_runs(chat: Arc<ChatHost>) {
     let mut seen: HashMap<String, String> = HashMap::new();
     let mut first = true;
@@ -1855,20 +1875,15 @@ pub async fn watch_runs(chat: Arc<ChatHost>) {
             if first || !newly_terminal {
                 continue;
             }
-            let Ok(sessions) = store.list_chat_sessions_by_project(&run.project_id) else {
+            // The session to poke — the one that launched the run, if it still
+            // exists with history. `None` skips (orphan run, or a session that
+            // was deleted). Never a project-wide guess.
+            let Some(session_id) = notify_target(&store, &run) else {
                 continue;
             };
-            // Most recently touched session that already has history — never
-            // mint or retitle a fresh one.
-            let Some(session) = sessions.into_iter().find(|s| {
-                store
-                    .list_chat_messages(&s.id)
-                    .map(|m| !m.is_empty())
-                    .unwrap_or(false)
-            }) else {
-                continue;
-            };
-            if chat.is_busy(&session.id).await {
+            if chat.is_busy(&session_id).await {
+                // The owner is awake — likely blocking in its own `orx exp
+                // wait` — and will observe the completion itself.
                 continue;
             }
             let text = format!(
@@ -1878,7 +1893,7 @@ pub async fn watch_runs(chat: Arc<ChatHost>) {
                 run.id, run.status, run.project_id, run.id
             );
             if let Err(err) = chat
-                .send_message(&session.id, text, TurnOverrides::default(), Vec::new())
+                .send_message(&session_id, text, TurnOverrides::default(), Vec::new())
                 .await
             {
                 eprintln!("orx up: run watcher: {err}");
@@ -1906,6 +1921,29 @@ pub fn prepare_env(cmd: &mut tokio::process::Command) {
             cmd.env(key, value);
         }
     }
+}
+
+/// Env var carrying the launching chat session's id into a harness child. The
+/// agent shells out `orx exp run`, a fresh `orx` subprocess that inherits this,
+/// so run creation can stamp `StoredRun::chat_session_id` (see
+/// `launching_chat_session`) and the run watcher can route the completion
+/// notification back to exactly the session that started it.
+pub const CHAT_SESSION_ENV: &str = "ORX_CHAT_SESSION_ID";
+
+/// Stamp the launching session id onto a harness child's env. Call *after*
+/// `prepare_env` so a dashboard-synced value can't shadow it. Harness children
+/// are one-per-session, so this is unambiguous.
+pub fn set_chat_session_env(cmd: &mut tokio::process::Command, session_id: &str) {
+    cmd.env(CHAT_SESSION_ENV, session_id);
+}
+
+/// The chat session that launched this run, read from the env the harness child
+/// exported (see [`set_chat_session_env`]). `None` for CLI-launched or server
+/// runs — those intentionally poke no chat session on completion.
+pub fn launching_chat_session() -> Option<String> {
+    std::env::var(CHAT_SESSION_ENV)
+        .ok()
+        .filter(|s| !s.is_empty())
 }
 
 /// Append-only stderr sink for a harness child (startup/debug diagnostics).
@@ -2154,5 +2192,103 @@ mod bridge_tests {
             serde_json::to_value(&usage).unwrap(),
             json!({ "usedTokens": 100 })
         );
+    }
+}
+
+#[cfg(test)]
+mod notify_target_tests {
+    use super::*;
+    use crate::store::{Store, StoredChatMessage, StoredChatSession, StoredRun};
+
+    fn session(store: &Store, id: &str, project: &str, updated_at: i64, msgs: usize) {
+        store
+            .create_chat_session(&StoredChatSession {
+                id: id.into(),
+                project_id: project.into(),
+                harness: "codex".into(),
+                native_session_id: None,
+                title: None,
+                model: None,
+                permission_mode: None,
+                reasoning_level: None,
+                archived: false,
+                context_usage_json: None,
+                created_at: 1,
+                updated_at,
+            })
+            .unwrap();
+        for i in 0..msgs {
+            store
+                .upsert_chat_message(&StoredChatMessage {
+                    id: format!("{id}-m{i}"),
+                    session_id: id.into(),
+                    role: "user".into(),
+                    parts_json: "[]".into(),
+                    created_at: 1,
+                })
+                .unwrap();
+        }
+    }
+
+    fn run(project: &str, owner: Option<&str>) -> StoredRun {
+        StoredRun {
+            id: "run_x".into(),
+            experiment_id: "exp_1".into(),
+            project_id: project.into(),
+            status: "failed".into(),
+            backend_json: "{}".into(),
+            command: "echo hi".into(),
+            created_at: 1,
+            updated_at: 1,
+            ended_at: None,
+            exit_code: None,
+            commit_sha: None,
+            result_markdown: None,
+            cancel_requested: false,
+            chat_session_id: owner.map(str::to_string),
+        }
+    }
+
+    fn temp_store(tag: &str) -> (Store, std::path::PathBuf) {
+        let dir = std::env::temp_dir().join(format!("orx-notify-{tag}-{}", uuid::Uuid::new_v4()));
+        (Store::open_at(dir.clone()).unwrap(), dir)
+    }
+
+    /// The reported bug: an idle bystander is the *most recently updated*
+    /// session in the project, while an older session actually launched the
+    /// run. Routing must follow ownership, not recency.
+    #[test]
+    fn routes_to_launcher_not_the_newest_bystander() {
+        let (store, dir) = temp_store("owner");
+        let proj = "p1";
+        // Owner is older; bystander is the newest — what the old project-wide
+        // heuristic would have wrongly picked.
+        session(&store, "owner", proj, 100, 3);
+        session(&store, "bystander", proj, 999, 3);
+
+        let target = notify_target(&store, &run(proj, Some("owner")));
+        assert_eq!(target.as_deref(), Some("owner"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A run with no recorded owner (CLI-launched / pre-migration) pokes no one
+    /// — never a project-wide guess.
+    #[test]
+    fn orphan_run_notifies_no_one() {
+        let (store, dir) = temp_store("orphan");
+        session(&store, "bystander", "p1", 999, 3);
+        assert_eq!(notify_target(&store, &run("p1", None)), None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The owner must still exist and have history; an empty (or vanished)
+    /// launcher is skipped rather than poked.
+    #[test]
+    fn empty_or_missing_owner_is_skipped() {
+        let (store, dir) = temp_store("empty");
+        session(&store, "empty_owner", "p1", 100, 0);
+        assert_eq!(notify_target(&store, &run("p1", Some("empty_owner"))), None);
+        assert_eq!(notify_target(&store, &run("p1", Some("ghost"))), None);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/local/claude.rs
+++ b/src/local/claude.rs
@@ -381,6 +381,10 @@ async fn spawn_client(spec: &SpawnSpec) -> Result<Arc<ClaudeClient>> {
         }
     }
     crate::local::chat::prepare_env(&mut cmd);
+    // Stamp the launching session so `orx exp run` (a fresh subprocess the
+    // agent shells out) tags its run with this session, and the run watcher
+    // notifies the right chat on completion. After prepare_env so it wins.
+    crate::local::chat::set_chat_session_env(&mut cmd, &spec.session_id);
     // Own process group: a terminal SIGINT reaches orx up alone, which then
     // tears the resident child down deliberately (kill_session / shutdown). A
     // shared group would let Ctrl-C kill a persistent child mid-turn.

--- a/src/local/codex.rs
+++ b/src/local/codex.rs
@@ -474,7 +474,7 @@ async fn read_loop(client: Arc<CodexClient>, stdout: tokio::process::ChildStdout
 /// Spawn `codex app-server` (no handshake yet — see `CodexHost::ensure`, which
 /// registers the client *before* the handshake so every kill path can reach
 /// the child even if the spawning turn task is aborted mid-handshake).
-async fn spawn_client() -> Result<Arc<CodexClient>> {
+async fn spawn_client(session_id: &str) -> Result<Arc<CodexClient>> {
     let bin = find_codex_required()?;
     let mut cmd = Command::new(&bin);
     cmd.arg("app-server")
@@ -483,6 +483,10 @@ async fn spawn_client() -> Result<Arc<CodexClient>> {
         .stderr(Stdio::from(crate::local::chat::harness_log("codex")?))
         .kill_on_drop(true);
     crate::local::chat::prepare_env(&mut cmd);
+    // Stamp the launching session (one app-server child per orx session) so a
+    // run the agent starts via `orx exp run` is tagged with it and the run
+    // watcher notifies this chat. After prepare_env so it isn't shadowed.
+    crate::local::chat::set_chat_session_env(&mut cmd, session_id);
     // Pin the child's store to the same canonicalized dir the sandbox policy
     // grants (see harness/codex.rs `ensure_orx_data_dir`) — after prepare_env
     // so the pin beats a dashboard-synced ORX_DATA_DIR. Unconditional: the
@@ -615,7 +619,7 @@ impl CodexHost {
         let host = self.clone();
         let session = session_id.to_string();
         tokio::spawn(async move {
-            let client = spawn_client().await?;
+            let client = spawn_client(&session).await?;
             // Never displace a live entry: if an abandoned bring-up's insert
             // races a successor's (spawn_lock was released by the abort), the
             // loser kills its own child and defers to the live one.

--- a/src/local/harness/codex.rs
+++ b/src/local/harness/codex.rs
@@ -41,8 +41,8 @@ use super::options::{HarnessOptions, PermissionMode};
 use super::{should_synthesize_plan, synthesize_resume, Harness, ResumeAction};
 use crate::error::{anyhow, Result};
 use crate::local::chat::{
-    prepare_env, ContextUsage, PromptAnswer, ResumeCtx, TurnCtx, WirePart, WirePrompt,
-    WireQuestionOption, WireToolState,
+    prepare_env, set_chat_session_env, ContextUsage, PromptAnswer, ResumeCtx, TurnCtx, WirePart,
+    WirePrompt, WireQuestionOption, WireToolState,
 };
 use crate::local::codex::{CodexClient, ServerReqKind, TurnEvent};
 use crate::local::opencode::ensure_playbook;
@@ -1751,6 +1751,10 @@ async fn run_turn_exec(ctx: &mut TurnCtx) -> Result<()> {
     };
     cmd.arg(prompt);
     prepare_env(&mut cmd);
+    // Tag the run this sandboxed turn may launch (`orx exp run`) with the
+    // session, so the run watcher notifies this chat. After prepare_env so it
+    // isn't shadowed by a synced value.
+    set_chat_session_env(&mut cmd, &ctx.session_id);
     // Pin the sandboxed turn's store to the exact path granted above. The
     // grant was resolved from the host's env, but the child could resolve a
     // different data dir — `prepare_env` injects dashboard-synced vars (a

--- a/src/local/hf.rs
+++ b/src/local/hf.rs
@@ -186,6 +186,7 @@ pub async fn submit_local_hf(args: &crate::ExpRunArgs) -> Result<StoredRun> {
         commit_sha: Some(commit_sha),
         result_markdown: None,
         cancel_requested: false,
+        chat_session_id: crate::local::chat::launching_chat_session(),
     };
     store.upsert_run(&run)?;
 

--- a/src/local/k8s.rs
+++ b/src/local/k8s.rs
@@ -222,6 +222,7 @@ pub async fn submit_local_k8s(args: &crate::ExpRunArgs) -> Result<StoredRun> {
         commit_sha: Some(commit_sha),
         result_markdown: None,
         cancel_requested: false,
+        chat_session_id: crate::local::chat::launching_chat_session(),
     };
     store.upsert_run(&run)?;
 

--- a/src/local/localrun.rs
+++ b/src/local/localrun.rs
@@ -161,6 +161,7 @@ pub async fn submit_local_run(args: &crate::ExpRunArgs) -> Result<StoredRun> {
         commit_sha: Some(commit_sha),
         result_markdown: None,
         cancel_requested: false,
+        chat_session_id: crate::local::chat::launching_chat_session(),
     };
     store.upsert_run(&run)?;
 

--- a/src/local/modal.rs
+++ b/src/local/modal.rs
@@ -188,6 +188,7 @@ pub async fn submit_local_modal(args: &crate::ExpRunArgs) -> Result<StoredRun> {
         commit_sha: Some(commit_sha),
         result_markdown: None,
         cancel_requested: false,
+        chat_session_id: crate::local::chat::launching_chat_session(),
     };
     store.upsert_run(&run)?;
 

--- a/src/local/opencode.rs
+++ b/src/local/opencode.rs
@@ -488,6 +488,10 @@ async fn spawn_agent(
             cmd.env(key, value);
         }
     }
+    // Tag runs the agent launches (`orx exp run`) with this session so the run
+    // watcher notifies this chat. One serve child per session; set after the
+    // synced-env loop so it isn't shadowed.
+    crate::local::chat::set_chat_session_env(&mut cmd, session_id);
     if let Some(config) = &config_override {
         // The repo tracks its own opencode.json; ours rides OPENCODE_CONFIG.
         // Project configs load after OPENCODE_CONFIG and would override our

--- a/src/local/openresearch.rs
+++ b/src/local/openresearch.rs
@@ -220,6 +220,7 @@ pub async fn submit_local_openresearch(args: &crate::ExpRunArgs) -> Result<Store
         commit_sha: Some(commit_sha),
         result_markdown: None,
         cancel_requested: false,
+        chat_session_id: crate::local::chat::launching_chat_session(),
     };
 
     // From here the box is billing: never leak it behind an error the store

--- a/src/local/resolve.rs
+++ b/src/local/resolve.rs
@@ -149,6 +149,7 @@ mod tests {
             commit_sha: None,
             result_markdown: None,
             cancel_requested: false,
+            chat_session_id: None,
         }
     }
 

--- a/src/local/slurm.rs
+++ b/src/local/slurm.rs
@@ -211,6 +211,7 @@ pub async fn submit_local_slurm(args: &crate::ExpRunArgs) -> Result<StoredRun> {
         commit_sha: Some(commit_sha),
         result_markdown: None,
         cancel_requested: false,
+        chat_session_id: crate::local::chat::launching_chat_session(),
     };
     store.upsert_run(&run)?;
 

--- a/src/local/ssh.rs
+++ b/src/local/ssh.rs
@@ -172,6 +172,7 @@ pub async fn submit_local_ssh(args: &crate::ExpRunArgs) -> Result<StoredRun> {
         commit_sha: Some(commit_sha),
         result_markdown: None,
         cancel_requested: false,
+        chat_session_id: crate::local::chat::launching_chat_session(),
     };
     store.upsert_run(&run)?;
 

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -411,6 +411,7 @@ mod tests {
             commit_sha: Some("abcdef1234567890".to_string()),
             result_markdown: result_markdown.map(str::to_string),
             cancel_requested: false,
+            chat_session_id: None,
         }
     }
 

--- a/src/plane/server_plane.rs
+++ b/src/plane/server_plane.rs
@@ -930,6 +930,7 @@ impl ServerPlane {
             commit_sha: None,
             result_markdown: None,
             cancel_requested: false,
+            chat_session_id: crate::local::chat::launching_chat_session(),
         })?;
         if let Err(err) = crate::client::update_external_run(
             creds,
@@ -1070,6 +1071,7 @@ impl ServerPlane {
             commit_sha: None,
             result_markdown: None,
             cancel_requested: false,
+            chat_session_id: crate::local::chat::launching_chat_session(),
         })?;
         if let Err(err) = crate::client::update_external_run(
             creds,

--- a/src/store.rs
+++ b/src/store.rs
@@ -144,6 +144,11 @@ pub struct StoredRun {
     pub result_markdown: Option<String>,
     /// Local-mode cancel intent (the supervisor polls it; server runs ignore it).
     pub cancel_requested: bool,
+    /// The `orx up` chat session that launched this run, when it was started by
+    /// an agent harness child (which exports `ORX_CHAT_SESSION_ID`). `None` for
+    /// CLI-launched or server runs. The run watcher routes the completion
+    /// notification to exactly this session — never a project-wide guess.
+    pub chat_session_id: Option<String>,
 }
 
 pub struct Store {
@@ -245,6 +250,7 @@ impl Store {
             "ALTER TABLE runs ADD COLUMN commit_sha TEXT",
             "ALTER TABLE runs ADD COLUMN result_markdown TEXT",
             "ALTER TABLE runs ADD COLUMN cancel_requested INTEGER NOT NULL DEFAULT 0",
+            "ALTER TABLE runs ADD COLUMN chat_session_id TEXT",
             "ALTER TABLE chat_sessions ADD COLUMN permission_mode TEXT",
             "ALTER TABLE chat_sessions ADD COLUMN reasoning_level TEXT",
             "ALTER TABLE chat_sessions ADD COLUMN archived INTEGER NOT NULL DEFAULT 0",
@@ -331,8 +337,9 @@ impl Store {
         self.conn.execute(
             "INSERT INTO runs (id, experiment_id, project_id, status, backend_json, command,
                                created_at, updated_at, ended_at, exit_code,
-                               commit_sha, result_markdown, cancel_requested)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+                               commit_sha, result_markdown, cancel_requested,
+                               chat_session_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
              ON CONFLICT(id) DO UPDATE SET
                status = excluded.status,
                backend_json = excluded.backend_json,
@@ -341,6 +348,9 @@ impl Store {
                exit_code = excluded.exit_code,
                commit_sha = excluded.commit_sha,
                result_markdown = excluded.result_markdown",
+            // chat_session_id is deliberately absent from the DO UPDATE SET:
+            // run ownership is immutable, so a later status upsert never
+            // rewrites (or clears) the session that launched the run.
             params![
                 run.id,
                 run.experiment_id,
@@ -355,6 +365,7 @@ impl Store {
                 run.commit_sha,
                 run.result_markdown,
                 run.cancel_requested,
+                run.chat_session_id,
             ],
         )?;
         Ok(())
@@ -909,7 +920,8 @@ fn row_to_chat_session(
 
 const SELECT_RUN: &str = "SELECT id, experiment_id, project_id, status, backend_json, command,
                                  created_at, updated_at, ended_at, exit_code,
-                                 commit_sha, result_markdown, cancel_requested FROM runs";
+                                 commit_sha, result_markdown, cancel_requested,
+                                 chat_session_id FROM runs";
 
 const PROJECT_COLS: &str = "id, name, slug, github_owner, github_repo, baseline_branch, \
                             repo_path, run_command, paper_id, created_at, updated_at";
@@ -932,6 +944,7 @@ fn row_to_run(row: &rusqlite::Row<'_>) -> std::result::Result<StoredRun, rusqlit
         commit_sha: row.get(10)?,
         result_markdown: row.get(11)?,
         cancel_requested: row.get(12)?,
+        chat_session_id: row.get(13)?,
     })
 }
 
@@ -992,6 +1005,80 @@ mod tests {
                 .context_usage_json
                 .as_deref(),
             Some(json)
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    fn run_fixture(id: &str, status: &str, chat_session_id: Option<&str>) -> StoredRun {
+        StoredRun {
+            id: id.into(),
+            experiment_id: "exp_1".into(),
+            project_id: "proj_1".into(),
+            status: status.into(),
+            backend_json: "{}".into(),
+            command: "echo hi".into(),
+            created_at: 1,
+            updated_at: 1,
+            ended_at: None,
+            exit_code: None,
+            commit_sha: None,
+            result_markdown: None,
+            cancel_requested: false,
+            chat_session_id: chat_session_id.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn run_chat_session_id_roundtrips() {
+        let dir = std::env::temp_dir().join(format!("orx-store-runsess-{}", uuid::Uuid::new_v4()));
+        let store = Store::open_at(dir.clone()).unwrap();
+
+        store
+            .upsert_run(&run_fixture("run_owned", "starting", Some("chat_A")))
+            .unwrap();
+        store
+            .upsert_run(&run_fixture("run_orphan", "starting", None))
+            .unwrap();
+
+        assert_eq!(
+            store.get_run("run_owned").unwrap().unwrap().chat_session_id,
+            Some("chat_A".to_string())
+        );
+        assert_eq!(
+            store
+                .get_run("run_orphan")
+                .unwrap()
+                .unwrap()
+                .chat_session_id,
+            None
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn run_ownership_is_immutable_across_upserts() {
+        let dir = std::env::temp_dir().join(format!("orx-store-runimmut-{}", uuid::Uuid::new_v4()));
+        let store = Store::open_at(dir.clone()).unwrap();
+
+        // Created by chat_A.
+        store
+            .upsert_run(&run_fixture("run_1", "starting", Some("chat_A")))
+            .unwrap();
+        // A later status upsert that carries a *different* (or absent) session
+        // must NOT rewrite the owner — ownership is immutable.
+        store
+            .upsert_run(&run_fixture("run_1", "failed", Some("chat_B")))
+            .unwrap();
+        store
+            .upsert_run(&run_fixture("run_1", "done", None))
+            .unwrap();
+
+        let run = store.get_run("run_1").unwrap().unwrap();
+        assert_eq!(run.status, "done", "status still updates on conflict");
+        assert_eq!(
+            run.chat_session_id,
+            Some("chat_A".to_string()),
+            "the launching session is never overwritten by a later upsert"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }


### PR DESCRIPTION
## Problem

When two agents (chat sessions) ran in the same project and one launched an experiment, the run-completion/failure notification —

> `[orx] Run \`…\` finished with status **failed**. Reconcile with … and continue the loop.`

— was delivered to the **wrong, idle session**, prompting a bystander agent to "fix" a run it never launched.

**Root cause:** runs carried no owning-session id. `watch_runs` (`src/local/chat/mod.rs`) picked the recipient from `project_id` alone — the most-recently-touched, non-busy session in the project. The launching agent was skipped by the `is_busy` guard (it was blocking in its own `orx exp wait` loop), so an idle bystander won.

## Fix

Persist the launching chat session on the run and route the notification to exactly that session.

- **Data model** (`src/store.rs`): new `runs.chat_session_id` column, added via the same best-effort `ALTER TABLE` migration pattern as `commit_sha`/`cancel_requested`. Included in `SELECT_RUN` / `row_to_run` / `upsert_run` — but **deliberately excluded from the `ON CONFLICT DO UPDATE SET`** clause, so ownership is immutable across later status upserts.
- **Env threading**: each per-session harness child (claude `spawn_client`, codex app-server `spawn_client`, codex sandboxed `run_turn_exec`, opencode `spawn_agent`) exports `ORX_CHAT_SESSION_ID`, set *after* `prepare_env` so a dashboard-synced value can't shadow it. The agent's `orx exp run` is a fresh subprocess that inherits it, so run creation stamps the owner via `launching_chat_session()`.
- **Routing** (`src/local/chat/mod.rs`): `watch_runs` now routes via a new store-only `notify_target(store, run)` helper. A busy owner is skipped as before (it'll see the completion in its wait loop); a run with no owning session (CLI-launched / pre-migration) pokes nobody — never a project-wide guess.

## Testing

- **Unit** (`cargo test`, 256 pass): run round-trip (`Some`/`None`), ownership-immutable-across-upserts, and 3 `notify_target` routing tests — including `routes_to_launcher_not_the_newest_bystander`, which reproduces the exact bug.
- **CI parity**: `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --locked` all clean.
- **Migration**: ran the built binary against a snapshot of a real production-shaped DB — column added cleanly, existing runs/projects/sessions intact, pre-migration runs read back as `chat_session_id = NULL`.
- **Live E2E**: ran the real `orx up` backend on an isolated DB with two sessions in one project (bystander = the newest, what the old code picked). A failing run owned by the older launcher delivered the `[orx] Run …` message to the **launcher only** (0 to the bystander); an orphan run notified nobody.

## Review

Passed a 4-agent independent review round (2 correctness, 2 quality) — unanimous NO BLOCKERS. Minor comment nits applied.