### PR TITLE
Stamp chatSessionId on server-plane experiment creation

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -478,6 +478,9 @@ pub struct CreateChildBody {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     pub parent_experiment_id: String,
+    /// Populated from `launching_chat_session()`; None outside a chat session.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chat_session_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -491,6 +494,9 @@ pub struct CreateBaselineExperimentBody {
     /// Omit to set it later (`orx exp cmd`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub run_command: Option<String>,
+    /// Populated from `launching_chat_session()`; None outside a chat session.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chat_session_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1544,8 +1550,8 @@ pub async fn fetch_paper_markdown(kind: &str, paper_id: &str) -> Result<Option<S
 #[cfg(test)]
 mod tests {
     use super::{
-        CreateSandboxBody, ListCatalog, ListCpuCatalog, RunBody, RunTarget, SandboxEnvelope,
-        SandboxTarget,
+        CreateBaselineExperimentBody, CreateChildBody, CreateSandboxBody, ListCatalog,
+        ListCpuCatalog, RunBody, RunTarget, SandboxEnvelope, SandboxTarget,
     };
     use serde_json::json;
 
@@ -1819,5 +1825,47 @@ mod tests {
         assert_eq!(sb.ssh_hostname.as_deref(), Some("203.0.113.7"));
         assert_eq!(sb.ssh_port, Some(22022));
         assert_eq!(sb.ssh_username.as_deref(), Some("root"));
+    }
+
+    /// The api declares `chatSessionId` optional: a lost `rename_all` would send
+    /// `chat_session_id` and a lost `skip_serializing_if` would send `null`,
+    /// either of which silently drops the row's attribution.
+    #[test]
+    fn serializes_experiment_chat_session_id() {
+        let child = serde_json::to_value(CreateChildBody {
+            title: "Child".into(),
+            description: None,
+            parent_experiment_id: "exp_parent".into(),
+            chat_session_id: Some("ses_abc123".into()),
+        })
+        .unwrap();
+        assert_eq!(child.get("chatSessionId"), Some(&json!("ses_abc123")));
+
+        let child_without = serde_json::to_value(CreateChildBody {
+            title: "Child".into(),
+            description: None,
+            parent_experiment_id: "exp_parent".into(),
+            chat_session_id: None,
+        })
+        .unwrap();
+        assert!(child_without.get("chatSessionId").is_none());
+
+        let baseline = serde_json::to_value(CreateBaselineExperimentBody {
+            title: Some("Baseline".into()),
+            description: None,
+            run_command: None,
+            chat_session_id: Some("ses_abc123".into()),
+        })
+        .unwrap();
+        assert_eq!(baseline.get("chatSessionId"), Some(&json!("ses_abc123")));
+
+        let baseline_without = serde_json::to_value(CreateBaselineExperimentBody {
+            title: Some("Baseline".into()),
+            description: None,
+            run_command: None,
+            chat_session_id: None,
+        })
+        .unwrap();
+        assert!(baseline_without.get("chatSessionId").is_none());
     }
 }

--- a/src/local/chat/mod.rs
+++ b/src/local/chat/mod.rs
@@ -2072,11 +2072,17 @@ pub fn prepare_env(cmd: &mut tokio::process::Command) {
 /// notification back to exactly the session that started it.
 pub const CHAT_SESSION_ENV: &str = "ORX_CHAT_SESSION_ID";
 
+/// Marks a process as a child of a local `orx up` harness. Separate from
+/// [`CHAT_SESSION_ENV`], which the cloud box's opencode plugin also exports for
+/// attribution — presence of a session id alone no longer implies local.
+pub const LOCAL_SESSION_ENV: &str = "ORX_LOCAL_SESSION";
+
 /// Stamp the launching session id onto a harness child's env. Call *after*
 /// `prepare_env` so a dashboard-synced value can't shadow it. Harness children
 /// are one-per-session, so this is unambiguous.
 pub fn set_chat_session_env(cmd: &mut tokio::process::Command, session_id: &str) {
     cmd.env(CHAT_SESSION_ENV, session_id);
+    cmd.env(LOCAL_SESSION_ENV, "1");
 }
 
 /// The chat session that launched this run, read from the env the harness child
@@ -2089,13 +2095,13 @@ pub fn launching_chat_session() -> Option<String> {
 }
 
 /// Whether this process is running inside a local `orx up` session.
-/// [`CHAT_SESSION_ENV`] is exported only by [`set_chat_session_env`] onto
+/// [`LOCAL_SESSION_ENV`] is exported only by [`set_chat_session_env`] onto
 /// `orx up` harness children, so its presence means this process is one (or a
 /// subprocess of one). Commands that take a project or run id should prefer
 /// `…is_local()` on the resolved entity; this is for the ones that take
 /// neither (e.g. `orx skill <name>`).
 pub fn in_local_session() -> bool {
-    launching_chat_session().is_some()
+    std::env::var(LOCAL_SESSION_ENV).is_ok_and(|v| !v.is_empty())
 }
 
 /// Append-only stderr sink for a harness child (startup/debug diagnostics).
@@ -2110,6 +2116,65 @@ pub fn harness_log(name: &str) -> Result<std::fs::File> {
         .append(true)
         .open(&path)
         .map_err(|e| anyhow!("Could not open {}: {}", path.display(), e))
+}
+
+#[cfg(test)]
+mod session_env_tests {
+    use super::{in_local_session, CHAT_SESSION_ENV, LOCAL_SESSION_ENV};
+    use std::sync::{Mutex, MutexGuard};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        saved: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn new(vars: &[&'static str]) -> Self {
+            let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let saved = vars
+                .iter()
+                .map(|k| (*k, std::env::var(k).ok()))
+                .collect::<Vec<_>>();
+            for k in vars {
+                std::env::remove_var(k);
+            }
+            EnvGuard { _lock: lock, saved }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, v) in &self.saved {
+                match v {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+    }
+
+    /// The cloud box's opencode plugin exports CHAT_SESSION_ENV for experiment
+    /// attribution. That must not read as a local `orx up` session, or
+    /// `orx skill` serves the Local skill bodies on every cloud box.
+    #[test]
+    fn chat_session_alone_is_not_a_local_session() {
+        let _guard = EnvGuard::new(&[CHAT_SESSION_ENV, LOCAL_SESSION_ENV]);
+
+        std::env::set_var(CHAT_SESSION_ENV, "ses_cloud_box");
+        assert!(!in_local_session());
+
+        std::env::set_var(LOCAL_SESSION_ENV, "1");
+        assert!(in_local_session());
+    }
+
+    #[test]
+    fn empty_local_marker_is_not_a_local_session() {
+        let _guard = EnvGuard::new(&[CHAT_SESSION_ENV, LOCAL_SESSION_ENV]);
+        std::env::set_var(LOCAL_SESSION_ENV, "");
+        assert!(!in_local_session());
+    }
 }
 
 #[cfg(test)]

--- a/src/plane/server_plane.rs
+++ b/src/plane/server_plane.rs
@@ -621,6 +621,7 @@ impl ControlPlane for ServerPlane {
                     title,
                     description,
                     parent_experiment_id: parent,
+                    chat_session_id: crate::local::chat::launching_chat_session(),
                 },
             )
             .await?;
@@ -637,6 +638,7 @@ impl ControlPlane for ServerPlane {
                     title: Some(title),
                     description,
                     run_command,
+                    chat_session_id: crate::local::chat::launching_chat_session(),
                 },
             )
             .await?;


### PR DESCRIPTION
## Summary

Server-plane experiment creation now forwards the launching chat session (`launching_chat_session()`, already used by every local creation path) so openresearch.sh can attribute experiments to the agent conversation that asked for them. `CreateChildBody` and `CreateBaselineExperimentBody` gain `chat_session_id`, serialized as `chatSessionId` via the struct-wide camelCase rename and omitted entirely when absent.

Also splits a new `ORX_LOCAL_SESSION` marker out of `ORX_CHAT_SESSION_ID`. The cloud box's opencode plugin (in the companion PR) exports `ORX_CHAT_SESSION_ID` for attribution, and `in_local_session()` keyed off exactly that variable — so without the split, every cloud box would have read as a local `orx up` session and `orx skill` would have served the Local skill bodies instead of the Full ones. Local `orx up` behavior is unchanged: `set_chat_session_env` now sets both vars, and all four harness call sites go through it.

Pairs with alphaXiv/openresearch.sh#567. Neither breaks the other in isolation — the api treats `chatSessionId` as optional, and an older orx simply omits it.

No `ui/` changes, so no `ui/dist` rebuild and no version bump.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --locked` (325 passing)
- [x] Serde test pins both the camelCase key and the omit-when-None behavior
- [x] Env-split test: `ORX_CHAT_SESSION_ID` alone is NOT a local session; verified it fails if the old `launching_chat_session().is_some()` body is restored
- [ ] On a cloud box, `orx skill` still prints the Full skill bodies (not Local) while the plugin is active
- [ ] In a local `orx up` session, `orx skill` still prints the Local bodies
- [ ] Agent-created experiment on a cloud box lands with `chat_session_id` set in the api DB
- [ ] `orx create-experiment` from a plain terminal still sends no `chatSessionId`