### PR TITLE
OR-171: Make file references clickable

### DIFF
--- a/SYSTEM_PROMPT.md
+++ b/SYSTEM_PROMPT.md
@@ -204,34 +204,20 @@ Use conventional Markdown math delimiters: `$...$` for inline math and
 `$$...$$` for display math. Escape literal currency dollar signs, for example
 write `\$10` rather than `$10`, so prices are never interpreted as math.
 
-Every substantive factual or quantitative claim you make in chat should carry an
-evidence chip the reader can click to see the source — a number, a "we found X",
-a "the harness caps Y" is not trustworthy on its own. Put the chip right after
-the claim (it renders as a small pill). Emit evidence tags as raw tags; never
-surround them with backticks or a code fence, which prevents them from becoming
-clickable:
+Every substantive factual or quantitative claim in chat needs a clickable
+evidence tag immediately after it. Emit tags raw, never inside backticks or a
+code fence:
 
-- **Code fact** (a value, a bug, a behavior in the source): wrap the source file
-  so OpenResearch links it to the project — `<file path="relative/path.py" />`,
-  or with a line target `<file path="relative/path.py" lines="20-40" />`. Use
-  repo-relative paths (from the worktree root), not absolute paths. Also reach
-  for this whenever you'd otherwise write a bare file path or a markdown link to
-  a file — the file you edited, the entrypoint you're describing. When the file
-  belongs to an experiment's branch (code you wrote for a node), add
-  `exp="<experimentId>"` so the reader sees which experiment it's from and opens
-  that node's committed version: `<file path="minimal_maxrl.py" lines="60"
-  exp="889383f1-…" />`.
-- **Metric or result** (a score, a delta, a significance call): cite the run
-  whose logs produced it — `<run id="<runId>" />`. Logs are the only evidence
-  channel, so this opens exactly the log behind the number. Run ids come from
-  `orx runs` / launching a run. Add a short `label` to name the claim on the
-  pill, e.g. `<run id="run_abc123" label="+3.65pp" />`.
-- **Artifact** (a report, figure, CSV, or table you wrote): link the file under
-  the artifacts directory — `<file path="artifacts/<name>" />`.
+- **File or code fact:** Use <file path="relative/path.py" />. Every file or
+  artifact mentioned in prose must use this raw tag, never a bare or backticked
+  path. Commands and code blocks are exempt. Use repo-relative paths, optional
+  `lines="20-40"`, and `exp="<experimentId>"` for experiment files. Cite
+  artifacts as <file path="artifacts/<relative-path>" />.
+- **Metric or result:** Cite the producing run with <run id="<runId>" />.
+  Add a short label when useful: <run id="run_abc123" label="+3.65pp" />.
 
-Example: `Re-measured with 4 repeats: +3.65pp, not significant
-<run id="run_abc123" />. The harness capped response tokens at 320
-<file path="src/harness.py" lines="41" />.`
+Wrong: Saved as `figures/result.png`.
+Right: Saved as <file path="artifacts/figures/result.png" />.
 
 ## Compute backends
 

--- a/SYSTEM_PROMPT.md
+++ b/SYSTEM_PROMPT.md
@@ -204,17 +204,26 @@ Use conventional Markdown math delimiters: `$...$` for inline math and
 `$$...$$` for display math. Escape literal currency dollar signs, for example
 write `\$10` rather than `$10`, so prices are never interpreted as math.
 
-Every substantive factual or quantitative claim in chat needs a clickable
-evidence tag immediately after it. Emit tags raw, never inside backticks or a
-code fence:
+Every substantive factual or quantitative claim in chat should carry a
+clickable evidence chip immediately after it; the chip renders as a small pill.
+A number, a "we found X", or a "the harness caps Y" is not trustworthy on its
+own. Emit evidence tags raw; never surround them with backticks or a code fence,
+which prevents them from becoming clickable:
 
-- **File or code fact:** Use <file path="relative/path.py" />. Every file or
-  artifact mentioned in prose must use this raw tag, never a bare or backticked
-  path. Commands and code blocks are exempt. Use repo-relative paths, optional
-  `lines="20-40"`, and `exp="<experimentId>"` for experiment files. Cite
-  artifacts as <file path="artifacts/<relative-path>" />.
-- **Metric or result:** Cite the producing run with <run id="<runId>" />.
-  Add a short label when useful: <run id="run_abc123" label="+3.65pp" />.
+- **File or code fact** (a value, bug, or source behavior): every file or
+  artifact mentioned in prose must use a raw <file path="relative/path.py" />
+  tag, never a bare or backticked path. Paths inside commands and code blocks are
+  exempt. Use repo-relative paths (from the worktree root), not absolute paths;
+  add `lines="20-40"` to target lines. For a file on an experiment branch, add
+  `exp="<experimentId>"` so the reader sees its experiment and opens the
+  committed version: <file path="minimal_maxrl.py" lines="60"
+  exp="889383f1-…" />.
+- **Metric or result** (a score, delta, or significance call): cite the run whose
+  logs produced it with <run id="<runId>" />. Logs are the only evidence channel,
+  and run ids come from `orx runs` or launching a run. Add a short label to name
+  the claim when useful: <run id="run_abc123" label="+3.65pp" />.
+- **Artifact** (a report, figure, CSV, or table you wrote): cite its path under
+  the artifacts directory as <file path="artifacts/<relative-path>" />.
 
 Wrong: Saved as `figures/result.png`.
 Right: Saved as <file path="artifacts/figures/result.png" />.

--- a/agent-skills/orx-reports/SKILL.local.md
+++ b/agent-skills/orx-reports/SKILL.local.md
@@ -3,10 +3,9 @@ name: orx-reports
 description: "Write durable research outputs into the local project's artifacts directory. Use when a line of work concludes, when the user asks for a write-up, summary, comparison, figures, or exported data, or before ending a long task — findings not written down are lost."
 ---
 
-In local mode (`orx up`), outputs are written **directly into the project's
-artifacts directory** — there is no upload step. Reports, figures, images, CSVs,
-PDFs, and other useful outputs become project artifacts immediately. The
-directory path is shown in your session playbook.
+In local mode (`orx up`), write reports, figures, CSVs, PDFs, and other outputs
+directly into the artifacts directory shown in the session playbook. There is
+no upload step; written files become project artifacts immediately.
 
 When a line of work concludes (or the user asks for a write-up), use a descriptive
 filename that explains the output without relying on its directory, for example:
@@ -15,8 +14,7 @@ filename that explains the output without relying on its directory, for example:
 - `<artifacts-dir>/benchmark-results.csv`
 - `<artifacts-dir>/ablation-comparison.png`
 
-Write directly at the artifacts root by default. Folders and nested files are
-fully supported when the user requests them or the output naturally needs them.
-Markdown may reference nearby images by relative path; choose descriptive names
-for both the document and its assets. No directory name or filename such as
-`project/`, an experiment slug, or `report.md` is required or reserved.
+Write at the artifacts root unless a folder is useful. Markdown may reference
+nearby images by relative path; no name such as `project/`, an experiment slug,
+or `report.md` is reserved. In chat, cite every relevant output as raw
+<file path="artifacts/<relative-path>" />, never as a bare or backticked path.

--- a/src/local/agent_skills.rs
+++ b/src/local/agent_skills.rs
@@ -389,6 +389,13 @@ mod tests {
     }
 
     #[test]
+    fn local_reports_skill_links_written_artifacts() {
+        assert!(REPORTS_LOCAL.contains("cite every relevant output as raw"));
+        assert!(REPORTS_LOCAL.contains("<file path=\"artifacts/<relative-path>\" />"));
+        assert!(REPORTS_LOCAL.contains("never as a bare or backticked path"));
+    }
+
+    #[test]
     fn ensure_session_skills_writes_local_set_idempotently() {
         let tmp = std::env::temp_dir().join(format!(
             "orx-agent-skills-test-{}-{}",

--- a/src/local/opencode.rs
+++ b/src/local/opencode.rs
@@ -762,9 +762,16 @@ mod tests {
     #[test]
     fn playbook_requires_clickable_file_references() {
         let md = sample_playbook();
-        assert!(md.contains("Every file or"));
-        assert!(md.contains("artifact mentioned in prose must use this raw tag"));
-        assert!(md.contains("never a bare or backticked"));
+        assert!(md.contains("chip renders as a small pill"));
+        assert!(md.contains("every file or"));
+        assert!(md.contains("artifact mentioned in prose"));
+        assert!(md.contains("never a bare or backticked path"));
+        assert!(md.contains("Use repo-relative paths"));
+        assert!(md.contains("committed version"));
+        assert!(md.contains("Logs are the only evidence channel"));
+        assert!(md.contains("run ids come from `orx runs`"));
+        assert!(md.contains("Add a short label to name"));
+        assert!(md.contains("the claim when useful"));
         assert!(md.contains("<file path=\"artifacts/<relative-path>\" />"));
         assert!(md.contains("Wrong: Saved as"));
         assert!(md.contains("<file path=\"artifacts/figures/result.png\" />"));

--- a/src/local/opencode.rs
+++ b/src/local/opencode.rs
@@ -760,6 +760,17 @@ mod tests {
     }
 
     #[test]
+    fn playbook_requires_clickable_file_references() {
+        let md = sample_playbook();
+        assert!(md.contains("Every file or"));
+        assert!(md.contains("artifact mentioned in prose must use this raw tag"));
+        assert!(md.contains("never a bare or backticked"));
+        assert!(md.contains("<file path=\"artifacts/<relative-path>\" />"));
+        assert!(md.contains("Wrong: Saved as"));
+        assert!(md.contains("<file path=\"artifacts/figures/result.png\" />"));
+    }
+
+    #[test]
     fn playbook_avoids_ui_navigation() {
         let mut local_only = sample_project();
         local_only.github_owner.clear();


### PR DESCRIPTION
## Summary
- Require every file or artifact mentioned in prose to use a raw `<file>` tag
- Preserve evidence-chip placement, line targets, experiment provenance, committed-version behavior, log provenance, run-ID discovery, and labels
- Reinforce artifact linking at write time while keeping the combined prompt and skill 87 words shorter
- Add regression coverage for the playbook and bundled local reports skill

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --locked`
- [x] `cargo test --locked` (450 passed, 1 ignored)
- [ ] Manually confirm a live agent links a newly created artifact in chat

Linear: https://linear.app/alphaxiv/issue/OR-171/make-sure-image-citations-are-clickable