### PR TITLE
OR-150 Add copy button to onboarding command text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,7 +928,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openresearch-cli"
-version = "0.1.94"
+version = "0.1.95"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openresearch-cli"
-version = "0.1.94"
+version = "0.1.95"
 edition = "2021"
 description = "OpenResearch CLI (orx) — Rust port"
 repository = "https://github.com/alphaXiv/openresearch-cli"

--- a/ui/src/components/Onboarding.tsx
+++ b/ui/src/components/Onboarding.tsx
@@ -418,46 +418,52 @@ function AgentCard({
 }) {
   const badge = agentBadge(h);
   const version = h.version?.replace(/\s*\(.*\)$/, "");
+  const head = (
+    <div className="onb-card-head">
+      <span className="onb-card-identity">
+        <AgentLogo harness={h.id} />
+        <span className="onb-card-name">{h.name}</span>
+      </span>
+      <span className={`status-badge ${badge.cls}`}>
+        {h.agentReady ? <Check size={12} strokeWidth={3} /> : <span className="dot" />}
+        {badge.label}
+      </span>
+    </div>
+  );
+  // An unready agent can't be selected — render it as a plain container, not a
+  // disabled button, so the copy button on its `agentNote` command stays live.
+  if (!h.agentReady) {
+    return (
+      <div className="onb-card onb-agent-choice">
+        {head}
+        <div className="onb-card-meta">{renderNote(h.agentNote)}</div>
+      </div>
+    );
+  }
   return (
     <button
       type="button"
       className={`onb-card onb-agent-choice${selected ? " selected" : ""}`}
-      disabled={!h.agentReady}
       aria-pressed={selected}
       onClick={onSelect}
     >
-      <div className="onb-card-head">
-        <span className="onb-card-identity">
-          <AgentLogo harness={h.id} />
-          <span className="onb-card-name">{h.name}</span>
-        </span>
-        <span className={`status-badge ${badge.cls}`}>
-          {h.agentReady ? <Check size={12} strokeWidth={3} /> : <span className="dot" />}
-          {badge.label}
-        </span>
+      {head}
+      <div className="onb-card-detail mono">
+        {h.account ?? "API key"}
+        {h.plan ? ` · ${h.plan}` : ""}
       </div>
-      {h.agentReady ? (
-        <>
-          <div className="onb-card-detail mono">
-            {h.account ?? "API key"}
-            {h.plan ? ` · ${h.plan}` : ""}
-          </div>
-          <div className="onb-card-meta">
-            {[
-              version,
-              h.models.length > 0 &&
-                `${h.models.length} model${h.models.length === 1 ? "" : "s"} — ${h.models
-                  .slice(0, 3)
-                  .map((m) => harnessModelLabel(m))
-                  .join(", ")}${h.models.length > 3 ? ", …" : ""}`,
-            ]
-              .filter(Boolean)
-              .join(" · ")}
-          </div>
-        </>
-      ) : (
-        <div className="onb-card-meta">{renderNote(h.agentNote)}</div>
-      )}
+      <div className="onb-card-meta">
+        {[
+          version,
+          h.models.length > 0 &&
+            `${h.models.length} model${h.models.length === 1 ? "" : "s"} — ${h.models
+              .slice(0, 3)
+              .map((m) => harnessModelLabel(m))
+              .join(", ")}${h.models.length > 3 ? ", …" : ""}`,
+        ]
+          .filter(Boolean)
+          .join(" · ")}
+      </div>
     </button>
   );
 }

--- a/ui/src/components/agentNote.tsx
+++ b/ui/src/components/agentNote.tsx
@@ -1,16 +1,41 @@
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
+
+/** A backtick command from an `agentNote`, rendered as a code pill with its own
+ * copy button so the user can grab it without retyping. */
+function CommandPill({ cmd }: { cmd: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <span className="cmd-inline">
+      <code className="mono">{cmd}</code>
+      <button
+        type="button"
+        className="cmd-inline-copy"
+        onClick={() => {
+          void navigator.clipboard
+            .writeText(cmd)
+            .then(() => {
+              setCopied(true);
+              setTimeout(() => setCopied(false), 1500);
+            })
+            .catch(() => {});
+        }}
+        aria-label={copied ? "Copied" : `Copy ${cmd}`}
+        title={copied ? "Copied" : "Copy"}
+      >
+        {copied ? <Check size={11} strokeWidth={3} /> : <Copy size={11} />}
+      </button>
+    </span>
+  );
+}
+
 /** Harness `agentNote` strings carry the command to run in backticks
- * (`claude auth login`) — render those spans as code so they read as something
- * to type, not prose. Shared by every surface that shows a note: onboarding,
- * the model picker, and settings. */
+ * (`claude auth login`) — render those spans as copyable code pills so they read
+ * as something to type, not prose. Shared by every surface that shows a note:
+ * onboarding, the model picker, and the chat panel. */
 export function renderNote(note: string | undefined) {
   if (!note) return null;
-  return note.split(/`([^`]+)`/).map((part, i) =>
-    i % 2 === 1 ? (
-      <code key={i} className="mono">
-        {part}
-      </code>
-    ) : (
-      part
-    ),
-  );
+  return note
+    .split(/`([^`]+)`/)
+    .map((part, i) => (i % 2 === 1 ? <CommandPill key={i} cmd={part} /> : part));
 }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -3088,18 +3088,19 @@ textarea::placeholder {
   color: inherit;
   font: inherit;
   text-align: left;
-  cursor: pointer;
   transition: border-color 120ms ease, box-shadow 120ms ease;
 }
-.onb-agent-choice:not(:disabled):hover {
+/* Only a selectable (ready) card is a button — the unready card is an inert div,
+   so keep the pointer cursor and hover feedback off it. */
+button.onb-agent-choice {
+  cursor: pointer;
+}
+button.onb-agent-choice:hover {
   border-color: var(--muted);
 }
 .onb-agent-choice.selected {
   border-color: var(--accent);
   box-shadow: 0 0 0 1px var(--accent);
-}
-.onb-agent-choice:disabled {
-  cursor: default;
 }
 .onb-card-head {
   display: flex;
@@ -3144,6 +3145,27 @@ textarea::placeholder {
   border-radius: var(--radius-xs);
   padding: 1px 5px;
   white-space: nowrap;
+}
+/* A renderNote() command plus its copy button, kept on one baseline. */
+.cmd-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  vertical-align: baseline;
+}
+.cmd-inline-copy {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px;
+  border: 0;
+  border-radius: var(--radius-xs);
+  background: none;
+  color: var(--muted);
+  cursor: pointer;
+}
+.cmd-inline-copy:hover {
+  background: var(--surface);
+  color: var(--text);
 }
 .onb-loading {
   display: flex;


### PR DESCRIPTION
Commands shown to the user in onboarding (e.g. `claude auth login` in an agent card's `agentNote`) are now copyable: renderNote emits a code pill with a copy button, shared across onboarding, the model picker, and the chat-panel harness warning.

An unready agent card is rendered as a plain <div> instead of a disabled <button> — a disabled button suppresses pointer events on its children, so the nested copy button could not be clicked; interactive cursor/hover styles are scoped to button.onb-agent-choice so the inert card stays inert.