### PR TITLE
OR-161: make experiment wake-ups opt-in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,7 +1025,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openresearch-cli"
-version = "0.1.100"
+version = "0.1.101"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openresearch-cli"
-version = "0.1.100"
+version = "0.1.101"
 edition = "2021"
 description = "OpenResearch CLI (orx) — Rust port"
 repository = "https://github.com/alphaXiv/openresearch-cli"

--- a/SYSTEM_PROMPT.md
+++ b/SYSTEM_PROMPT.md
@@ -135,6 +135,7 @@ preferences.
 | {run_invocation} | {run_guidance} |
 | `orx exp cancel <expId>` | Cancel the in-flight run. |
 | `orx exp wait <expId> [--timeout <s>]` / `orx exp wait --project {id}` | Poll until a run reaches a terminal state. Exits **non-zero** after `--timeout` seconds (default 1800) with nothing changed — that means "still running", not an error. |
+| `orx exp wake <expId>` | Resume this local chat after the experiment's latest run succeeds or fails. Cancelled runs do not wake the chat. |
 | `orx runs {id} [--experiment <expId>]` | Run table, newest first. Run ids come from here. |
 | `orx logs <runId> [--head] [--bytes <n>] [--range <s>:<e>]` | Read a run's log (tail by default). |
 | `orx lit "<query>" [--source alphaxiv\|openalex\|biorxiv]` / `orx paper <id\|url>` | Literature search across alphaXiv, OpenAlex, and bioRxiv (public, no login): **`orx-lit`** skill. Preferred over web search for academic/research queries — start here. |
@@ -155,9 +156,9 @@ Carry one goal across many runs (full guidance: **`orx-experiment-tree`** skill)
    — one child per distinct thing you try.
 {edit_step}
 {launch_step}
-4. **Wait — hold your turn open**: call `orx exp wait <expId> --timeout 480`
-   (or `--project` when several are in flight) in a loop until it exits 0,
-   then go analyze (each call stays under your shell tool's own time limit).
+4. **Wait or wake**: stay active with `orx exp wait <expId> --timeout 480`
+   (or `--project` when several are in flight), or call `orx exp wake <expId>`
+   before ending your turn so this chat resumes after that run succeeds or fails.
 5. **Analyze**: `orx logs <runId>`. Logs are the only evidence channel — make
    the run command print every metric you'll need (**`orx-evidence`** skill).
 6. **Decide** — four moves. Write what you learned into `orx exp desc`.
@@ -190,13 +191,11 @@ runs, needs no summary.
 
 ## Staying online while runs execute
 
-Nothing re-invokes you when a run finishes, and there are no background
-monitors — any process you background dies when your turn ends, so "I'll keep
-watching the run" is not something you can do. While a run you launched is in
-flight, the wait loop above IS your job: stay in it, and end your turn only
-once you've read the result and acted on it. (If your turn does end early,
-OpenResearch injects an `[orx]` message when a run completes — treat it as
-the wake-up to reconcile and continue the loop.)
+Choose explicitly after launching a run. Use `orx exp wait` to keep this turn
+active until a run reaches a terminal state. Use `orx exp wake <expId>` when
+you intend to end the turn and resume later; it registers the experiment's
+latest run for this local chat. Unregistered runs never wake the chat, and
+cancelled runs never send a wake-up.
 
 ## Citing evidence
 

--- a/agent-skills/orx-compute/SKILL.local-only.md
+++ b/agent-skills/orx-compute/SKILL.local-only.md
@@ -1,6 +1,6 @@
 ---
 name: orx-compute
-description: "Launch committed experiments on this machine with `orx exp run --backend local`, wait for completion, and inspect logs. Use before launching or repairing any run in a local-only project."
+description: "Launch committed experiments on this machine with `orx exp run --backend local`, choose `orx exp wait` vs `orx exp wake`, and inspect logs. Use before launching or repairing any run in a local-only project."
 ---
 
 This project is local-only, so every experiment runs on this machine. Commit
@@ -10,6 +10,7 @@ the experiment branch first, then launch without selecting an external backend:
 orx exp status <expId>
 orx exp run <expId> --backend local
 orx exp wait --project <projectId>
+orx exp wake <expId>                    # alternative: go idle and resume later
 orx runs <projectId>
 orx logs <runId>
 ```
@@ -18,6 +19,11 @@ The runner clones the recorded commit from the project folder and checks out
 that exact commit detached. Uncommitted changes are excluded. A run returns
 immediately; use `orx exp wait --project` as a wake-up signal and reconcile
 terminal state with `orx runs` after every wake.
+
+If you want to end the current turn instead of blocking, call `orx exp wake
+<expId>` after launch. It resumes this agent when the latest run reaches `done`
+or `failed`; cancellation intentionally does not wake the agent. Do not use
+`exp wait` and `exp wake` for the same run.
 
 External compute is intentionally unavailable. If the user explicitly wants
 it, ask them to enable GitHub syncing for this project; do not attempt provider

--- a/agent-skills/orx-compute/SKILL.local.md
+++ b/agent-skills/orx-compute/SKILL.local.md
@@ -1,6 +1,6 @@
 ---
 name: orx-compute
-description: "Launch experiment runs with `orx exp run`: backends (hf, modal, k8s, ssh, slurm, ray, openresearch, local), flavors, timeouts, images, sizing, and `orx exp wait`. Use before launching or re-launching any run, when choosing or switching a backend or GPU flavor, when a job OOMs, stalls, or times out, or when deciding GPU vs CPU."
+description: "Launch experiment runs with `orx exp run`: backends (hf, modal, k8s, ssh, slurm, ray, openresearch, local), flavors, timeouts, images, sizing, and choosing `orx exp wait` vs `orx exp wake`. Use before launching or re-launching any run, when choosing or switching a backend or GPU flavor, when a job OOMs, stalls, or times out, or when deciding GPU vs CPU."
 ---
 
 Commit the experiment before launching. `orx` archives that exact revision and
@@ -244,6 +244,13 @@ orx exp wait <expId> --interval 10 --timeout 3600   # tune polling
 - **A failed run is not a new node.** Re-launch the same `<expId>` — a failure
   answered nothing, so the node is still repairable in place
   (`orx-experiment-tree`).
+
+### Going idle instead — `orx exp wake`
+
+After launching a run, use `orx exp wake <expId>` when you want to end the
+current turn and resume after that run succeeds or fails. The wake-up is opt-in,
+fires only for `done` or `failed`, and waits behind any user messages already
+queued for the session. Use either `exp wait` or `exp wake` for a run, not both.
 
 ## Sizing compute
 

--- a/src/commands/exp.rs
+++ b/src/commands/exp.rs
@@ -4,6 +4,7 @@
 //!   orx exp cmd    <expId> [--set …]  view or set the run command
 //!   orx exp run    <expId> …          launch a run on new or existing compute
 //!   orx exp cancel <expId>            cancel the in-flight run
+//!   orx exp wake   <expId>            resume this agent when the run succeeds or fails
 //!
 //! Unlike the project-scoped data commands, every verb here takes an
 //! *experiment* id (from `orx experiments <projectId>`).
@@ -51,6 +52,7 @@ pub async fn run(args: crate::ExpArgs) -> Result<()> {
                 .await
         }
         ExpCommand::Cancel { exp_id } => resolve_experiment(store, &exp_id)?.cancel().await,
+        ExpCommand::Wake { exp_id } => wake(&store, &exp_id),
         ExpCommand::Wait {
             exp_id,
             project,
@@ -58,6 +60,39 @@ pub async fn run(args: crate::ExpArgs) -> Result<()> {
             interval,
         } => wait(store, exp_id, project, timeout, interval).await,
     }
+}
+
+fn wake(store: &Store, exp_id: &str) -> Result<()> {
+    if !crate::local::chat::in_local_session() {
+        return Err(anyhow!(
+            "`orx exp wake` is only available inside a local `orx up` agent session."
+        ));
+    }
+    let session_id = crate::local::chat::launching_chat_session()
+        .ok_or_else(|| anyhow!("This agent session has no chat id to wake."))?;
+    if store.get_chat_session(&session_id)?.is_none() {
+        return Err(anyhow!("The current chat session no longer exists."));
+    }
+    let run = store
+        .latest_run_for_experiment(exp_id)?
+        .ok_or_else(|| anyhow!("Experiment {exp_id} has no runs to wake for."))?;
+    if run.status == "cancelled" {
+        store.remove_run_wakeup(&run.id, &session_id)?;
+        println!("Run {} was cancelled; no wake-up scheduled.", run.id);
+        return Ok(());
+    }
+    match store.register_run_wakeup(&run.id, &session_id)? {
+        crate::store::RunWakeupRegistration::Scheduled => {
+            println!("Wake-up scheduled for run {}.", run.id);
+        }
+        crate::store::RunWakeupRegistration::AlreadyPending => {
+            println!("Wake-up already scheduled for run {}.", run.id);
+        }
+        crate::store::RunWakeupRegistration::AlreadyDelivered => {
+            println!("Run {} already delivered its wake-up.", run.id);
+        }
+    }
+    Ok(())
 }
 
 /// `orx exp wait …` — block on run state, for agents driving a research loop.

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -67,14 +67,18 @@ pub async fn run(args: UpArgs) -> Result<()> {
         project_lifecycle: Arc::new(ProjectLifecycle::default()),
         publication_locks: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         data_dir_move_in_progress: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        data_dir_gate: Arc::new(tokio::sync::Mutex::new(())),
     };
     // Plan-mode turns hand this port to the `orx mcp-gate` permission bridge.
     state.chat.set_up_port(port);
 
     spawn_agent_preflight();
-    // Wake an idle chat session when a run completes (the agent's wait loop
-    // covers the busy case; this covers turns that ended early).
-    tokio::spawn(local::chat::watch_runs(state.chat.clone()));
+    // Deliver explicitly registered run wake-ups once their chat becomes idle.
+    tokio::spawn(local::chat::watch_runs(
+        state.chat.clone(),
+        state.data_dir_move_in_progress.clone(),
+        state.data_dir_gate.clone(),
+    ));
     spawn_claude_auth_monitor(state.chat.clone(), claude.clone(), state.harnesses.clone());
 
     let app = router(state);
@@ -153,6 +157,8 @@ struct AppState {
     /// check it and refuse (409) so nothing starts writing the store mid-move —
     /// closing the window between the move's in-flight check and its completion.
     data_dir_move_in_progress: Arc<std::sync::atomic::AtomicBool>,
+    /// Serializes wake-up store writes with a live data-directory move.
+    data_dir_gate: Arc<tokio::sync::Mutex<()>>,
 }
 
 async fn project_publication_lock(
@@ -2840,6 +2846,39 @@ async fn move_data_dir(State(state): State<AppState>, Json(req): Json<DataDirReq
             .store(false, Ordering::SeqCst);
     };
 
+    let data_dir_guard = state.data_dir_gate.clone().lock_owned().await;
+    let source_data_dir = crate::store::data_dir();
+    let move_token = uuid::Uuid::new_v4().to_string();
+    let (move_store, move_lock) = match Store::open().and_then(|store| {
+        let lock = store.acquire_data_dir_move_lock()?;
+        Ok((store, lock))
+    }) {
+        Ok(claim) => claim,
+        Err(_) => {
+            release(&state);
+            return ApiError(
+                StatusCode::CONFLICT,
+                "Another dashboard is moving the data directory.".into(),
+            )
+            .into_response();
+        }
+    };
+    let move_claimed = move_store.claim_data_dir_move(&move_token).unwrap_or(false);
+    if !move_claimed {
+        release(&state);
+        return ApiError(
+            StatusCode::CONFLICT,
+            "Can't move while another dashboard has an active chat turn or storage move.".into(),
+        )
+        .into_response();
+    }
+
+    let release_move_claim = |token: &str| {
+        if let Ok(store) = Store::open() {
+            let _ = store.release_data_dir_move(token);
+        }
+    };
+
     // In-flight guard: block if a chat turn or a run is active right now. (The
     // flag we just set prevents *new* ones from starting past this point.)
     let busy = state.chat.busy_sessions().await;
@@ -2848,6 +2887,7 @@ async fn move_data_dir(State(state): State<AppState>, Json(req): Json<DataDirReq
         .unwrap_or(0);
     let active_operations = state.project_lifecycle.operation_count();
     if !busy.is_empty() || active_runs > 0 || active_operations > 0 {
+        release_move_claim(&move_token);
         release(&state);
         return ApiError(
             StatusCode::CONFLICT,
@@ -2870,10 +2910,12 @@ async fn move_data_dir(State(state): State<AppState>, Json(req): Json<DataDirReq
     match validated {
         Ok(Ok(_)) => {}
         Ok(Err(e)) => {
+            release_move_claim(&move_token);
             release(&state);
             return bad_request(e).into_response();
         }
         Err(e) => {
+            release_move_claim(&move_token);
             release(&state);
             return ApiError::from(anyhow!("validate task failed: {e}")).into_response();
         }
@@ -2885,6 +2927,8 @@ async fn move_data_dir(State(state): State<AppState>, Json(req): Json<DataDirReq
     let flag = state.data_dir_move_in_progress.clone();
     let target = std::path::PathBuf::from(path);
     tokio::spawn(async move {
+        let _data_dir_guard = data_dir_guard;
+        let _move_lock = move_lock;
         use crate::local::datadir::MoveProgress;
         let chat_for_progress = chat.clone();
         // Throttle: forward at most one progress event per ~120ms of copy, but
@@ -2918,6 +2962,16 @@ async fn move_data_dir(State(state): State<AppState>, Json(req): Json<DataDirReq
                 "datadir.move.error",
                 json!({ "error": format!("move task panicked: {e}") }),
             ),
+        }
+        // A cross-filesystem copy retains the source DB, while a rename removes
+        // it. Avoid reopening a removed source path and recreating it.
+        if source_data_dir.exists() {
+            if let Ok(store) = Store::open_at(source_data_dir) {
+                let _ = store.release_data_dir_move(&move_token);
+            }
+        }
+        if let Ok(store) = Store::open() {
+            let _ = store.release_data_dir_move(&move_token);
         }
         flag.store(false, Ordering::SeqCst);
     });

--- a/src/local/agent_skills.rs
+++ b/src/local/agent_skills.rs
@@ -75,20 +75,18 @@ const EVIDENCE_CLOUD: &str = include_str!("../../agent-skills/orx-evidence/SKILL
 // works blind). Keep each ≤400 chars — Codex's ambient budget is ~8k across
 // the whole set.
 
-// The compute and experiment-tree descriptions are shared by the local and
-// cloud body variants (same public name, same triggers — only the body
-// changes), so they live in one const each.
-const D_COMPUTE: &str = "Launch experiment runs with `orx exp run`: backends (hf, modal, k8s, ssh, slurm, ray, openresearch, local), flavors, timeouts, images, sizing, and `orx exp wait`. Use before launching or re-launching any run, when choosing or switching a backend or GPU flavor, when a job OOMs, stalls, or times out, or when deciding GPU vs CPU.";
+const D_COMPUTE_LOCAL: &str = "Launch experiment runs with `orx exp run`: backends (hf, modal, k8s, ssh, slurm, ray, openresearch, local), flavors, timeouts, images, sizing, and choosing `orx exp wait` vs `orx exp wake`. Use before launching or re-launching any run, when choosing or switching a backend or GPU flavor, when a job OOMs, stalls, or times out, or when deciding GPU vs CPU.";
+const D_COMPUTE_CLOUD: &str = "Launch experiment runs with `orx exp run`: backends (hf, modal, k8s, ssh, slurm, ray, openresearch, local), flavors, timeouts, images, sizing, and `orx exp wait`. Use before launching or re-launching any run, when choosing or switching a backend or GPU flavor, when a job OOMs, stalls, or times out, or when deciding GPU vs CPU.";
 const D_EXPERIMENT_TREE: &str = "The experiment-tree model and the auto-research loop: shape the tree (stacked bushes), branch/launch/wait/promote, and `orx exp desc` notes. Use before creating, planning, or reorganizing experiments, when deciding what to try next, when a round of runs finishes, or whenever you're unsure how work maps onto the tree.";
 
 const S_COMPUTE_LOCAL: AgentSkill = AgentSkill {
     name: "orx-compute",
-    description: D_COMPUTE,
+    description: D_COMPUTE_LOCAL,
     content: COMPUTE_LOCAL,
 };
 const S_COMPUTE_CLOUD: AgentSkill = AgentSkill {
     name: "orx-compute",
-    description: D_COMPUTE,
+    description: D_COMPUTE_CLOUD,
     content: COMPUTE_CLOUD,
 };
 const S_COMPUTE_K8S: AgentSkill = AgentSkill {

--- a/src/local/chat/mod.rs
+++ b/src/local/chat/mod.rs
@@ -1357,6 +1357,8 @@ pub struct ChatHost {
     /// A key remains present throughout the lifecycle, so a replacement turn
     /// cannot race native shutdown for the preceding one.
     turns: Mutex<HashMap<String, TurnState>>,
+    /// Cross-process ownership tokens for locally active turn slots.
+    durable_turns: std::sync::Mutex<HashMap<String, String>>,
     deleting_sessions: Arc<std::sync::Mutex<HashSet<String>>>,
     /// Per-session serialization for `respond`. Answering a prompt reads the
     /// card, delivers the answer (a non-idempotent POST for inline harnesses),
@@ -1453,6 +1455,13 @@ enum TurnAdmission {
     Preclaimed(TurnGuard),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TurnSubmission {
+    Started,
+    Queued,
+    NotStarted,
+}
+
 fn contextualize_messages(
     messages: Vec<AnnotatedText>,
     mut expand: impl FnMut(&str) -> String,
@@ -1466,6 +1475,30 @@ fn contextualize_messages(
         .filter(|text| !text.trim().is_empty())
         .collect::<Vec<_>>()
         .join("\n\n")
+}
+
+fn transcript_parts(
+    display_text: &str,
+    saved_images: &[SavedAttachment],
+    annotations: &[TextAnnotation],
+) -> Vec<WirePart> {
+    let mut parts = Vec::new();
+    if !display_text.is_empty() {
+        parts.push(WirePart::text("p0", display_text.to_string()));
+    }
+    for (i, attachment) in saved_images.iter().enumerate() {
+        parts.push(WirePart::image(
+            format!("img{i}"),
+            attachment.file_name.clone(),
+        ));
+    }
+    for (i, annotation) in annotations.iter().enumerate() {
+        parts.push(WirePart::annotation(
+            format!("annotation{i}"),
+            annotation.text.trim(),
+        ));
+    }
+    parts
 }
 
 /// Chip label for a parked message: its text, or an attachment count for an
@@ -1525,6 +1558,9 @@ impl TurnGuard {
         {
             return None;
         }
+        if !host.claim_durable_turn(session_id) {
+            return None;
+        }
         turns.insert(session_id.to_string(), TurnState::Reserved);
         if let Some(overrides) = overrides {
             let mut plan_changes = host.plan_changes.lock().unwrap();
@@ -1543,6 +1579,32 @@ impl TurnGuard {
         })
     }
 
+    /// Reserve a wake-up turn only when no turn or queued user message exists.
+    async fn claim_hidden(host: &Arc<ChatHost>, session_id: &str) -> Option<Self> {
+        if host.deleting_sessions.lock().unwrap().contains(session_id) {
+            return None;
+        }
+        let mut turns = host.turns.lock().await;
+        let queued = host.queued.lock().unwrap();
+        if host.deleting_sessions.lock().unwrap().contains(session_id)
+            || turns.contains_key(session_id)
+            || queued
+                .get(session_id)
+                .is_some_and(|messages| !messages.is_empty())
+        {
+            return None;
+        }
+        if !host.claim_durable_turn(session_id) {
+            return None;
+        }
+        turns.insert(session_id.to_string(), TurnState::Reserved);
+        Some(Self {
+            host: host.clone(),
+            session_id: session_id.to_string(),
+            armed: true,
+        })
+    }
+
     /// Hand ownership of the slot to the spawned turn — stop clearing it on drop.
     fn defuse(mut self) {
         self.armed = false;
@@ -1553,20 +1615,35 @@ impl TurnGuard {
             return;
         }
         self.armed = false;
-        let removed = {
+        let (removed, drain_queued) = {
             let mut turns = self.host.turns.lock().await;
             if matches!(turns.get(&self.session_id), Some(TurnState::Reserved)) {
-                turns.remove(&self.session_id);
-                true
+                let drain_queued = self
+                    .host
+                    .queued
+                    .lock()
+                    .unwrap()
+                    .get(&self.session_id)
+                    .is_some_and(|queue| !queue.is_empty());
+                if drain_queued {
+                    turns.insert(self.session_id.clone(), TurnState::Draining);
+                } else {
+                    self.host.release_durable_turn(&self.session_id);
+                    turns.remove(&self.session_id);
+                }
+                (true, drain_queued)
             } else {
-                false
+                (false, false)
             }
         };
         if removed {
             self.host.emit(
                 "chat.busy",
-                json!({ "sessionId": &self.session_id, "busy": false }),
+                json!({ "sessionId": &self.session_id, "busy": drain_queued }),
             );
+            if drain_queued {
+                self.host.drain_queue(&self.session_id).await;
+            }
         }
     }
 }
@@ -1579,21 +1656,34 @@ impl Drop for TurnGuard {
         let host = self.host.clone();
         let session_id = self.session_id.clone();
         tokio::spawn(async move {
-            let removed = {
+            let (removed, drain_queued) = {
                 let mut turns = host.turns.lock().await;
                 if matches!(turns.get(&session_id), Some(TurnState::Reserved)) {
-                    turns.remove(&session_id);
-                    true
+                    let drain_queued = host
+                        .queued
+                        .lock()
+                        .unwrap()
+                        .get(&session_id)
+                        .is_some_and(|queue| !queue.is_empty());
+                    if drain_queued {
+                        turns.insert(session_id.clone(), TurnState::Draining);
+                    } else {
+                        host.release_durable_turn(&session_id);
+                        turns.remove(&session_id);
+                    }
+                    (true, drain_queued)
                 } else {
-                    false
+                    (false, false)
                 }
             };
             if removed {
                 host.emit(
                     "chat.busy",
-                    json!({ "sessionId": &session_id, "busy": false }),
+                    json!({ "sessionId": &session_id, "busy": drain_queued }),
                 );
-                host.drain_queue(&session_id).await;
+                if drain_queued {
+                    host.drain_queue(&session_id).await;
+                }
             }
         });
     }
@@ -1613,6 +1703,7 @@ impl ChatHost {
             http: reqwest::Client::new(),
             events,
             turns: Mutex::new(HashMap::new()),
+            durable_turns: std::sync::Mutex::new(HashMap::new()),
             deleting_sessions: Arc::new(std::sync::Mutex::new(HashSet::new())),
             respond_locks: Mutex::new(HashMap::new()),
             msg_write: std::sync::Mutex::new(()),
@@ -1918,6 +2009,43 @@ impl ChatHost {
         self.turns.lock().await.contains_key(session_id)
     }
 
+    fn claim_durable_turn(&self, session_id: &str) -> bool {
+        let mut claims = self.durable_turns.lock().unwrap();
+        if claims.contains_key(session_id) {
+            return false;
+        }
+        let token = uuid::Uuid::new_v4().to_string();
+        let Ok(store) = Store::open() else {
+            return false;
+        };
+        if !matches!(store.claim_chat_turn(session_id, &token), Ok(true)) {
+            return false;
+        }
+        claims.insert(session_id.to_string(), token);
+        true
+    }
+
+    fn release_durable_turn(&self, session_id: &str) {
+        let token = self.durable_turns.lock().unwrap().remove(session_id);
+        if let (Some(token), Ok(store)) = (token, Store::open()) {
+            let _ = store.release_chat_turn(session_id, &token);
+        }
+    }
+
+    fn renew_turn_leases(&self) -> Vec<String> {
+        let claims = self.durable_turns.lock().unwrap().clone();
+        let Ok(store) = Store::open() else {
+            return Vec::new();
+        };
+        let mut lost = Vec::new();
+        for (session_id, token) in claims {
+            if matches!(store.renew_chat_turn(&session_id, &token), Ok(false)) {
+                lost.push(session_id);
+            }
+        }
+        lost
+    }
+
     pub fn begin_session_delete(&self, session_id: &str) -> Option<SessionDeletionLease> {
         let mut deleting = self.deleting_sessions.lock().unwrap();
         if !deleting.insert(session_id.to_string()) {
@@ -2155,6 +2283,30 @@ impl ChatHost {
             TurnAdmission::QueueIfBusy,
         )
         .await
+        .map(|_| ())
+    }
+
+    async fn send_hidden_message(
+        self: &Arc<Self>,
+        session_id: &str,
+        text: String,
+        guard: TurnGuard,
+    ) -> Result<TurnSubmission> {
+        self.send_message_showing(
+            session_id,
+            vec![AnnotatedText {
+                text,
+                annotations: Vec::new(),
+            }],
+            TranscriptDisplay {
+                text: Some(String::new()),
+                annotations: None,
+            },
+            TurnOverrides::default(),
+            Vec::new(),
+            TurnAdmission::Preclaimed(guard),
+        )
+        .await
     }
 
     /// Persists one displayed user turn, then expands and contextualizes each
@@ -2168,7 +2320,7 @@ impl ChatHost {
         mut overrides: TurnOverrides,
         images: Vec<ImageAttachment>,
         admission: TurnAdmission,
-    ) -> Result<()> {
+    ) -> Result<TurnSubmission> {
         let TranscriptDisplay {
             text: transcript_text,
             annotations: transcript_annotations,
@@ -2214,80 +2366,90 @@ impl ChatHost {
         // same session. `_guard` releases the reservation on any early error.
         let mut guard = match admission {
             TurnAdmission::Preclaimed(guard) => guard,
-            admission => {
-                let queue_if_busy = matches!(admission, TurnAdmission::QueueIfBusy);
+            TurnAdmission::RejectIfBusy => {
                 match TurnGuard::claim(self, session_id, Some(&mut overrides)).await {
                     Some(guard) => guard,
-                    // Busy: park a genuine user send (Claude-desktop steering) so it
-                    // runs when the turn ends, instead of rejecting it. System/resume
-                    // sends pass `queue_if_busy = false` and keep the old rejection.
-                    None if queue_if_busy
-                        && !(text.trim().is_empty() && images.is_empty() && !has_annotations) =>
-                    {
-                        let message = messages
-                            .into_iter()
-                            .next()
-                            .ok_or_else(|| anyhow!("message content is required"))?;
-                        let AnnotatedText { text, annotations } = message;
-                        let idle = {
-                            let turns = self.turns.lock().await;
-                            if matches!(turns.get(session_id), Some(TurnState::Cancelling)) {
-                                return Err(anyhow!(
-                                    "session is stopping — send again once it is idle"
-                                ));
-                            }
-                            let mut plan_changes = self.plan_changes.lock().unwrap();
-                            let mut permission_changes = self.permission_changes.lock().unwrap();
-                            let mut queued = self.queued.lock().unwrap();
-                            stamp_turn_revisions(
-                                &mut overrides,
-                                session_id,
-                                &mut plan_changes,
-                                &mut permission_changes,
-                            );
-                            if let Some(plan_mode) = overrides.plan_mode {
-                                let current = store
-                                    .get_chat_session(session_id)?
-                                    .ok_or_else(|| anyhow!("chat session not found"))?;
-                                let reset_pending = !plan_mode
-                                    && current.harness == "codex"
-                                    && (current.plan_mode || current.plan_reset_pending);
-                                store.set_chat_session_plan_state(
-                                    session_id,
-                                    plan_mode,
-                                    reset_pending,
-                                )?;
-                                overrides.plan_mode = None;
-                                overrides.plan_revision = None;
-                            }
-                            if let Some(permission_mode) = overrides.permission_mode.take() {
-                                store.set_chat_session_permission_mode(
-                                    session_id,
-                                    &permission_mode,
-                                )?;
-                                overrides.permission_revision = None;
-                            }
-                            queued.entry(session_id.to_string()).or_default().push_back(
-                                QueuedMessage {
-                                    id: format!("q_{}", uuid::Uuid::new_v4()),
-                                    text,
-                                    transcript_text,
-                                    overrides,
-                                    images,
-                                    annotations,
-                                },
-                            );
-                            !turns.contains_key(session_id)
-                        };
-                        self.emit_queued(session_id);
-                        self.emit_session(store.get_chat_session(session_id)?).await;
-                        if idle {
-                            self.drain_queue(session_id).await;
-                        }
-                        return Ok(());
-                    }
                     None => return Err(anyhow!("session is busy — interrupt it first")),
                 }
+            }
+            TurnAdmission::QueueIfBusy => {
+                let mut turns = self.turns.lock().await;
+                if self.deleting_sessions.lock().unwrap().contains(session_id) {
+                    return Err(anyhow!("chat session not found"));
+                }
+                if turns.contains_key(session_id) {
+                    if matches!(turns.get(session_id), Some(TurnState::Cancelling)) {
+                        return Err(anyhow!("session is stopping — send again once it is idle"));
+                    }
+                    if text.trim().is_empty() && images.is_empty() && !has_annotations {
+                        return Err(anyhow!("message content is required"));
+                    }
+                    let message = messages
+                        .into_iter()
+                        .next()
+                        .ok_or_else(|| anyhow!("message content is required"))?;
+                    let AnnotatedText { text, annotations } = message;
+                    let mut plan_changes = self.plan_changes.lock().unwrap();
+                    let mut permission_changes = self.permission_changes.lock().unwrap();
+                    let mut queued = self.queued.lock().unwrap();
+                    stamp_turn_revisions(
+                        &mut overrides,
+                        session_id,
+                        &mut plan_changes,
+                        &mut permission_changes,
+                    );
+                    if let Some(plan_mode) = overrides.plan_mode {
+                        let current = store
+                            .get_chat_session(session_id)?
+                            .ok_or_else(|| anyhow!("chat session not found"))?;
+                        let reset_pending = !plan_mode
+                            && current.harness == "codex"
+                            && (current.plan_mode || current.plan_reset_pending);
+                        store.set_chat_session_plan_state(session_id, plan_mode, reset_pending)?;
+                        overrides.plan_mode = None;
+                        overrides.plan_revision = None;
+                    }
+                    if let Some(permission_mode) = overrides.permission_mode.take() {
+                        store.set_chat_session_permission_mode(session_id, &permission_mode)?;
+                        overrides.permission_revision = None;
+                    }
+                    queued
+                        .entry(session_id.to_string())
+                        .or_default()
+                        .push_back(QueuedMessage {
+                            id: format!("q_{}", uuid::Uuid::new_v4()),
+                            text,
+                            transcript_text,
+                            overrides,
+                            images,
+                            annotations,
+                        });
+                    drop(queued);
+                    drop(permission_changes);
+                    drop(plan_changes);
+                    drop(turns);
+                    self.emit_queued(session_id);
+                    if let Some(session) = store.get_chat_session(session_id)? {
+                        self.emit(
+                            "chat.session",
+                            json!({ "session": session_json(&session, true) }),
+                        );
+                    }
+                    return Ok(TurnSubmission::Queued);
+                }
+                if !self.claim_durable_turn(session_id) {
+                    return Err(anyhow!("session is busy in another `orx up` process"));
+                }
+                turns.insert(session_id.to_string(), TurnState::Reserved);
+                let mut plan_changes = self.plan_changes.lock().unwrap();
+                let mut permission_changes = self.permission_changes.lock().unwrap();
+                stamp_turn_revisions(
+                    &mut overrides,
+                    session_id,
+                    &mut plan_changes,
+                    &mut permission_changes,
+                );
+                TurnGuard::adopt(self, session_id)
             }
         };
         // Composer selections are sticky: an override that differs from the
@@ -2405,19 +2567,7 @@ impl ChatHost {
             }
         }
 
-        let mut parts = Vec::new();
-        if !display_text.is_empty() {
-            parts.push(WirePart::text("p0", display_text.to_string()));
-        }
-        for (i, att) in saved_images.iter().enumerate() {
-            parts.push(WirePart::image(format!("img{i}"), att.file_name.clone()));
-        }
-        for (i, annotation) in transcript_annotations.iter().enumerate() {
-            parts.push(WirePart::annotation(
-                format!("annotation{i}"),
-                annotation.text.trim(),
-            ));
-        }
+        let parts = transcript_parts(display_text, &saved_images, &transcript_annotations);
         // A resume whose transcript text is empty (e.g. a note-less plan
         // approval) records no user message: the resolved card already tells
         // that part of the story, and an empty bubble would just be noise.
@@ -2527,7 +2677,7 @@ impl ChatHost {
             {
                 drop(turns);
                 guard.release().await;
-                return Ok(());
+                return Ok(TurnSubmission::NotStarted);
             }
             let (target_path, target_event_offset) =
                 target_event_start(&session.id, &ctx.assistant.id);
@@ -2572,36 +2722,19 @@ impl ChatHost {
             }
             guard.defuse();
         }
-        Ok(())
+        Ok(TurnSubmission::Started)
     }
 
     /// Turn cleanup: drop the handle, bump the session, broadcast idle.
     async fn finish_turn(&self, session_id: &str, message_id: Option<&str>) {
-        let (should_finish, reserved_queue) = {
-            let mut turns = self.turns.lock().await;
-            let matches = match (turns.get(session_id), message_id) {
+        let should_finish = {
+            let turns = self.turns.lock().await;
+            match (turns.get(session_id), message_id) {
                 (Some(TurnState::Active(active)), Some(message_id)) => {
                     active.message_id == message_id
                 }
                 (Some(TurnState::Cancelling), None) => true,
                 _ => false,
-            };
-            if matches {
-                let reserved_queue = message_id.is_some()
-                    && self
-                        .queued
-                        .lock()
-                        .unwrap()
-                        .get(session_id)
-                        .is_some_and(|queue| !queue.is_empty());
-                if reserved_queue {
-                    turns.insert(session_id.to_string(), TurnState::Draining);
-                } else {
-                    turns.remove(session_id);
-                }
-                (true, reserved_queue)
-            } else {
-                (false, false)
             }
         };
         if !should_finish {
@@ -2610,14 +2743,44 @@ impl ChatHost {
         // Any bridge card still pending belongs to the turn that just ended —
         // deny it so the (dying) bridge child's long-poll unblocks.
         self.cancel_pending_permissions(session_id);
-        if let Ok(store) = Store::open() {
+        let session = if let Ok(store) = Store::open() {
             let _ = store.touch_chat_session(session_id);
-            if let Ok(Some(session)) = store.get_chat_session(session_id) {
-                self.emit(
-                    "chat.session",
-                    json!({ "session": session_json(&session, false) }),
-                );
+            store.get_chat_session(session_id).ok().flatten()
+        } else {
+            None
+        };
+        let reserved_queue = {
+            let mut turns = self.turns.lock().await;
+            let matches = match (turns.get(session_id), message_id) {
+                (Some(TurnState::Active(active)), Some(message_id)) => {
+                    active.message_id == message_id
+                }
+                (Some(TurnState::Cancelling), None) => true,
+                _ => false,
+            };
+            if !matches {
+                return;
             }
+            let reserved_queue = message_id.is_some()
+                && self
+                    .queued
+                    .lock()
+                    .unwrap()
+                    .get(session_id)
+                    .is_some_and(|queue| !queue.is_empty());
+            if reserved_queue {
+                turns.insert(session_id.to_string(), TurnState::Draining);
+            } else {
+                self.release_durable_turn(session_id);
+                turns.remove(session_id);
+            }
+            reserved_queue
+        };
+        if let Some(session) = session {
+            self.emit(
+                "chat.session",
+                json!({ "session": session_json(&session, reserved_queue) }),
+            );
         }
         self.emit(
             "chat.busy",
@@ -3893,80 +4056,114 @@ pub fn list_messages(session_id: &str) -> Result<Vec<WireMessage>> {
 
 // --- run watcher ----------------------------------------------------------------
 
-fn is_terminal(status: &str) -> bool {
-    matches!(status, "done" | "failed" | "cancelled")
+fn run_wakeup_text(run: &crate::store::StoredRun) -> Option<String> {
+    matches!(run.status.as_str(), "done" | "failed").then(|| {
+        format!(
+            "[orx] Run `{}` finished with status **{}**. You can compare this result with other \
+             project runs using `orx runs {}` and inspect this run's logs using `orx logs {}`.",
+            run.id, run.status, run.project_id, run.id
+        )
+    })
 }
 
-/// The chat session a completed run should notify: the one that *launched* it
-/// (recorded on the run), provided it still exists and has history. Returns
-/// `None` for an orphan run (no owning session — CLI-launched or pre-migration)
-/// or a launcher since deleted/emptied. Store-only (the busy check and send stay
-/// in `watch_runs`), which also keeps the routing decision unit-testable.
-fn notify_target(store: &Store, run: &crate::store::StoredRun) -> Option<String> {
-    let session_id = run.chat_session_id.clone()?;
-    let session = store.get_chat_session(&session_id).ok().flatten()?;
-    let has_history = store
-        .list_chat_messages(&session.id)
-        .map(|m| !m.is_empty())
-        .unwrap_or(false);
-    has_history.then_some(session.id)
+fn first_wakeup_per_session(wakeups: Vec<crate::store::RunWakeup>) -> Vec<crate::store::RunWakeup> {
+    let mut seen_sessions = HashSet::new();
+    wakeups
+        .into_iter()
+        .filter(|wakeup| seen_sessions.insert(wakeup.chat_session_id.clone()))
+        .collect()
 }
 
-/// Poke the chat session that *launched* a run when it completes while no turn
-/// is in flight — the local stand-in for the cloud agent staying online inside
-/// a blocking `orx exp wait`. Routing is by the run's recorded
-/// `chat_session_id` (stamped from the harness child's `ORX_CHAT_SESSION_ID`),
-/// never a project-wide guess, so a second idle agent in the same project is
-/// never handed another agent's run. The first pass only seeds the cursor, so a
-/// server restart doesn't replay old completions. A busy owner is skipped (the
-/// agent is awake — likely in its wait loop — and will see the completion
-/// itself); a run with no owning session (CLI-launched) pokes nothing.
-pub async fn watch_runs(chat: Arc<ChatHost>) {
-    let mut seen: HashMap<String, String> = HashMap::new();
-    let mut first = true;
-    loop {
-        tokio::time::sleep(Duration::from_secs(3)).await;
-        // Store hiccups (locked db) just skip a tick.
-        let Ok(store) = Store::open() else { continue };
-        let Ok(runs) = store.list_runs(200) else {
+async fn process_run_wakeups(
+    chat: &Arc<ChatHost>,
+    store: Store,
+    data_dir_move_in_progress: Option<&std::sync::atomic::AtomicBool>,
+) -> Result<()> {
+    if data_dir_move_in_progress.is_some_and(|flag| flag.load(std::sync::atomic::Ordering::SeqCst))
+    {
+        return Ok(());
+    }
+    store.prune_run_wakeups()?;
+    for wakeup in first_wakeup_per_session(store.list_ready_run_wakeups()?) {
+        if wakeup.state != "pending" {
+            continue;
+        }
+        let Some(mut guard) = TurnGuard::claim_hidden(chat, &wakeup.chat_session_id).await else {
             continue;
         };
-        for run in runs {
-            let prev = seen.insert(run.id.clone(), run.status.clone());
-            let newly_terminal =
-                is_terminal(&run.status) && !matches!(prev.as_deref(), Some(s) if is_terminal(s));
-            if first || !newly_terminal {
-                continue;
+        if data_dir_move_in_progress
+            .is_some_and(|flag| flag.load(std::sync::atomic::Ordering::SeqCst))
+        {
+            guard.release().await;
+            return Ok(());
+        }
+        let Some(token) = store.claim_run_wakeup(&wakeup.run.id, &wakeup.chat_session_id)? else {
+            guard.release().await;
+            continue;
+        };
+        if !store.renew_run_wakeup_claim(&wakeup.run.id, &wakeup.chat_session_id, &token)? {
+            guard.release().await;
+            continue;
+        }
+        let Some(text) = run_wakeup_text(&wakeup.run) else {
+            store.release_run_wakeup(&wakeup.run.id, &wakeup.chat_session_id, &token)?;
+            guard.release().await;
+            continue;
+        };
+        match chat
+            .send_hidden_message(&wakeup.chat_session_id, text, guard)
+            .await
+        {
+            Ok(TurnSubmission::Started) => {
+                if !store.mark_run_wakeup_delivered(
+                    &wakeup.run.id,
+                    &wakeup.chat_session_id,
+                    &token,
+                )? {
+                    return Err(anyhow!(
+                        "run wake-up claim expired before delivery was recorded"
+                    ));
+                }
             }
-            // The launching session (see `notify_target`); `None` skips.
-            let Some(session_id) = notify_target(&store, &run) else {
-                continue;
-            };
-            if chat.is_busy(&session_id).await {
-                // The owner is awake — likely blocking in its own `orx exp
-                // wait` — and will observe the completion itself.
-                continue;
+            Ok(TurnSubmission::Queued | TurnSubmission::NotStarted) => {
+                store.release_run_wakeup(&wakeup.run.id, &wakeup.chat_session_id, &token)?;
             }
-            let text = format!(
-                "[orx] Run `{}` finished with status **{}**. Reconcile with \
-                 `orx runs {}`, analyze the result (`orx logs {}`), and \
-                 continue the loop.",
-                run.id, run.status, run.project_id, run.id
-            );
-            if let Err(err) = chat
-                .send_message(
-                    &session_id,
-                    text,
-                    TurnOverrides::default(),
-                    Vec::new(),
-                    Vec::new(),
-                )
-                .await
-            {
-                eprintln!("orx up: run watcher: {err}");
+            Err(err) => {
+                store.release_run_wakeup(&wakeup.run.id, &wakeup.chat_session_id, &token)?;
+                if !chat.is_busy(&wakeup.chat_session_id).await {
+                    eprintln!("orx up: run watcher: {err}");
+                }
             }
         }
-        first = false;
+    }
+    Ok(())
+}
+
+/// Resume explicitly subscribed agent sessions after a run finishes. Busy and
+/// draining sessions retain their durable wake-up until they become idle.
+pub async fn watch_runs(
+    chat: Arc<ChatHost>,
+    data_dir_move_in_progress: Arc<std::sync::atomic::AtomicBool>,
+    data_dir_gate: Arc<tokio::sync::Mutex<()>>,
+) {
+    loop {
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        if data_dir_move_in_progress.load(std::sync::atomic::Ordering::SeqCst) {
+            continue;
+        }
+        let _data_dir_guard = data_dir_gate.lock().await;
+        if data_dir_move_in_progress.load(std::sync::atomic::Ordering::SeqCst) {
+            continue;
+        }
+        for session_id in chat.renew_turn_leases() {
+            let _ = chat.interrupt(&session_id).await;
+        }
+        let Ok(store) = Store::open() else { continue };
+        if let Err(err) =
+            process_run_wakeups(&chat, store, Some(data_dir_move_in_progress.as_ref())).await
+        {
+            eprintln!("orx up: run watcher: {err}");
+        }
     }
 }
 
@@ -3993,8 +4190,7 @@ pub fn prepare_env(cmd: &mut tokio::process::Command) {
 /// Env var carrying the launching chat session's id into a harness child. The
 /// agent shells out `orx exp run`, a fresh `orx` subprocess that inherits this,
 /// so run creation can stamp `StoredRun::chat_session_id` (see
-/// `launching_chat_session`) and the run watcher can route the completion
-/// notification back to exactly the session that started it.
+/// `launching_chat_session`) and `orx exp wake` can register the current chat.
 pub const CHAT_SESSION_ENV: &str = "ORX_CHAT_SESSION_ID";
 
 /// Marks a process as a child of a local `orx up` harness. Separate from
@@ -5049,15 +5245,15 @@ mod bridge_tests {
 }
 
 #[cfg(test)]
-mod notify_target_tests {
+mod run_wakeup_tests {
     use super::*;
-    use crate::store::{Store, StoredChatMessage, StoredChatSession, StoredRun};
+    use crate::store::{Store, StoredChatSession, StoredRun};
 
-    fn session(store: &Store, id: &str, project: &str, updated_at: i64, msgs: usize) {
+    fn session(store: &Store, id: &str) {
         store
             .create_chat_session(&StoredChatSession {
                 id: id.into(),
-                project_id: project.into(),
+                project_id: "p1".into(),
                 harness: "codex".into(),
                 native_session_id: None,
                 title: None,
@@ -5071,28 +5267,17 @@ mod notify_target_tests {
                 context_usage_json: None,
                 bootstrap_context: None,
                 created_at: 1,
-                updated_at,
+                updated_at: 1,
             })
             .unwrap();
-        for i in 0..msgs {
-            store
-                .upsert_chat_message(&StoredChatMessage {
-                    id: format!("{id}-m{i}"),
-                    session_id: id.into(),
-                    role: "user".into(),
-                    parts_json: "[]".into(),
-                    created_at: 1,
-                })
-                .unwrap();
-        }
     }
 
-    fn run(project: &str, owner: Option<&str>) -> StoredRun {
+    fn run(status: &str) -> StoredRun {
         StoredRun {
             id: "run_x".into(),
             experiment_id: "exp_1".into(),
-            project_id: project.into(),
-            status: "failed".into(),
+            project_id: "p1".into(),
+            status: status.into(),
             backend_json: "{}".into(),
             command: "echo hi".into(),
             created_at: 1,
@@ -5102,50 +5287,153 @@ mod notify_target_tests {
             commit_sha: None,
             result_markdown: None,
             cancel_requested: false,
-            chat_session_id: owner.map(str::to_string),
+            chat_session_id: Some("owner".into()),
         }
     }
 
     fn temp_store(tag: &str) -> (Store, std::path::PathBuf) {
-        let dir = std::env::temp_dir().join(format!("orx-notify-{tag}-{}", uuid::Uuid::new_v4()));
+        let dir = std::env::temp_dir().join(format!("orx-wakeup-{tag}-{}", uuid::Uuid::new_v4()));
         (Store::open_at(dir.clone()).unwrap(), dir)
     }
 
-    /// The reported bug: an idle bystander is the *most recently updated*
-    /// session in the project, while an older session actually launched the
-    /// run. Routing must follow ownership, not recency.
     #[test]
-    fn routes_to_launcher_not_the_newest_bystander() {
-        let (store, dir) = temp_store("owner");
-        let proj = "p1";
-        // Owner is older; bystander is the newest — what the old project-wide
-        // heuristic would have wrongly picked.
-        session(&store, "owner", proj, 100, 3);
-        session(&store, "bystander", proj, 999, 3);
-
-        let target = notify_target(&store, &run(proj, Some("owner")));
-        assert_eq!(target.as_deref(), Some("owner"));
-        let _ = std::fs::remove_dir_all(&dir);
+    fn wakeup_messages_are_exact_and_exclude_cancellation() {
+        assert_eq!(
+            run_wakeup_text(&run("done")).as_deref(),
+            Some(
+                "[orx] Run `run_x` finished with status **done**. You can compare this result \
+with other project runs using `orx runs p1` and inspect this run's logs using `orx logs run_x`."
+            )
+        );
+        assert_eq!(
+            run_wakeup_text(&run("failed")).as_deref(),
+            Some(
+                "[orx] Run `run_x` finished with status **failed**. You can compare this result \
+with other project runs using `orx runs p1` and inspect this run's logs using `orx logs run_x`."
+            )
+        );
+        assert!(run_wakeup_text(&run("cancelled")).is_none());
     }
 
-    /// A run with no recorded owner (CLI-launched / pre-migration) pokes no one
-    /// — never a project-wide guess.
     #[test]
-    fn orphan_run_notifies_no_one() {
-        let (store, dir) = temp_store("orphan");
-        session(&store, "bystander", "p1", 999, 3);
-        assert_eq!(notify_target(&store, &run("p1", None)), None);
-        let _ = std::fs::remove_dir_all(&dir);
+    fn hidden_transcript_override_creates_no_user_parts() {
+        assert!(transcript_parts("", &[], &[]).is_empty());
     }
 
-    /// The owner must still exist and have history; an empty (or vanished)
-    /// launcher is skipped rather than poked.
     #[test]
-    fn empty_or_missing_owner_is_skipped() {
-        let (store, dir) = temp_store("empty");
-        session(&store, "empty_owner", "p1", 100, 0);
-        assert_eq!(notify_target(&store, &run("p1", Some("empty_owner"))), None);
-        assert_eq!(notify_target(&store, &run("p1", Some("ghost"))), None);
-        let _ = std::fs::remove_dir_all(&dir);
+    fn only_earliest_wakeup_per_session_is_attempted_each_tick() {
+        let mut first = run("done");
+        first.id = "run_first".into();
+        let mut second = run("done");
+        second.id = "run_second".into();
+        let selected = first_wakeup_per_session(vec![
+            crate::store::RunWakeup {
+                run: first,
+                chat_session_id: "owner".into(),
+                state: "pending".into(),
+            },
+            crate::store::RunWakeup {
+                run: second,
+                chat_session_id: "owner".into(),
+                state: "pending".into(),
+            },
+        ]);
+
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].run.id, "run_first");
+    }
+
+    #[tokio::test]
+    async fn queued_user_message_blocks_hidden_turn_claim() {
+        let host = Arc::new(ChatHost::new(
+            Arc::new(crate::local::opencode::AgentHost::new(None)),
+            Arc::new(crate::local::codex::CodexHost::new()),
+            Arc::new(crate::local::claude::ClaudeHost::new()),
+        ));
+        host.queued.lock().unwrap().insert(
+            "owner".into(),
+            VecDeque::from([QueuedMessage {
+                id: "q_1".into(),
+                text: "user first".into(),
+                transcript_text: None,
+                overrides: TurnOverrides::default(),
+                images: Vec::new(),
+                annotations: Vec::new(),
+            }]),
+        );
+
+        assert!(TurnGuard::claim_hidden(&host, "owner").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn terminal_run_without_subscription_starts_no_turn() {
+        let (store, dir) = temp_store("unsubscribed");
+        session(&store, "owner");
+        store.upsert_run(&run("done")).unwrap();
+        let host = Arc::new(ChatHost::new(
+            Arc::new(crate::local::opencode::AgentHost::new(None)),
+            Arc::new(crate::local::codex::CodexHost::new()),
+            Arc::new(crate::local::claude::ClaudeHost::new()),
+        ));
+
+        drop(store);
+        process_run_wakeups(&host, Store::open_at(dir.clone()).unwrap(), None)
+            .await
+            .unwrap();
+
+        assert!(!host.is_busy("owner").await);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn data_directory_move_keeps_wakeup_pending() {
+        let (store, dir) = temp_store("moving");
+        session(&store, "owner");
+        store.upsert_run(&run("done")).unwrap();
+        store.register_run_wakeup("run_x", "owner").unwrap();
+        let host = Arc::new(ChatHost::new(
+            Arc::new(crate::local::opencode::AgentHost::new(None)),
+            Arc::new(crate::local::codex::CodexHost::new()),
+            Arc::new(crate::local::claude::ClaudeHost::new()),
+        ));
+        let moving = std::sync::atomic::AtomicBool::new(true);
+
+        drop(store);
+        process_run_wakeups(&host, Store::open_at(dir.clone()).unwrap(), Some(&moving))
+            .await
+            .unwrap();
+
+        let store = Store::open_at(dir.clone()).unwrap();
+        assert_eq!(store.list_ready_run_wakeups().unwrap().len(), 1);
+        assert!(!host.is_busy("owner").await);
+        drop(store);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn draining_user_messages_keep_wakeup_pending() {
+        let (store, dir) = temp_store("draining");
+        session(&store, "owner");
+        store.upsert_run(&run("done")).unwrap();
+        store.register_run_wakeup("run_x", "owner").unwrap();
+        let host = Arc::new(ChatHost::new(
+            Arc::new(crate::local::opencode::AgentHost::new(None)),
+            Arc::new(crate::local::codex::CodexHost::new()),
+            Arc::new(crate::local::claude::ClaudeHost::new()),
+        ));
+        host.turns
+            .lock()
+            .await
+            .insert("owner".into(), TurnState::Draining);
+
+        drop(store);
+        process_run_wakeups(&host, Store::open_at(dir.clone()).unwrap(), None)
+            .await
+            .unwrap();
+
+        let store = Store::open_at(dir.clone()).unwrap();
+        assert_eq!(store.list_ready_run_wakeups().unwrap().len(), 1);
+        drop(store);
+        std::fs::remove_dir_all(dir).unwrap();
     }
 }

--- a/src/local/claude.rs
+++ b/src/local/claude.rs
@@ -408,8 +408,8 @@ async fn spawn_client(spec: &SpawnSpec, auth_generation: u64) -> Result<Arc<Clau
     }
     crate::local::chat::prepare_env(&mut cmd);
     // Stamp the launching session so `orx exp run` (a fresh subprocess the
-    // agent shells out) tags its run with this session, and the run watcher
-    // notifies the right chat on completion. After prepare_env so it wins.
+    // agent shells out) tags its run and can explicitly subscribe this chat.
+    // After prepare_env so it wins.
     crate::local::chat::set_chat_session_env(&mut cmd, &spec.session_id);
     // Own process group: a terminal SIGINT reaches orx up alone, which then
     // tears the resident child down deliberately (kill_session / shutdown). A

--- a/src/local/codex.rs
+++ b/src/local/codex.rs
@@ -516,8 +516,8 @@ async fn spawn_client(session_id: &str) -> Result<Arc<CodexClient>> {
         .kill_on_drop(true);
     crate::local::chat::prepare_env(&mut cmd);
     // Stamp the launching session (one app-server child per orx session) so a
-    // run the agent starts via `orx exp run` is tagged with it and the run
-    // watcher notifies this chat. After prepare_env so it isn't shadowed.
+    // run the agent starts via `orx exp run` is tagged with it and can be
+    // explicitly subscribed to. After prepare_env so it isn't shadowed.
     crate::local::chat::set_chat_session_env(&mut cmd, session_id);
     // Pin the child's store to the same canonicalized dir the sandbox policy
     // grants (see harness/codex.rs `ensure_orx_data_dir`) — after prepare_env

--- a/src/local/harness/codex.rs
+++ b/src/local/harness/codex.rs
@@ -2657,7 +2657,7 @@ async fn run_turn_exec(ctx: &mut TurnCtx) -> Result<()> {
     cmd.arg(prompt);
     prepare_env(&mut cmd);
     // Tag the run this sandboxed turn may launch (`orx exp run`) with the
-    // session, so the run watcher notifies this chat. After prepare_env so it
+    // session so it can be explicitly subscribed to. After prepare_env so it
     // isn't shadowed by a synced value.
     set_chat_session_env(&mut cmd, &ctx.session_id);
     // Pin the sandboxed turn's store to the exact path granted above. The

--- a/src/local/opencode.rs
+++ b/src/local/opencode.rs
@@ -531,8 +531,8 @@ async fn spawn_agent(
             cmd.env(key, value);
         }
     }
-    // Tag runs the agent launches (`orx exp run`) with this session so the run
-    // watcher notifies this chat. One serve child per session; set after the
+    // Tag runs the agent launches (`orx exp run`) with this session so they can
+    // be explicitly subscribed to. One serve child per session; set after the
     // synced-env loop so it isn't shadowed.
     crate::local::chat::set_chat_session_env(&mut cmd, session_id);
     if let Some(config) = &config_override {
@@ -757,6 +757,15 @@ mod tests {
         assert!(md.contains("Do not push just to launch compute"));
         assert!(md.contains("orx-compute-k8s"));
         assert!(md.contains("--backend <hf|modal"));
+    }
+
+    #[test]
+    fn playbook_explains_opt_in_run_wakeups() {
+        let md = sample_playbook();
+        assert!(md.contains("`orx exp wake <expId>`"));
+        assert!(md.contains("Unregistered runs never wake the chat"));
+        assert!(md.contains("cancelled runs never send a wake-up"));
+        assert!(!md.contains("OpenResearch injects an `[orx]` message"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -525,6 +525,9 @@ pub enum ExpCommand {
     /// Cancel the in-flight run.
     Cancel { exp_id: String },
 
+    /// Resume this agent after the experiment's latest run succeeds or fails.
+    Wake { exp_id: String },
+
     /// Wait for a run to finish: one experiment (`<expId>`) or the next completion in a project (`--project`).
     Wait {
         /// Experiment to watch; its latest run is polled until it reaches a

--- a/src/store.rs
+++ b/src/store.rs
@@ -60,6 +60,57 @@ pub(crate) fn open_lifecycle_lock_at(
     Ok(fd_lock::RwLock::new(file))
 }
 
+fn data_dir_move_lock_path() -> PathBuf {
+    crate::config::config_dir().join("orx.data-dir-move.lock")
+}
+
+pub(crate) struct DataDirMoveLock {
+    release: Option<std::sync::mpsc::Sender<()>>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Drop for DataDirMoveLock {
+    fn drop(&mut self) {
+        self.release.take();
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+fn acquire_data_dir_move_lock(path: PathBuf) -> Result<DataDirMoveLock> {
+    let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(1);
+    let (release_tx, release_rx) = std::sync::mpsc::channel();
+    let thread = std::thread::spawn(move || {
+        let result = (|| -> Result<()> {
+            let mut lock = open_lifecycle_lock_at(&path)?;
+            let _guard = lock.try_write()?;
+            ready_tx
+                .send(Ok(()))
+                .map_err(|_| anyhow!("data-directory move lock receiver closed"))?;
+            let _ = release_rx.recv();
+            Ok(())
+        })();
+        if let Err(error) = result {
+            let _ = ready_tx.send(Err(error.to_string()));
+        }
+    });
+    match ready_rx.recv() {
+        Ok(Ok(())) => Ok(DataDirMoveLock {
+            release: Some(release_tx),
+            thread: Some(thread),
+        }),
+        Ok(Err(error)) => {
+            let _ = thread.join();
+            Err(anyhow!(error))
+        }
+        Err(_) => {
+            let _ = thread.join();
+            Err(anyhow!("data-directory move lock thread exited"))
+        }
+    }
+}
+
 /// Read an env var as a path, treating unset **and empty** the same (an empty
 /// `export ORX_DATA_DIR=` is a shell footgun that must not resolve to `""`).
 fn env_path(key: &str) -> Option<PathBuf> {
@@ -169,20 +220,38 @@ pub struct StoredRun {
     pub cancel_requested: bool,
     /// The `orx up` chat session that launched this run, when it was started by
     /// an agent harness child (which exports `ORX_CHAT_SESSION_ID`). `None` for
-    /// CLI-launched or server runs. The run watcher routes the completion
-    /// notification to exactly this session — never a project-wide guess.
+    /// CLI-launched or server runs. This records attribution; wake-ups are
+    /// separately and explicitly registered in `chat_run_wakeups`.
     pub chat_session_id: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+pub struct RunWakeup {
+    pub run: StoredRun,
+    pub chat_session_id: String,
+    pub state: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunWakeupRegistration {
+    Scheduled,
+    AlreadyPending,
+    AlreadyDelivered,
+}
+
+const RUN_WAKEUP_CLAIM_TTL_MS: i64 = 60 * 1000;
+const CHAT_TURN_LEASE_TTL_MS: i64 = 60 * 1000;
+
 pub struct Store {
     conn: Connection,
+    data_dir_move_lock_path: PathBuf,
 }
 
 impl Store {
     /// Open (creating dirs/schema as needed). WAL so the supervise writers and
     /// the serve readers never block each other.
     pub fn open() -> Result<Self> {
-        Self::open_at(data_dir())
+        Self::open_at_with_move_lock(data_dir(), data_dir_move_lock_path())
     }
 
     /// Open a store rooted at an explicit directory, bypassing `data_dir()`
@@ -190,6 +259,11 @@ impl Store {
     /// process-global `$ORX_DATA_DIR`, which the localbox lifecycle test owns
     /// (tests in different modules share env under the parallel runner).
     pub fn open_at(dir: PathBuf) -> Result<Self> {
+        let move_lock_path = dir.join(".orx-data-dir-move.lock");
+        Self::open_at_with_move_lock(dir, move_lock_path)
+    }
+
+    fn open_at_with_move_lock(dir: PathBuf, data_dir_move_lock_path: PathBuf) -> Result<Self> {
         std::fs::create_dir_all(dir.join("run-logs"))
             .map_err(|e| anyhow!("Could not create {}: {}", dir.display(), e))?;
         let conn = Connection::open(dir.join("orx.db"))?;
@@ -265,6 +339,28 @@ impl Store {
             );
             CREATE INDEX IF NOT EXISTS idx_chat_messages_session
                 ON chat_messages(session_id, created_at);
+            CREATE TABLE IF NOT EXISTS chat_run_wakeups (
+                run_id          TEXT NOT NULL,
+                chat_session_id TEXT NOT NULL,
+                requested_at    INTEGER NOT NULL,
+                state           TEXT NOT NULL DEFAULT 'pending',
+                claim_token     TEXT,
+                claimed_at      INTEGER,
+                delivered_at    INTEGER,
+                PRIMARY KEY(run_id, chat_session_id)
+            );
+            CREATE INDEX IF NOT EXISTS idx_chat_run_wakeups_requested
+                ON chat_run_wakeups(requested_at);
+            CREATE TABLE IF NOT EXISTS chat_turn_leases (
+                chat_session_id TEXT PRIMARY KEY,
+                claim_token     TEXT NOT NULL,
+                heartbeat_at    INTEGER NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS data_dir_move_lease (
+                id           INTEGER PRIMARY KEY CHECK (id = 1),
+                claim_token  TEXT NOT NULL,
+                heartbeat_at INTEGER NOT NULL
+            );
             CREATE TABLE IF NOT EXISTS ssh_host_tests (
                 host      TEXT PRIMARY KEY,
                 reachable INTEGER NOT NULL,
@@ -302,6 +398,10 @@ impl Store {
             "ALTER TABLE local_projects ADD COLUMN github_sync_enabled INTEGER NOT NULL DEFAULT 1",
             "ALTER TABLE local_experiments ADD COLUMN chat_session_id TEXT",
             "ALTER TABLE ssh_host_tests ADD COLUMN tools_found INTEGER NOT NULL DEFAULT 0",
+            "ALTER TABLE chat_run_wakeups ADD COLUMN state TEXT NOT NULL DEFAULT 'pending'",
+            "ALTER TABLE chat_run_wakeups ADD COLUMN claim_token TEXT",
+            "ALTER TABLE chat_run_wakeups ADD COLUMN claimed_at INTEGER",
+            "ALTER TABLE chat_run_wakeups ADD COLUMN delivered_at INTEGER",
         ] {
             let _ = conn.execute(ddl, []);
         }
@@ -448,7 +548,10 @@ impl Store {
         // to do it safely exists: `reconcileReasoning` in `ui/src/api.ts` drops
         // one the selected model doesn't offer, and each harness's mapper drops
         // it again before it can reach a CLI.
-        Ok(Self { conn })
+        Ok(Self {
+            conn,
+            data_dir_move_lock_path,
+        })
     }
 
     /// Short write transaction over this connection; rolls back when dropped
@@ -648,6 +751,239 @@ impl Store {
             )
             .optional()?;
         Ok(run)
+    }
+
+    pub fn register_run_wakeup(
+        &self,
+        run_id: &str,
+        chat_session_id: &str,
+    ) -> Result<RunWakeupRegistration> {
+        let inserted = self.conn.execute(
+            "INSERT OR IGNORE INTO chat_run_wakeups (run_id, chat_session_id, requested_at)
+             VALUES (?1, ?2, ?3)",
+            params![run_id, chat_session_id, now_ms()],
+        )?;
+        if inserted == 1 {
+            return Ok(RunWakeupRegistration::Scheduled);
+        }
+        let state: String = self.conn.query_row(
+            "SELECT state FROM chat_run_wakeups WHERE run_id = ?1 AND chat_session_id = ?2",
+            params![run_id, chat_session_id],
+            |row| row.get(0),
+        )?;
+        Ok(if state == "delivered" {
+            RunWakeupRegistration::AlreadyDelivered
+        } else {
+            RunWakeupRegistration::AlreadyPending
+        })
+    }
+
+    pub fn remove_run_wakeup(&self, run_id: &str, chat_session_id: &str) -> Result<()> {
+        self.conn.execute(
+            "DELETE FROM chat_run_wakeups WHERE run_id = ?1 AND chat_session_id = ?2",
+            params![run_id, chat_session_id],
+        )?;
+        Ok(())
+    }
+
+    pub fn prune_run_wakeups(&self) -> Result<()> {
+        self.clear_stale_data_dir_move_lease()?;
+        self.conn.execute(
+            "UPDATE chat_run_wakeups
+             SET state = 'pending', claim_token = NULL, claimed_at = NULL
+             WHERE state = 'claimed' AND claimed_at < ?1
+               AND NOT EXISTS (SELECT 1 FROM data_dir_move_lease WHERE id = 1)",
+            params![now_ms() - RUN_WAKEUP_CLAIM_TTL_MS],
+        )?;
+        self.conn.execute(
+            "DELETE FROM chat_run_wakeups
+             WHERE NOT EXISTS (SELECT 1 FROM data_dir_move_lease WHERE id = 1)
+               AND (
+                 NOT EXISTS (SELECT 1 FROM runs WHERE runs.id = chat_run_wakeups.run_id)
+                OR NOT EXISTS (
+                    SELECT 1 FROM chat_sessions
+                    WHERE chat_sessions.id = chat_run_wakeups.chat_session_id
+                )
+                OR EXISTS (
+                    SELECT 1 FROM runs
+                    WHERE runs.id = chat_run_wakeups.run_id
+                      AND runs.status = 'cancelled'
+                )
+               )",
+            [],
+        )?;
+        Ok(())
+    }
+
+    pub fn list_ready_run_wakeups(&self) -> Result<Vec<RunWakeup>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT r.id, r.experiment_id, r.project_id, r.status, r.backend_json, r.command,
+                    r.created_at, r.updated_at, r.ended_at, r.exit_code,
+                    r.commit_sha, r.result_markdown, r.cancel_requested, r.chat_session_id,
+                    w.chat_session_id, w.state
+             FROM chat_run_wakeups w
+             JOIN runs r ON r.id = w.run_id
+             WHERE w.state IN ('pending', 'claimed') AND r.status IN ('done', 'failed')
+             ORDER BY COALESCE(r.ended_at, r.updated_at), w.requested_at, r.id",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(RunWakeup {
+                run: row_to_run(row)?,
+                chat_session_id: row.get(14)?,
+                state: row.get(15)?,
+            })
+        })?;
+        Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
+    }
+
+    pub fn claim_run_wakeup(&self, run_id: &str, chat_session_id: &str) -> Result<Option<String>> {
+        let token = uuid::Uuid::new_v4().to_string();
+        let claimed = self.conn.execute(
+            "UPDATE chat_run_wakeups
+             SET state = 'claimed', claim_token = ?3, claimed_at = ?4
+             WHERE run_id = ?1 AND chat_session_id = ?2 AND state = 'pending'",
+            params![run_id, chat_session_id, token, now_ms()],
+        )?;
+        Ok((claimed == 1).then_some(token))
+    }
+
+    pub fn renew_run_wakeup_claim(
+        &self,
+        run_id: &str,
+        chat_session_id: &str,
+        token: &str,
+    ) -> Result<bool> {
+        let renewed = self.conn.execute(
+            "UPDATE chat_run_wakeups SET claimed_at = ?4
+             WHERE run_id = ?1 AND chat_session_id = ?2
+               AND state = 'claimed' AND claim_token = ?3",
+            params![run_id, chat_session_id, token, now_ms()],
+        )?;
+        Ok(renewed == 1)
+    }
+
+    pub fn release_run_wakeup(
+        &self,
+        run_id: &str,
+        chat_session_id: &str,
+        token: &str,
+    ) -> Result<()> {
+        self.conn.execute(
+            "UPDATE chat_run_wakeups
+             SET state = 'pending', claim_token = NULL, claimed_at = NULL
+             WHERE run_id = ?1 AND chat_session_id = ?2
+               AND state = 'claimed' AND claim_token = ?3",
+            params![run_id, chat_session_id, token],
+        )?;
+        Ok(())
+    }
+
+    pub fn mark_run_wakeup_delivered(
+        &self,
+        run_id: &str,
+        chat_session_id: &str,
+        token: &str,
+    ) -> Result<bool> {
+        let delivered = self.conn.execute(
+            "UPDATE chat_run_wakeups
+             SET state = 'delivered', claim_token = NULL, claimed_at = NULL, delivered_at = ?4
+             WHERE run_id = ?1 AND chat_session_id = ?2
+               AND state = 'claimed' AND claim_token = ?3",
+            params![run_id, chat_session_id, token, now_ms()],
+        )?;
+        Ok(delivered == 1)
+    }
+
+    pub fn claim_chat_turn(&self, chat_session_id: &str, token: &str) -> Result<bool> {
+        self.clear_stale_data_dir_move_lease()?;
+        self.conn.execute(
+            "DELETE FROM chat_turn_leases
+             WHERE heartbeat_at < ?1
+                OR NOT EXISTS (
+                    SELECT 1 FROM chat_sessions
+                    WHERE chat_sessions.id = chat_turn_leases.chat_session_id
+                )",
+            params![now_ms() - CHAT_TURN_LEASE_TTL_MS],
+        )?;
+        let claimed = self.conn.execute(
+            "INSERT OR IGNORE INTO chat_turn_leases
+                 (chat_session_id, claim_token, heartbeat_at)
+             SELECT ?1, ?2, ?3
+             WHERE NOT EXISTS (SELECT 1 FROM data_dir_move_lease WHERE id = 1)",
+            params![chat_session_id, token, now_ms()],
+        )?;
+        Ok(claimed == 1)
+    }
+
+    pub fn renew_chat_turn(&self, chat_session_id: &str, token: &str) -> Result<bool> {
+        let renewed = self.conn.execute(
+            "UPDATE chat_turn_leases SET heartbeat_at = ?3
+             WHERE chat_session_id = ?1 AND claim_token = ?2",
+            params![chat_session_id, token, now_ms()],
+        )?;
+        Ok(renewed == 1)
+    }
+
+    pub fn release_chat_turn(&self, chat_session_id: &str, token: &str) -> Result<()> {
+        self.conn.execute(
+            "DELETE FROM chat_turn_leases
+             WHERE chat_session_id = ?1 AND claim_token = ?2",
+            params![chat_session_id, token],
+        )?;
+        Ok(())
+    }
+
+    pub fn claim_data_dir_move(&self, token: &str) -> Result<bool> {
+        self.conn.execute(
+            "DELETE FROM chat_turn_leases WHERE heartbeat_at < ?1",
+            params![now_ms() - CHAT_TURN_LEASE_TTL_MS],
+        )?;
+        self.clear_stale_data_dir_move_lease()?;
+        let claimed = self.conn.execute(
+            "INSERT OR IGNORE INTO data_dir_move_lease (id, claim_token, heartbeat_at)
+             SELECT 1, ?1, ?2
+             WHERE NOT EXISTS (SELECT 1 FROM chat_turn_leases)",
+            params![token, now_ms()],
+        )?;
+        Ok(claimed == 1)
+    }
+
+    pub(crate) fn acquire_data_dir_move_lock(&self) -> Result<DataDirMoveLock> {
+        acquire_data_dir_move_lock(self.data_dir_move_lock_path.clone())
+    }
+
+    fn clear_stale_data_dir_move_lease(&self) -> Result<()> {
+        let token = self
+            .conn
+            .query_row(
+                "SELECT claim_token FROM data_dir_move_lease WHERE id = 1",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        let Some(token) = token else {
+            return Ok(());
+        };
+        let mut lock = open_lifecycle_lock_at(&self.data_dir_move_lock_path)?;
+        match lock.try_write() {
+            Ok(_guard) => {
+                self.conn.execute(
+                    "DELETE FROM data_dir_move_lease WHERE id = 1 AND claim_token = ?1",
+                    params![token],
+                )?;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
+            Err(error) => return Err(error.into()),
+        }
+        Ok(())
+    }
+
+    pub fn release_data_dir_move(&self, token: &str) -> Result<()> {
+        self.conn.execute(
+            "DELETE FROM data_dir_move_lease WHERE id = 1 AND claim_token = ?1",
+            params![token],
+        )?;
+        Ok(())
     }
 
     pub fn set_cancel_requested(&self, run_id: &str, requested: bool) -> Result<()> {
@@ -1757,6 +2093,204 @@ mod tests {
             None
         );
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn run_wakeups_are_idempotent_ready_only_at_success_or_failure_and_pruned() {
+        let dir = std::env::temp_dir().join(format!("orx-store-wake-{}", uuid::Uuid::new_v4()));
+        let store = Store::open_at(dir.clone()).unwrap();
+        store
+            .create_chat_session(&chat_session_fixture("chat_A"))
+            .unwrap();
+        for (id, status) in [
+            ("run_active", "running"),
+            ("run_done", "done"),
+            ("run_failed", "failed"),
+            ("run_cancelled", "cancelled"),
+        ] {
+            store
+                .upsert_run(&run_fixture(id, status, Some("chat_A")))
+                .unwrap();
+            assert_eq!(
+                store.register_run_wakeup(id, "chat_A").unwrap(),
+                RunWakeupRegistration::Scheduled
+            );
+            assert_eq!(
+                store.register_run_wakeup(id, "chat_A").unwrap(),
+                RunWakeupRegistration::AlreadyPending
+            );
+        }
+        store.register_run_wakeup("missing_run", "chat_A").unwrap();
+        store
+            .register_run_wakeup("run_done", "missing_chat")
+            .unwrap();
+
+        store.prune_run_wakeups().unwrap();
+        let ready = store.list_ready_run_wakeups().unwrap();
+        assert_eq!(
+            ready
+                .iter()
+                .map(|wakeup| wakeup.run.id.as_str())
+                .collect::<Vec<_>>(),
+            ["run_done", "run_failed"]
+        );
+
+        store
+            .update_status("run_active", "done", Some(2), Some(0))
+            .unwrap();
+        assert_eq!(store.list_ready_run_wakeups().unwrap().len(), 3);
+        let token = store
+            .claim_run_wakeup("run_done", "chat_A")
+            .unwrap()
+            .unwrap();
+        assert!(store
+            .claim_run_wakeup("run_done", "chat_A")
+            .unwrap()
+            .is_none());
+        assert!(store
+            .list_ready_run_wakeups()
+            .unwrap()
+            .iter()
+            .any(|wakeup| wakeup.run.id == "run_done" && wakeup.state == "claimed"));
+        store
+            .release_run_wakeup("run_done", "chat_A", &token)
+            .unwrap();
+        assert!(store
+            .list_ready_run_wakeups()
+            .unwrap()
+            .iter()
+            .any(|wakeup| wakeup.run.id == "run_done"));
+        let token = store
+            .claim_run_wakeup("run_done", "chat_A")
+            .unwrap()
+            .unwrap();
+        assert!(store
+            .mark_run_wakeup_delivered("run_done", "chat_A", &token)
+            .unwrap());
+        assert_eq!(
+            store.register_run_wakeup("run_done", "chat_A").unwrap(),
+            RunWakeupRegistration::AlreadyDelivered
+        );
+        assert!(store
+            .list_ready_run_wakeups()
+            .unwrap()
+            .iter()
+            .all(|wakeup| wakeup.run.id != "run_done"));
+
+        drop(store);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn run_wakeup_claim_is_atomic_across_store_connections_and_recoverable() {
+        let dir = std::env::temp_dir().join(format!("orx-store-claim-{}", uuid::Uuid::new_v4()));
+        let first = Store::open_at(dir.clone()).unwrap();
+        first
+            .create_chat_session(&chat_session_fixture("chat_A"))
+            .unwrap();
+        first
+            .upsert_run(&run_fixture("run_done", "done", Some("chat_A")))
+            .unwrap();
+        first.register_run_wakeup("run_done", "chat_A").unwrap();
+        let second = Store::open_at(dir.clone()).unwrap();
+
+        let stale_token = first
+            .claim_run_wakeup("run_done", "chat_A")
+            .unwrap()
+            .unwrap();
+        assert!(second
+            .claim_run_wakeup("run_done", "chat_A")
+            .unwrap()
+            .is_none());
+        first
+            .conn
+            .execute(
+                "UPDATE chat_run_wakeups SET claimed_at = 0 WHERE run_id = 'run_done'",
+                [],
+            )
+            .unwrap();
+        second.prune_run_wakeups().unwrap();
+        let current_token = second
+            .claim_run_wakeup("run_done", "chat_A")
+            .unwrap()
+            .unwrap();
+        first
+            .release_run_wakeup("run_done", "chat_A", &stale_token)
+            .unwrap();
+        assert!(!first
+            .mark_run_wakeup_delivered("run_done", "chat_A", &stale_token)
+            .unwrap());
+        assert!(second
+            .renew_run_wakeup_claim("run_done", "chat_A", &current_token)
+            .unwrap());
+        second
+            .release_run_wakeup("run_done", "chat_A", &current_token)
+            .unwrap();
+        assert!(first
+            .claim_run_wakeup("run_done", "chat_A")
+            .unwrap()
+            .is_some());
+
+        drop(second);
+        drop(first);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn ready_run_wakeups_are_ordered_by_terminal_time() {
+        let dir = std::env::temp_dir().join(format!("orx-store-order-{}", uuid::Uuid::new_v4()));
+        let store = Store::open_at(dir.clone()).unwrap();
+        store
+            .create_chat_session(&chat_session_fixture("chat_A"))
+            .unwrap();
+        for (id, ended_at) in [("run_late", 20), ("run_early", 10)] {
+            let mut run = run_fixture(id, "done", Some("chat_A"));
+            run.ended_at = Some(ended_at);
+            store.upsert_run(&run).unwrap();
+            store.register_run_wakeup(id, "chat_A").unwrap();
+        }
+
+        assert_eq!(
+            store
+                .list_ready_run_wakeups()
+                .unwrap()
+                .iter()
+                .map(|wakeup| wakeup.run.id.as_str())
+                .collect::<Vec<_>>(),
+            ["run_early", "run_late"]
+        );
+
+        drop(store);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn chat_turn_lease_is_cross_process_and_token_scoped() {
+        let dir = std::env::temp_dir().join(format!("orx-store-turn-{}", uuid::Uuid::new_v4()));
+        let first = Store::open_at(dir.clone()).unwrap();
+        first
+            .create_chat_session(&chat_session_fixture("chat_A"))
+            .unwrap();
+        let second = Store::open_at(dir.clone()).unwrap();
+
+        assert!(first.claim_chat_turn("chat_A", "token_A").unwrap());
+        assert!(!second.claim_chat_turn("chat_A", "token_B").unwrap());
+        assert!(!second.renew_chat_turn("chat_A", "token_B").unwrap());
+        assert!(!second.claim_data_dir_move("move_A").unwrap());
+        second.release_chat_turn("chat_A", "token_B").unwrap();
+        assert!(!second.claim_chat_turn("chat_A", "token_B").unwrap());
+        first.release_chat_turn("chat_A", "token_A").unwrap();
+        let move_lock = first.acquire_data_dir_move_lock().unwrap();
+        assert!(first.claim_data_dir_move("move_A").unwrap());
+        assert!(!second.claim_chat_turn("chat_A", "token_B").unwrap());
+        second.release_data_dir_move("move_B").unwrap();
+        assert!(!second.claim_chat_turn("chat_A", "token_B").unwrap());
+        drop(move_lock);
+        assert!(second.claim_chat_turn("chat_A", "token_B").unwrap());
+
+        drop(second);
+        drop(first);
+        std::fs::remove_dir_all(dir).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add opt-in experiment wake subscriptions through orx exp wake
- deliver successful and failed terminal states as hidden turns only after the session is truly idle
- persist and coordinate wake and turn claims across watcher restarts and multiple local dashboards
- keep queued user messages ahead of wake-ups and suppress cancelled-run notifications

## Verification
- cargo fmt --all --check
- cargo clippy --all-targets -- -D warnings
- cargo build --locked
- cargo test --locked (457 passed, 1 ignored)
- four-reviewer blocker-free review round

## Manual follow-up
- [ ] Exercise an end-to-end local run from the dashboard with each supported harness