### PR TITLE
Fix duplicated assistant text for thinking models in the Claude harness (v0.1.80)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,7 +928,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openresearch-cli"
-version = "0.1.79"
+version = "0.1.80"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openresearch-cli"
-version = "0.1.79"
+version = "0.1.80"
 edition = "2021"
 description = "OpenResearch CLI (orx) — Rust port"
 repository = "https://github.com/alphaXiv/openresearch-cli"

--- a/src/local/harness/claude.rs
+++ b/src/local/harness/claude.rs
@@ -628,11 +628,8 @@ struct TurnState {
     /// upserts.
     stream_mid: Option<String>,
     /// Content blocks already consumed from prior `assistant` events, keyed
-    /// per message (and per subagent — see the `assistant` arm). The CLI
-    /// emits one `assistant` event *per content block* (a single-element
-    /// `content` array), so a block's index in the message — the `index` its
-    /// stream deltas carried — is this running offset plus its position
-    /// within the event.
+    /// per message id (subagent events namespaced by `parent_tool_use_id`) —
+    /// see the `assistant` arm for why this offset exists.
     assistant_blocks_seen: HashMap<String, usize>,
 }
 
@@ -649,7 +646,8 @@ fn apply_event(ctx: &mut TurnCtx, state: &mut TurnState, event: &Value) -> bool 
         // when the complete `assistant` event arrives. Deltas build a part
         // under the same `{mid}-{index}` id that the assistant event upserts,
         // so the authoritative full text simply overwrites the accumulated
-        // one. That overwrite (and part ordering) leans on two stream-protocol
+        // one (the `assistant` arm reconstructs the block index from a
+        // running offset). That overwrite (and part ordering) leans on two stream-protocol
         // invariants: the stream's message id equals the assistant events',
         // and a block's `index` is its position in the message's content,
         // with blocks streamed in ascending order.
@@ -712,15 +710,16 @@ fn apply_event(ctx: &mut TurnCtx, state: &mut TurnState, event: &Value) -> bool 
                 .and_then(Value::as_array)
                 .cloned()
                 .unwrap_or_default();
-            // Per-block `assistant` events continue the message where the
-            // last left off; a message's first event starts at offset 0, so a
-            // single full-content array behaves as before. The counter trusts
-            // the CLI to emit each block exactly once, in order — it has no
-            // wire index to cross-check (the events don't carry one). A
+            // The CLI emits one `assistant` event per content block (a
+            // single-element `content` array), so each event continues the
+            // message where the last left off; a message's first event starts
+            // at offset 0, so a single full-content array behaves the same.
+            // The counter trusts the CLI to emit each block exactly once, in
+            // order — the events carry no wire index to cross-check. A
             // subagent's events (parent_tool_use_id set) get their own
-            // namespace so they can never advance the main message's offset,
-            // even on a colliding or missing message id.
-            let offset_key = match event.get("parent_tool_use_id").and_then(Value::as_str) {
+            // namespace so they can never advance the main message's offset.
+            let parent = event.get("parent_tool_use_id").and_then(Value::as_str);
+            let offset_key = match parent {
                 Some(parent) => format!("{parent}:{mid}"),
                 None => mid.clone(),
             };
@@ -795,11 +794,9 @@ fn apply_event(ctx: &mut TurnCtx, state: &mut TurnState, event: &Value) -> bool 
                 .insert(offset_key, offset + blocks.len());
             // Per-message usage gives live updates during multi-step turns; the
             // window arrives later on `result`, so report the token count only.
-            // A subagent's message is a top-level `assistant` event with
-            // `parent_tool_use_id` set — its smaller count must not overwrite
-            // (latest-wins) the main session's occupancy, so skip its usage.
-            let is_subagent = !event.get("parent_tool_use_id").is_none_or(Value::is_null);
-            if !is_subagent {
+            // A subagent's smaller count must not overwrite (latest-wins) the
+            // main session's occupancy, so skip its usage.
+            if parent.is_none() {
                 if let Some(used) = claude_used_tokens(event.pointer("/message/usage")) {
                     ctx.report_usage(ContextUsage {
                         used_tokens: used,
@@ -1308,8 +1305,10 @@ mod tests {
     fn stream_deltas_paint_parts_and_a_whole_message_event_overwrites_them() {
         // Deltas accumulate under {mid}-{index}; an assistant event carrying
         // the whole content array (the offset-0 degenerate case — the live
-        // CLI splits per block, see the next test) upserts the authoritative
-        // text over the very same parts — no duplicate, final text wins.
+        // CLI splits per block, see
+        // `per_block_assistant_events_land_on_the_delta_parts`) upserts the
+        // authoritative text over the very same parts — no duplicate, final
+        // text wins.
         let transcript = [
             r#"{"type":"system","subtype":"init","session_id":"sd1"}"#,
             r#"{"type":"stream_event","event":{"type":"message_start","message":{"id":"m9"}},"parent_tool_use_id":null}"#,
@@ -1334,8 +1333,8 @@ mod tests {
     #[test]
     fn per_block_assistant_events_land_on_the_delta_parts() {
         // The CLI emits one `assistant` event per completed content block,
-        // each with a single-element content array (captured live from
-        // claude 2.1.212). Without the running block offset, the text block's
+        // each with a single-element content array (captured live from the
+        // claude CLI). Without the running block offset, the text block's
         // event would key to {mid}-0, clobbering the reasoning part while the
         // delta-built text at {mid}-1 survived as a duplicate.
         let transcript = [
@@ -1375,7 +1374,7 @@ mod tests {
             r#"{"type":"result","subtype":"success","session_id":"sd3","is_error":false}"#,
         ];
         let mut ctx = TurnCtx::test_stub();
-        fold(&mut ctx, false, &transcript);
+        let state = fold(&mut ctx, false, &transcript);
         let parts = &ctx.assistant.parts;
         assert_eq!(parts.len(), 3, "{parts:?}");
         assert_eq!(parts[0].id, "mA-0");
@@ -1383,6 +1382,7 @@ mod tests {
         assert_eq!(parts[1].text.as_deref(), Some("first"));
         assert_eq!(parts[2].id, "mB-0");
         assert_eq!(parts[2].text.as_deref(), Some("second"));
+        assert_eq!(state.last_text, "second");
     }
 
     #[test]
@@ -1410,24 +1410,28 @@ mod tests {
     fn subagent_assistant_events_do_not_share_the_main_offset() {
         // A Task subagent's top-level assistant events (parent_tool_use_id
         // set) still fold into parts — pre-existing behavior — but their
-        // offsets live in their own namespace, so an interleaved subagent
-        // event can't push the main message's next block off the part id its
-        // stream deltas built.
+        // offsets live in their own namespace, so even a subagent message
+        // reusing the main message's id (synthetic here; real API ids are
+        // globally unique) can't push the main message's next block off the
+        // part id its stream deltas built. Without the namespace the main
+        // text would land at mD-2.
         let transcript = [
             r#"{"type":"system","subtype":"init","session_id":"sd5"}"#,
             r#"{"type":"assistant","message":{"id":"mD","content":[{"type":"thinking","thinking":"t"}]}}"#,
-            r#"{"type":"assistant","message":{"id":"mSub","content":[{"type":"text","text":"sub"}]},"parent_tool_use_id":"toolu_1"}"#,
+            r#"{"type":"assistant","message":{"id":"mD","content":[{"type":"text","text":"sub"}]},"parent_tool_use_id":"toolu_1"}"#,
             r#"{"type":"assistant","message":{"id":"mD","content":[{"type":"text","text":"main"}]}}"#,
             r#"{"type":"result","subtype":"success","session_id":"sd5","is_error":false}"#,
         ];
         let mut ctx = TurnCtx::test_stub();
         fold(&mut ctx, false, &transcript);
         let parts = &ctx.assistant.parts;
-        assert_eq!(parts.len(), 3, "{parts:?}");
+        // The subagent's un-namespaced part id collides with the synthetic
+        // shared mid and upserts over mD-0 — an artifact of the collision,
+        // not the invariant under test.
+        assert_eq!(parts.len(), 2, "{parts:?}");
         assert_eq!(parts[0].id, "mD-0");
-        assert_eq!(parts[1].id, "mSub-0");
-        assert_eq!(parts[2].id, "mD-1");
-        assert_eq!(parts[2].text.as_deref(), Some("main"));
+        assert_eq!(parts[1].id, "mD-1");
+        assert_eq!(parts[1].text.as_deref(), Some("main"));
     }
 
     #[test]

--- a/src/local/harness/claude.rs
+++ b/src/local/harness/claude.rs
@@ -626,6 +626,15 @@ struct TurnState {
     /// same `{mid}-{index}` part ids the final complete `assistant` event
     /// upserts.
     stream_mid: Option<String>,
+    /// Content blocks already consumed from prior `assistant` events, per
+    /// message id. The CLI emits one `assistant` event *per content block*
+    /// (each with a single-element `content` array), so a block's position in
+    /// the message — the `index` its stream deltas carried — is this running
+    /// offset plus its position within the event. Without it, every block
+    /// would key to `{mid}-0` and a text block following a thinking block
+    /// would clobber the reasoning part while its own delta-built part
+    /// survived as a duplicate.
+    assistant_blocks_seen: std::collections::HashMap<String, usize>,
 }
 
 /// Fold one stream-json output object into the turn's transcript + `TurnState`.
@@ -639,12 +648,14 @@ fn apply_event(ctx: &mut TurnCtx, state: &mut TurnState, event: &Value) -> bool 
         // Partial-message deltas (opt-in via --include-partial-messages): the
         // text/thinking streams token by token instead of landing as one block
         // when the complete `assistant` event arrives. Deltas build a part
-        // under the same `{mid}-{index}` id that the final event upserts, so
-        // the authoritative full text simply overwrites the accumulated one.
-        // That overwrite (and part ordering) leans on two stream-protocol
-        // invariants: the stream's message id equals the final assistant
-        // event's, and a block's `index` is its position in the final content
-        // array, with blocks streamed in ascending order.
+        // under the same `{mid}-{index}` id that the assistant event upserts,
+        // so the authoritative full text simply overwrites the accumulated
+        // one. That overwrite (and part ordering) leans on two stream-protocol
+        // invariants: the stream's message id equals the assistant events',
+        // and a block's `index` is its position in the message's content,
+        // with blocks streamed (and their assistant events emitted) in
+        // ascending order — see `assistant_blocks_seen` for how the per-block
+        // assistant events recover that index.
         Some("stream_event") => {
             // A subagent's nested stream (parent_tool_use_id set) would
             // interleave its text into the transcript — main loop only.
@@ -704,7 +715,14 @@ fn apply_event(ctx: &mut TurnCtx, state: &mut TurnState, event: &Value) -> bool 
                 .and_then(Value::as_array)
                 .cloned()
                 .unwrap_or_default();
+            // The CLI streams one `assistant` event per completed content
+            // block, so this event's blocks continue the message where the
+            // previous event left off — offset by the blocks already seen to
+            // recover each block's true index in the message (a full-content
+            // array in a single event starts at offset 0 and works the same).
+            let offset = state.assistant_blocks_seen.get(&mid).copied().unwrap_or(0);
             for (i, block) in blocks.iter().enumerate() {
+                let i = offset + i;
                 match block.get("type").and_then(Value::as_str) {
                     Some("text") => {
                         let text = block.get("text").and_then(Value::as_str).unwrap_or("");
@@ -762,6 +780,9 @@ fn apply_event(ctx: &mut TurnCtx, state: &mut TurnState, event: &Value) -> bool 
                     _ => {}
                 }
             }
+            state
+                .assistant_blocks_seen
+                .insert(mid, offset + blocks.len());
             // Per-message usage gives live updates during multi-step turns; the
             // window arrives later on `result`, so report the token count only.
             // A subagent's message is a top-level `assistant` event with
@@ -1297,6 +1318,57 @@ mod tests {
         assert_eq!(parts[1].text.as_deref(), Some("Rivers flow."));
         // The final assistant event still feeds last_text (plan synthesis).
         assert_eq!(state.last_text, "Rivers flow.");
+    }
+
+    #[test]
+    fn per_block_assistant_events_land_on_the_delta_parts() {
+        // The CLI emits one `assistant` event per completed content block,
+        // each with a single-element content array (captured live from
+        // claude 2.1.212). Without the running block offset, the text block's
+        // event would key to {mid}-0, clobbering the reasoning part while the
+        // delta-built text at {mid}-1 survived as a duplicate.
+        let transcript = [
+            r#"{"type":"system","subtype":"init","session_id":"sd2"}"#,
+            r#"{"type":"stream_event","event":{"type":"message_start","message":{"id":"m9"}},"parent_tool_use_id":null}"#,
+            r#"{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"hmm"}},"parent_tool_use_id":null}"#,
+            r#"{"type":"assistant","message":{"id":"m9","content":[{"type":"thinking","thinking":"hmm"}]}}"#,
+            r#"{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Riv"}},"parent_tool_use_id":null}"#,
+            r#"{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"ers flow."}},"parent_tool_use_id":null}"#,
+            r#"{"type":"assistant","message":{"id":"m9","content":[{"type":"text","text":"Rivers flow."}]}}"#,
+            r#"{"type":"result","subtype":"success","session_id":"sd2","is_error":false}"#,
+        ];
+        let mut ctx = TurnCtx::test_stub();
+        let state = fold(&mut ctx, false, &transcript);
+        let parts = &ctx.assistant.parts;
+        assert_eq!(parts.len(), 2, "{parts:?}");
+        assert_eq!(parts[0].kind, "reasoning");
+        assert_eq!(parts[0].text.as_deref(), Some("hmm"));
+        assert_eq!(parts[1].kind, "text");
+        assert_eq!(parts[1].text.as_deref(), Some("Rivers flow."));
+        assert_eq!(state.last_text, "Rivers flow.");
+    }
+
+    #[test]
+    fn block_offsets_reset_across_messages_in_one_turn() {
+        // A multi-iteration turn has several assistant messages, each with its
+        // own id — the block offset is per message id, so the second message's
+        // first block keys to {mid2}-0, not a continuation of message one.
+        let transcript = [
+            r#"{"type":"system","subtype":"init","session_id":"sd3"}"#,
+            r#"{"type":"assistant","message":{"id":"mA","content":[{"type":"thinking","thinking":"t1"}]}}"#,
+            r#"{"type":"assistant","message":{"id":"mA","content":[{"type":"text","text":"first"}]}}"#,
+            r#"{"type":"assistant","message":{"id":"mB","content":[{"type":"text","text":"second"}]}}"#,
+            r#"{"type":"result","subtype":"success","session_id":"sd3","is_error":false}"#,
+        ];
+        let mut ctx = TurnCtx::test_stub();
+        fold(&mut ctx, false, &transcript);
+        let parts = &ctx.assistant.parts;
+        assert_eq!(parts.len(), 3, "{parts:?}");
+        assert_eq!(parts[0].id, "mA-0");
+        assert_eq!(parts[1].id, "mA-1");
+        assert_eq!(parts[1].text.as_deref(), Some("first"));
+        assert_eq!(parts[2].id, "mB-0");
+        assert_eq!(parts[2].text.as_deref(), Some("second"));
     }
 
     #[test]

--- a/src/local/harness/claude.rs
+++ b/src/local/harness/claude.rs
@@ -17,6 +17,7 @@
 //! read); `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` are credential
 //! fallbacks, and are what a custom `ANTHROPIC_BASE_URL` gateway uses.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use async_trait::async_trait;
@@ -626,15 +627,13 @@ struct TurnState {
     /// same `{mid}-{index}` part ids the final complete `assistant` event
     /// upserts.
     stream_mid: Option<String>,
-    /// Content blocks already consumed from prior `assistant` events, per
-    /// message id. The CLI emits one `assistant` event *per content block*
-    /// (each with a single-element `content` array), so a block's position in
-    /// the message — the `index` its stream deltas carried — is this running
-    /// offset plus its position within the event. Without it, every block
-    /// would key to `{mid}-0` and a text block following a thinking block
-    /// would clobber the reasoning part while its own delta-built part
-    /// survived as a duplicate.
-    assistant_blocks_seen: std::collections::HashMap<String, usize>,
+    /// Content blocks already consumed from prior `assistant` events, keyed
+    /// per message (and per subagent — see the `assistant` arm). The CLI
+    /// emits one `assistant` event *per content block* (a single-element
+    /// `content` array), so a block's index in the message — the `index` its
+    /// stream deltas carried — is this running offset plus its position
+    /// within the event.
+    assistant_blocks_seen: HashMap<String, usize>,
 }
 
 /// Fold one stream-json output object into the turn's transcript + `TurnState`.
@@ -653,9 +652,7 @@ fn apply_event(ctx: &mut TurnCtx, state: &mut TurnState, event: &Value) -> bool 
         // one. That overwrite (and part ordering) leans on two stream-protocol
         // invariants: the stream's message id equals the assistant events',
         // and a block's `index` is its position in the message's content,
-        // with blocks streamed (and their assistant events emitted) in
-        // ascending order — see `assistant_blocks_seen` for how the per-block
-        // assistant events recover that index.
+        // with blocks streamed in ascending order.
         Some("stream_event") => {
             // A subagent's nested stream (parent_tool_use_id set) would
             // interleave its text into the transcript — main loop only.
@@ -715,14 +712,25 @@ fn apply_event(ctx: &mut TurnCtx, state: &mut TurnState, event: &Value) -> bool 
                 .and_then(Value::as_array)
                 .cloned()
                 .unwrap_or_default();
-            // The CLI streams one `assistant` event per completed content
-            // block, so this event's blocks continue the message where the
-            // previous event left off — offset by the blocks already seen to
-            // recover each block's true index in the message (a full-content
-            // array in a single event starts at offset 0 and works the same).
-            let offset = state.assistant_blocks_seen.get(&mid).copied().unwrap_or(0);
-            for (i, block) in blocks.iter().enumerate() {
-                let i = offset + i;
+            // Per-block `assistant` events continue the message where the
+            // last left off; a message's first event starts at offset 0, so a
+            // single full-content array behaves as before. The counter trusts
+            // the CLI to emit each block exactly once, in order — it has no
+            // wire index to cross-check (the events don't carry one). A
+            // subagent's events (parent_tool_use_id set) get their own
+            // namespace so they can never advance the main message's offset,
+            // even on a colliding or missing message id.
+            let offset_key = match event.get("parent_tool_use_id").and_then(Value::as_str) {
+                Some(parent) => format!("{parent}:{mid}"),
+                None => mid.clone(),
+            };
+            let offset = state
+                .assistant_blocks_seen
+                .get(&offset_key)
+                .copied()
+                .unwrap_or(0);
+            for (n, block) in blocks.iter().enumerate() {
+                let i = offset + n;
                 match block.get("type").and_then(Value::as_str) {
                     Some("text") => {
                         let text = block.get("text").and_then(Value::as_str).unwrap_or("");
@@ -739,8 +747,7 @@ fn apply_event(ctx: &mut TurnCtx, state: &mut TurnState, event: &Value) -> bool 
                         let id = block
                             .get("id")
                             .and_then(Value::as_str)
-                            .unwrap_or(&format!("{mid}-{i}"))
-                            .to_string();
+                            .map_or_else(|| format!("{mid}-{i}"), str::to_string);
                         let name = block.get("name").and_then(Value::as_str).unwrap_or("");
                         let input = block.get("input");
                         // ExitPlanMode / AskUserQuestion surface as interactive
@@ -780,9 +787,12 @@ fn apply_event(ctx: &mut TurnCtx, state: &mut TurnState, event: &Value) -> bool 
                     _ => {}
                 }
             }
+            // Advance by the content-array length, not a render count: a
+            // bridge-suppressed ExitPlanMode/AskUserQuestion or an unknown
+            // block type still occupies its position in the message.
             state
                 .assistant_blocks_seen
-                .insert(mid, offset + blocks.len());
+                .insert(offset_key, offset + blocks.len());
             // Per-message usage gives live updates during multi-step turns; the
             // window arrives later on `result`, so report the token count only.
             // A subagent's message is a top-level `assistant` event with
@@ -1295,10 +1305,11 @@ mod tests {
     }
 
     #[test]
-    fn stream_deltas_paint_parts_and_the_final_event_overwrites_them() {
-        // Deltas accumulate under {mid}-{index}; the complete assistant event
-        // then upserts the authoritative text over the very same part — one
-        // part, no duplicate, final text wins.
+    fn stream_deltas_paint_parts_and_a_whole_message_event_overwrites_them() {
+        // Deltas accumulate under {mid}-{index}; an assistant event carrying
+        // the whole content array (the offset-0 degenerate case — the live
+        // CLI splits per block, see the next test) upserts the authoritative
+        // text over the very same parts — no duplicate, final text wins.
         let transcript = [
             r#"{"type":"system","subtype":"init","session_id":"sd1"}"#,
             r#"{"type":"stream_event","event":{"type":"message_start","message":{"id":"m9"}},"parent_tool_use_id":null}"#,
@@ -1341,18 +1352,21 @@ mod tests {
         let state = fold(&mut ctx, false, &transcript);
         let parts = &ctx.assistant.parts;
         assert_eq!(parts.len(), 2, "{parts:?}");
+        assert_eq!(parts[0].id, "m9-0");
         assert_eq!(parts[0].kind, "reasoning");
         assert_eq!(parts[0].text.as_deref(), Some("hmm"));
+        assert_eq!(parts[1].id, "m9-1");
         assert_eq!(parts[1].kind, "text");
         assert_eq!(parts[1].text.as_deref(), Some("Rivers flow."));
         assert_eq!(state.last_text, "Rivers flow.");
     }
 
     #[test]
-    fn block_offsets_reset_across_messages_in_one_turn() {
-        // A multi-iteration turn has several assistant messages, each with its
-        // own id — the block offset is per message id, so the second message's
-        // first block keys to {mid2}-0, not a continuation of message one.
+    fn block_offsets_are_keyed_per_message_id() {
+        // A multi-iteration turn has several assistant messages, each with
+        // its own id — each id gets its own offset, so the second message's
+        // first block keys to {mid2}-0, not a continuation of message one
+        // (a single running counter would break here).
         let transcript = [
             r#"{"type":"system","subtype":"init","session_id":"sd3"}"#,
             r#"{"type":"assistant","message":{"id":"mA","content":[{"type":"thinking","thinking":"t1"}]}}"#,
@@ -1369,6 +1383,51 @@ mod tests {
         assert_eq!(parts[1].text.as_deref(), Some("first"));
         assert_eq!(parts[2].id, "mB-0");
         assert_eq!(parts[2].text.as_deref(), Some("second"));
+    }
+
+    #[test]
+    fn bridge_suppressed_blocks_still_advance_the_offset() {
+        // A bridge-suppressed ExitPlanMode renders nothing but still occupies
+        // its position in the message — the text block after it must land at
+        // {mid}-1, overwriting its delta-built part, not at {mid}-0.
+        let transcript = [
+            r#"{"type":"system","subtype":"init","session_id":"sd4"}"#,
+            r#"{"type":"stream_event","event":{"type":"message_start","message":{"id":"mC"}},"parent_tool_use_id":null}"#,
+            r#"{"type":"assistant","message":{"id":"mC","content":[{"type":"tool_use","id":"toolu_p","name":"ExitPlanMode","input":{}}]}}"#,
+            r#"{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"after"}},"parent_tool_use_id":null}"#,
+            r#"{"type":"assistant","message":{"id":"mC","content":[{"type":"text","text":"after"}]}}"#,
+            r#"{"type":"result","subtype":"success","session_id":"sd4","is_error":false}"#,
+        ];
+        let mut ctx = TurnCtx::test_stub();
+        fold(&mut ctx, true, &transcript);
+        let parts = &ctx.assistant.parts;
+        assert_eq!(parts.len(), 1, "{parts:?}");
+        assert_eq!(parts[0].id, "mC-1");
+        assert_eq!(parts[0].text.as_deref(), Some("after"));
+    }
+
+    #[test]
+    fn subagent_assistant_events_do_not_share_the_main_offset() {
+        // A Task subagent's top-level assistant events (parent_tool_use_id
+        // set) still fold into parts — pre-existing behavior — but their
+        // offsets live in their own namespace, so an interleaved subagent
+        // event can't push the main message's next block off the part id its
+        // stream deltas built.
+        let transcript = [
+            r#"{"type":"system","subtype":"init","session_id":"sd5"}"#,
+            r#"{"type":"assistant","message":{"id":"mD","content":[{"type":"thinking","thinking":"t"}]}}"#,
+            r#"{"type":"assistant","message":{"id":"mSub","content":[{"type":"text","text":"sub"}]},"parent_tool_use_id":"toolu_1"}"#,
+            r#"{"type":"assistant","message":{"id":"mD","content":[{"type":"text","text":"main"}]}}"#,
+            r#"{"type":"result","subtype":"success","session_id":"sd5","is_error":false}"#,
+        ];
+        let mut ctx = TurnCtx::test_stub();
+        fold(&mut ctx, false, &transcript);
+        let parts = &ctx.assistant.parts;
+        assert_eq!(parts.len(), 3, "{parts:?}");
+        assert_eq!(parts[0].id, "mD-0");
+        assert_eq!(parts[1].id, "mSub-0");
+        assert_eq!(parts[2].id, "mD-1");
+        assert_eq!(parts[2].text.as_deref(), Some("main"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

With Claude models that stream visible thinking (e.g. Fable 5), every assistant reply rendered **twice** in the chat transcript, and the thinking block disappeared. Codex sessions were unaffected.

## Root cause

Verified live against claude CLI 2.1.212: with `--output-format stream-json --include-partial-messages`, the CLI emits **one `assistant` event per completed content block**, each with a single-element `content` array. The fold in `src/local/harness/claude.rs` keyed parts as `{message_id}-{enumerate index}` within each event, so every block keyed to `{mid}-0`:

1. Stream deltas correctly build parts `{mid}-0` (thinking) and `{mid}-1` (text) from the wire's block `index`.
2. The thinking block's `assistant` event upserts `{mid}-0` — fine.
3. The text block's `assistant` event **also** upserts `{mid}-0`, clobbering the reasoning part, while the delta-built text at `{mid}-1` survives → the reply appears twice, the thinking is gone.

Without thinking there is only one block, index 0 either way — which is why non-thinking runs never showed it.

## Fix

Track a running per-message block offset (`assistant_blocks_seen`) so each `assistant` event's blocks recover their true index in the message and land on the same part ids the deltas built. A whole-content array in a single event is the offset-0 degenerate case and behaves as before. Subagent events (`parent_tool_use_id` set) get their own offset namespace so they can never advance the main message's offset. The counter trusts the CLI's exactly-once, in-order block emission — the events carry no wire index to cross-check; if a future CLI re-emitted blocks cumulatively, this would need revisiting (documented at the offset computation).

(For comparison: codex resolves delta-vs-final by a single in-flight part id per kind, and opencode gets server-assigned part ids — neither applies here since Claude interleaves thinking/text blocks positionally within one message.)

## Tests

- `per_block_assistant_events_land_on_the_delta_parts` — the live-captured per-block shape (regression for this bug, asserts part ids).
- `bridge_suppressed_blocks_still_advance_the_offset` — a suppressed ExitPlanMode still occupies its content position.
- `subagent_assistant_events_do_not_share_the_main_offset` — offset-namespace isolation.
- `block_offsets_are_keyed_per_message_id` — multi-message turns don't share a counter.
- Existing whole-array test renamed to `stream_deltas_paint_parts_and_a_whole_message_event_overwrites_them`.

`cargo fmt --check`, `clippy -D warnings`, and `cargo test --locked` (284 passed) are green. Reviewed by two rounds of 4 independent review agents; round 2 was unanimously blocker-free.


Fixes #128.
