### PR TITLE
chore: release 0.1.102

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,7 +1025,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openresearch-cli"
-version = "0.1.101"
+version = "0.1.102"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openresearch-cli"
-version = "0.1.101"
+version = "0.1.102"
 edition = "2021"
 description = "OpenResearch CLI (orx) — Rust port"
 repository = "https://github.com/alphaXiv/openresearch-cli"


### PR DESCRIPTION
Bumps the package version to `0.1.102`. **Merging this publishes a release.**

## Why now

[#195](https://github.com/alphaXiv/openresearch-cli/pull/195) (the macOS app harness-detection and CLI-coexistence fixes) merged without a version bump, so `main` still reports `0.1.101` — and the existing `v0.1.101` tag predates the merge. There is currently no tag containing the fixes, which means the DMG pipeline has nothing to build the fixed app from: dispatching `release-macos-app.yml` with `v0.1.101` would silently produce a bundle without them.

It also makes the fix testable. Right now a tester can't distinguish a fixed build from the released one, since both report `0.1.101`.

## What merging does

`release-on-bump.yml` sees the new version on `main` and dispatches `release.yml`, which publishes the GitHub Release and creates the `v0.1.102` tag. The macOS DMG attaches automatically if `RELEASE_DISPATCH_TOKEN` is valid; otherwise it needs a manual `gh workflow run release-macos-app.yml -f tag=v0.1.102`, and is gated on the repo variable `MACOS_SIGNING_ENABLED=true`.

## Test plan

- [x] `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build --locked`, `cargo test --locked` (490 passed)
- [x] `Cargo.lock` records `0.1.102`; diff is those two files only
- [x] `v0.1.102` does not already exist as a tag
- [x] Version increases from the base by semver ordering (`0.1.101` → `0.1.102`)
- [ ] Release publishes and the `v0.1.102` tag is created
- [ ] `OpenResearch.dmg` attaches to the release, and its bundle contains the `Contents/MacOS/orx` symlink

🤖 Generated with [Claude Code](https://claude.com/claude-code)