### PR TITLE
Send CLI analytics to OpenResearch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,7 +1025,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openresearch-cli"
-version = "0.1.102"
+version = "0.1.103"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openresearch-cli"
-version = "0.1.102"
+version = "0.1.103"
 edition = "2021"
 description = "OpenResearch CLI (orx) — Rust port"
 repository = "https://github.com/alphaXiv/openresearch-cli"

--- a/README.md
+++ b/README.md
@@ -146,15 +146,12 @@ choice on first run.
 - **Collected:** command name, a random per-install UUID, CLI version, OS/arch,
   the official build channel, a CI flag, coarse install type, and coarse event
   labels (e.g. onboarding completed, project created, chat session started, or
-  a run launched on `modal`). When onboarding is completed, the disclosed
-  research profile is also sent unfiltered: selected research areas, the
-  Other-area description, research background, and representative paper IDs
-  and titles.
+  a run launched on `modal`). For the onboarding research profile, only selected
+  research-area categories and the number of linked papers are collected.
 - **Not automatically added:** code, prompts, file contents or paths, project or
   experiment IDs/names, repo names, tokens, emails, or account identifiers.
-  Anything entered in the onboarding profile is sent exactly as submitted and
-  may contain identifying information. The random install UUID is not tied to
-  your account.
+  Research-profile free text, paper IDs, and paper titles are not sent. The
+  random install UUID is not tied to your account.
 
 ```sh
 orx telemetry off        # persistent, per-machine
@@ -168,3 +165,4 @@ do not create an installation ID. `ORX_TELEMETRY_ENV=off` additionally disables
 analytics in an official binary; it cannot enable analytics in a source build.
 
 Events are fire-and-forget on a background task and never block a command.
+They are sent to OpenResearch's first-party API and stored in Postgres.

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,11 +1,10 @@
-//! Opt-out usage analytics → PostHog.
+//! Opt-out usage analytics → the first-party OpenResearch API.
 //!
 //! Why this exists: `orx` shipped with no telemetry, so we had no way to see
 //! installs, DAU/WAU, retention, or which commands people actually use. This
 //! module sends events under a random per-install UUID that is not tied to an
-//! account. The disclosed onboarding research profile is included unfiltered
-//! in its own event; prompts, file paths, and repo contents are never read from
-//! the workspace or added automatically.
+//! account. Only coarse research-area categories and paper count are included
+//! from the onboarding profile; free text and paper identifiers stay local.
 //!
 //! Guarantees, enforced by this module:
 //! - **Official builds only.** Source builds never send production telemetry or
@@ -30,19 +29,9 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-/// Public, write-only PostHog project key (openresearch CLI project). A `phc_`
-/// key can only *ingest* events — it cannot read data or change settings — so
-/// it is safe to commit and ship in the binary, exactly as PostHog intends for
-/// client-side keys. Do NOT put a personal (`phx_`) key here.
-const POSTHOG_KEY: &str = "phc_u2i23xa8CBjcZpQprf6kdDzzR8vb2iTpRT8FmdcREBvX";
-
-/// Prefix stamped onto EVERY event name. This PostHog project is shared with
-/// the website/cloud-agent analytics, so CLI events must be separable by name
-/// alone — not just by the `source: "cli"` property (which one forgotten
-/// dashboard filter would leak past). Applied centrally in `build_payload`, so
-/// every current and future CLI event is `cli_*` by construction; call sites
-/// pass the bare name (`command`, `experiment_started`).
+/// Prefix stamped onto every event name by the single wire encoder.
 const EVENT_PREFIX: &str = "cli_";
+const ANALYTICS_PATH: &str = "/analytics/v1/cli-events";
 
 const BUILD_CHANNEL: &str = env!("ORX_BUILD_CHANNEL");
 
@@ -50,10 +39,35 @@ pub(crate) fn build_channel() -> &'static str {
     BUILD_CHANNEL
 }
 
-/// US PostHog cloud. Overridable with `ORX_TELEMETRY_HOST` so tests can point
+/// First-party API origin. Overridable with `ORX_TELEMETRY_HOST` so tests can point
 /// at a throwaway local listener instead of production.
-fn posthog_host() -> String {
-    std::env::var("ORX_TELEMETRY_HOST").unwrap_or_else(|_| "https://us.i.posthog.com".to_string())
+fn telemetry_host() -> String {
+    const DEFAULT: &str = "https://api.openresearch.sh";
+    let Ok(candidate) = std::env::var("ORX_TELEMETRY_HOST") else {
+        return DEFAULT.to_string();
+    };
+    let candidate = candidate.trim_end_matches('/');
+    let Ok(url) = reqwest::Url::parse(candidate) else {
+        return DEFAULT.to_string();
+    };
+    let loopback = url.host_str().is_some_and(|host| {
+        host.eq_ignore_ascii_case("localhost")
+            || host
+                .parse::<std::net::IpAddr>()
+                .is_ok_and(|ip| ip.is_loopback())
+    });
+    if loopback
+        && matches!(url.scheme(), "http" | "https")
+        && url.username().is_empty()
+        && url.password().is_none()
+        && url.query().is_none()
+        && url.fragment().is_none()
+        && url.path() == "/"
+    {
+        candidate.to_string()
+    } else {
+        DEFAULT.to_string()
+    }
 }
 
 /// Flush window granted to an in-flight send before `#[tokio::main]` tears the
@@ -102,7 +116,7 @@ pub(crate) struct Settings {
     /// set once by `orx telemetry context <value>` during box provisioning.
     /// Stamped on every event as the `install_kind` property so first-party
     /// automation can be excluded from human usage metrics centrally (the
-    /// PostHog internal/test-users filter) instead of per-insight. Absent = a
+    /// analytics projections) instead of per-dashboard filters. Absent = a
     /// human install (`install_kind: "human"`).
     #[serde(default)]
     pub machine_context: Option<String>,
@@ -408,7 +422,7 @@ fn mutate_settings<F: FnOnce(&mut Settings)>(f: F) -> std::io::Result<()> {
     write_settings(&settings)
 }
 
-/// The anonymous `distinct_id`: an existing install id, or a freshly generated
+/// The anonymous installation ID: an existing install id, or a freshly generated
 /// one persisted on first use. Returns `None` only if the id can't be persisted
 /// (so a run that couldn't write never invents a throwaway id that would inflate
 /// install counts on every invocation).
@@ -586,49 +600,39 @@ fn is_ci() -> bool {
     std::env::var_os("CI").is_some()
 }
 
-/// Builds the PostHog capture payload for an event. Every event carries the
-/// same base context (source, version, build channel, os, arch, ci, install
-/// kind) plus `$process_person_profile: false` so PostHog does not create a
-/// person profile.
-/// `extra` supplies event-specific properties. Most callers use coarse enums;
-/// the onboarding research-profile event deliberately includes the fields
-/// disclosed in the UI.
-fn build_payload(event: &str, distinct_id: &str, extra: serde_json::Value) -> serde_json::Value {
-    let mut props = json!({
-        // Keep this random installation id out of PostHog person profiles.
-        "$process_person_profile": false,
-        "source": "cli",
-        "cli_version": crate::updates::current_version().to_string(),
-        "build_channel": build_channel(),
-        "os": std::env::consts::OS,
-        "arch": std::env::consts::ARCH,
-        "ci": is_ci(),
-        // Human install vs first-party automation (e.g. "cloud-agent" boxes).
-        // Fed into PostHog's internal-users filter so human-facing metrics
-        // exclude our own fleet by default, without per-insight filters.
-        "install_kind": install_kind(),
-    });
-    // Merge event-specific props FIRST so the invariant base context above can
-    // never be silently overwritten by a caller's `extra` (defense in depth —
-    // callers keep keys disjoint, but a stray `source`/`ci`/`os` key must not
-    // be able to corrupt identity fields).
-    if let (Some(obj), Some(add)) = (props.as_object_mut(), extra.as_object()) {
-        for (k, v) in add {
-            obj.entry(k.clone()).or_insert_with(|| v.clone());
-        }
-    }
+fn build_payload_with_id(
+    event: &str,
+    install_id: &str,
+    event_id: uuid::Uuid,
+    properties: serde_json::Value,
+) -> serde_json::Value {
     json!({
-        "api_key": POSTHOG_KEY,
-        // Every CLI event name is `cli_`-prefixed so it's separable from the
-        // website's events in this shared project by name alone.
-        "event": format!("{EVENT_PREFIX}{event}"),
-        "distinct_id": distinct_id,
-        // Client-side event time (UTC ISO-8601). Without this PostHog buckets on
-        // ingestion time, which for a fire-and-forget send that may land seconds
-        // late would smear DAU/retention — the metrics this feature exists for.
-        "timestamp": iso8601_utc(crate::store::now_ms()),
-        "properties": props,
+        "schemaVersion": 1,
+        "installId": install_id,
+        "context": {
+            "cliVersion": crate::updates::current_version().to_string(),
+            "buildChannel": build_channel(),
+            "os": std::env::consts::OS,
+            "arch": std::env::consts::ARCH,
+            "ci": is_ci(),
+            "installKind": install_kind(),
+        },
+        "events": [{
+            "eventId": event_id.to_string(),
+            "name": format!("{EVENT_PREFIX}{event}"),
+            "occurredAt": iso8601_utc(crate::store::now_ms()),
+            "properties": properties,
+        }],
     })
+}
+
+#[cfg(test)]
+fn build_payload(
+    event: &str,
+    install_id: &str,
+    properties: serde_json::Value,
+) -> serde_json::Value {
+    build_payload_with_id(event, install_id, uuid::Uuid::new_v4(), properties)
 }
 
 /// Format epoch milliseconds as a UTC ISO-8601 timestamp
@@ -661,12 +665,21 @@ fn iso8601_utc(ms: i64) -> String {
 /// Fire one event, right now, on the current task, awaiting the send. All
 /// errors are swallowed — telemetry never fails a command. Intended to be
 /// wrapped in `tokio::spawn` by callers that don't want to wait.
-async fn send(event: String, extra: serde_json::Value) {
-    let Some(distinct_id) = install_id() else {
+async fn send(event: String, event_id: uuid::Uuid, properties: serde_json::Value) {
+    let Some(install_id) = install_id() else {
         return;
     };
-    let payload = build_payload(&event, &distinct_id, extra);
-    let url = format!("{}/i/v0/e/", posthog_host());
+    send_with_id(event, install_id, event_id, properties).await;
+}
+
+async fn send_with_id(
+    event: String,
+    install_id: String,
+    event_id: uuid::Uuid,
+    properties: serde_json::Value,
+) {
+    let payload = build_payload_with_id(&event, &install_id, event_id, properties);
+    let url = format!("{}{ANALYTICS_PATH}", telemetry_host());
     // Bounded per-request timeout so a hung endpoint can't keep the background
     // task alive indefinitely.
     let _ = http()
@@ -683,12 +696,13 @@ async fn send(event: String, extra: serde_json::Value) {
 /// set in `main`, so there is exactly one flag-access idiom.
 fn spawn_event(
     event: impl Into<String>,
-    extra: serde_json::Value,
+    properties: serde_json::Value,
 ) -> Option<tokio::task::JoinHandle<()>> {
     if !is_enabled(flag()) {
         return None;
     }
-    Some(tokio::spawn(send(event.into(), extra)))
+    let event_id = uuid::Uuid::new_v4();
+    Some(tokio::spawn(send(event.into(), event_id, properties)))
 }
 
 /// Handles of spawned event sends that haven't been flushed yet. Draining +
@@ -716,17 +730,13 @@ fn capture(event: impl Into<String>, extra: serde_json::Value) {
     }
 }
 
-/// Shared `distinct_id` for consent events that must not touch the install id
-/// (declines, and agrees whose id could not be persisted). A FIXED sentinel, not
-/// a per-event UUID: a fresh UUID per event minted a brand-new PostHog person
-/// every time (67 phantom "users" in the launch week alone), silently inflating
-/// any unique-user metric that included the consent event. With one shared
-/// sentinel, all such events collapse into a single well-known person that is
-/// trivially excluded — while still writing nothing to disk and remaining
-/// unlinkable to any real install.
+/// Shared installation ID for consent events that must not touch the install id
+/// (declines, and agrees whose id could not be persisted). A fixed sentinel keeps
+/// declines from becoming unique installations while remaining unlinkable to a
+/// real install.
 const CONSENT_SENTINEL_ID: &str = "cli-consent-anonymous";
 
-/// Resolve the consent event's `distinct_id` per the identity policy on
+/// Resolve the consent event's installation ID per the identity policy on
 /// [`record_consent`] below. Split out so the identity rules are unit-testable
 /// without a network send. NB the `agreed` path calls `install_id()`, which
 /// generates + persists an id if absent — acceptable precisely because the
@@ -763,19 +773,15 @@ pub(crate) async fn record_consent(agreed: bool) {
         return;
     }
     let distinct_id = consent_distinct_id(agreed);
-    let payload = build_payload(
-        "telemetry_consent",
-        &distinct_id,
-        json!({ "agreed": agreed }),
-    );
-    let url = format!("{}/i/v0/e/", posthog_host());
+    let event_id = uuid::Uuid::new_v4();
     let send = async {
-        let _ = http()
-            .post(&url)
-            .timeout(Duration::from_secs(3))
-            .json(&payload)
-            .send()
-            .await;
+        send_with_id(
+            "telemetry_consent".to_string(),
+            distinct_id,
+            event_id,
+            json!({ "agreed": agreed }),
+        )
+        .await;
     };
     // Cap the wait so the settings POST / command return promptly even if the
     // network is slow; the send itself also has its own 3s request timeout.
@@ -787,26 +793,11 @@ pub(crate) fn capture_onboarding_completed() {
 }
 
 pub(crate) fn capture_onboarding_research_profile(profile: &ResearchProfile) {
-    let paper_ids: Vec<_> = profile
-        .papers
-        .iter()
-        .map(|paper| paper.paper_id.as_str())
-        .collect();
-    let paper_titles: Vec<_> = profile
-        .papers
-        .iter()
-        .map(|paper| paper.title.as_deref())
-        .collect();
     capture(
         "onboarding_research_profile_submitted",
         json!({
-            "research_areas": profile.research_areas,
-            "other_area": profile.other_area,
-            "background": profile.background,
-            "papers": profile.papers,
-            "paper_ids": paper_ids,
-            "paper_titles": paper_titles,
-            "paper_count": profile.papers.len(),
+            "researchAreas": profile.research_areas,
+            "paperCount": profile.papers.len(),
         }),
     );
 }
@@ -895,7 +886,7 @@ impl TelemetrySession {
 pub(crate) fn capture_experiment_started(kind: &str, local: bool, target: Option<&str>) {
     let mut extra = json!({ "kind": kind, "local": local });
     if let (Some(obj), Some(t)) = (extra.as_object_mut(), target) {
-        obj.insert("target".to_string(), json!(t));
+        obj.insert("computeTarget".to_string(), json!(t));
     }
     capture("experiment_started", extra);
 }
@@ -1264,33 +1255,28 @@ mod tests {
         let payload = build_payload(
             "experiment_started",
             "test-distinct-id",
-            json!({ "kind": "run", "local": false, "target": "modal" }),
+            json!({ "kind": "run", "local": false, "computeTarget": "modal" }),
         );
 
-        assert_eq!(payload["api_key"], POSTHOG_KEY);
-        // The bare name is `cli_`-prefixed on the wire so CLI events are
-        // separable from the website's events in this shared PostHog project.
-        assert_eq!(payload["event"], "cli_experiment_started");
-        assert_eq!(payload["distinct_id"], "test-distinct-id");
+        assert_eq!(payload["schemaVersion"], 1);
+        assert_eq!(payload["installId"], "test-distinct-id");
+        assert_eq!(payload["events"][0]["name"], "cli_experiment_started");
+        assert!(payload["events"][0]["eventId"].is_string());
 
-        let props = &payload["properties"];
-        // Anonymous marker present and false.
-        assert_eq!(props["$process_person_profile"], false);
-        assert_eq!(props["source"], "cli");
-        assert!(props["cli_version"].is_string());
-        assert_eq!(props["build_channel"], build_channel());
-        assert!(props["os"].is_string());
-        assert!(props["arch"].is_string());
-        assert!(props["ci"].is_boolean());
+        let context = &payload["context"];
+        assert!(context["cliVersion"].is_string());
+        assert_eq!(context["buildChannel"], build_channel());
+        assert!(context["os"].is_string());
+        assert!(context["arch"].is_string());
+        assert!(context["ci"].is_boolean());
         // No context configured → a human install.
-        assert_eq!(props["install_kind"], "human");
+        assert_eq!(context["installKind"], "human");
+        let props = &payload["events"][0]["properties"];
         // Event-specific coarse props.
         assert_eq!(props["kind"], "run");
-        assert_eq!(props["target"], "modal");
+        assert_eq!(props["computeTarget"], "modal");
 
-        // Client timestamp present at top level (so PostHog buckets on event
-        // time, not ingestion time).
-        assert!(payload["timestamp"].is_string());
+        assert!(payload["events"][0]["occurredAt"].is_string());
 
         // Standard product events must not automatically add obvious
         // identifying fields.
@@ -1315,23 +1301,25 @@ mod tests {
             "did",
             json!({
                 "source": "EVIL",
-                "build_channel": "EVIL",
+                "buildChannel": "EVIL",
                 "ci": "EVIL",
-                "install_kind": "EVIL",
+                "installKind": "EVIL",
                 "command": "login"
             }),
         );
-        let props = &payload["properties"];
-        assert_eq!(props["source"], "cli", "base source must win");
+        let context = &payload["context"];
         assert_eq!(
-            props["build_channel"],
+            context["buildChannel"],
             build_channel(),
             "embedded build channel must win"
         );
-        assert!(props["ci"].is_boolean(), "base ci must win");
-        assert_eq!(props["install_kind"], "human", "base install_kind must win");
+        assert!(context["ci"].is_boolean(), "base ci must win");
+        assert_eq!(
+            context["installKind"], "human",
+            "base install kind must win"
+        );
         // Non-colliding extra keys still land.
-        assert_eq!(props["command"], "login");
+        assert_eq!(payload["events"][0]["properties"]["command"], "login");
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -1406,10 +1394,7 @@ mod tests {
         let _g = EnvGuard::new(OPT_VARS);
         let dir = std::env::temp_dir().join(format!("orx-tel-prefix-{}", uuid::Uuid::new_v4()));
         std::env::set_var("XDG_CONFIG_HOME", &dir);
-        // This PostHog project is shared with the website; CLI events must be
-        // separable by name alone. `build_payload` prefixes unconditionally, so
-        // the base names map to their prefixed wire names and nothing can
-        // emit an unprefixed event.
+        // Event names remain stable across the first-party migration.
         for (bare, wire) in [
             ("command", "cli_command"),
             ("onboarding_completed", "cli_onboarding_completed"),
@@ -1423,9 +1408,95 @@ mod tests {
             ("telemetry_consent", "cli_telemetry_consent"),
         ] {
             let p = build_payload(bare, "did", json!({}));
-            assert_eq!(p["event"], wire, "`{bare}` must serialize as `{wire}`");
+            assert_eq!(
+                p["events"][0]["name"], wire,
+                "`{bare}` must serialize as `{wire}`"
+            );
         }
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn retry_payloads_reuse_the_client_event_id() {
+        let _g = EnvGuard::new(OPT_VARS);
+        let dir = std::env::temp_dir().join(format!("orx-tel-retry-{}", uuid::Uuid::new_v4()));
+        std::env::set_var("XDG_CONFIG_HOME", &dir);
+        let event_id = uuid::Uuid::new_v4();
+        let first = build_payload_with_id("command", "did", event_id, json!({ "command": "run" }));
+        let retry = build_payload_with_id("command", "did", event_id, json!({ "command": "run" }));
+        assert_eq!(first["events"][0]["eventId"], retry["events"][0]["eventId"]);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn sender_posts_the_first_party_endpoint() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let _g = EnvGuard::new(OPT_VARS);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        std::env::set_var("ORX_TELEMETRY_HOST", format!("http://{address}"));
+        let event_id = uuid::Uuid::new_v4();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut bytes = Vec::new();
+            let mut buffer = [0_u8; 4096];
+            loop {
+                let read = stream.read(&mut buffer).await.unwrap();
+                if read == 0 {
+                    break;
+                }
+                bytes.extend_from_slice(&buffer[..read]);
+                if let Some(header_end) = bytes.windows(4).position(|window| window == b"\r\n\r\n")
+                {
+                    let headers = String::from_utf8_lossy(&bytes[..header_end]);
+                    let content_length = headers
+                        .lines()
+                        .find_map(|line| {
+                            line.to_ascii_lowercase()
+                                .strip_prefix("content-length: ")
+                                .map(str::to_owned)
+                        })
+                        .and_then(|value| value.parse::<usize>().ok())
+                        .unwrap();
+                    if bytes.len() >= header_end + 4 + content_length {
+                        break;
+                    }
+                }
+            }
+            stream
+                .write_all(
+                    b"HTTP/1.1 202 Accepted\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .await
+                .unwrap();
+            bytes
+        });
+
+        send_with_id(
+            "command".to_string(),
+            "install".to_string(),
+            event_id,
+            json!({ "command": "run" }),
+        )
+        .await;
+        let request = String::from_utf8(server.await.unwrap()).unwrap();
+        assert!(request.starts_with("POST /analytics/v1/cli-events HTTP/1.1\r\n"));
+        let body = request.split("\r\n\r\n").nth(1).unwrap();
+        let payload: serde_json::Value = serde_json::from_str(body).unwrap();
+        assert_eq!(payload["events"][0]["eventId"], event_id.to_string());
+        assert_eq!(payload["events"][0]["name"], "cli_command");
+    }
+
+    #[test]
+    fn telemetry_host_override_only_accepts_loopback_origins() {
+        let _g = EnvGuard::new(OPT_VARS);
+        std::env::set_var("ORX_TELEMETRY_HOST", "http://127.0.0.1:4000");
+        assert_eq!(telemetry_host(), "http://127.0.0.1:4000");
+        std::env::set_var("ORX_TELEMETRY_HOST", "https://example.com");
+        assert_eq!(telemetry_host(), "https://api.openresearch.sh");
+        std::env::set_var("ORX_TELEMETRY_HOST", "http://localhost:4000/path");
+        assert_eq!(telemetry_host(), "https://api.openresearch.sh");
     }
 
     #[test]
@@ -1435,8 +1506,8 @@ mod tests {
         std::env::set_var("XDG_CONFIG_HOME", &dir);
         for agreed in [true, false] {
             let p = build_payload("telemetry_consent", "did", json!({ "agreed": agreed }));
-            assert_eq!(p["event"], "cli_telemetry_consent");
-            assert_eq!(p["properties"]["agreed"], agreed);
+            assert_eq!(p["events"][0]["name"], "cli_telemetry_consent");
+            assert_eq!(p["events"][0]["properties"]["agreed"], agreed);
         }
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -1448,71 +1519,46 @@ mod tests {
         std::env::set_var("XDG_CONFIG_HOME", &dir);
 
         let onboarding = build_payload("onboarding_completed", "did", json!({}));
-        assert_eq!(onboarding["event"], "cli_onboarding_completed");
-        assert_eq!(
-            property_keys(&onboarding),
-            vec![
-                "$process_person_profile",
-                "arch",
-                "build_channel",
-                "ci",
-                "cli_version",
-                "install_kind",
-                "os",
-                "source",
-            ]
-        );
+        assert_eq!(onboarding["events"][0]["name"], "cli_onboarding_completed");
+        assert!(property_keys(&onboarding).is_empty());
 
         let research_profile = build_payload(
             "onboarding_research_profile_submitted",
             "did",
             json!({
-                "research_areas": ["AI/ML", "Other"],
-                "other_area": "AI for theorem proving",
-                "background": "I study RL",
-                "papers": [{"paperId": "1706.03762", "title": "Attention Is All You Need"}],
-                "paper_ids": ["1706.03762"],
-                "paper_titles": ["Attention Is All You Need"],
-                "paper_count": 1,
+                "researchAreas": ["AI/ML", "Other"],
+                "paperCount": 1,
             }),
         );
         assert_eq!(
-            research_profile["event"],
+            research_profile["events"][0]["name"],
             "cli_onboarding_research_profile_submitted"
         );
-        assert_eq!(research_profile["properties"]["research_areas"][1], "Other");
         assert_eq!(
-            research_profile["properties"]["other_area"],
-            "AI for theorem proving"
+            research_profile["events"][0]["properties"]["researchAreas"][1],
+            "Other"
         );
-        assert_eq!(research_profile["properties"]["background"], "I study RL");
-        assert_eq!(
-            research_profile["properties"]["papers"][0]["title"],
-            "Attention Is All You Need"
-        );
-        assert_eq!(research_profile["properties"]["paper_ids"][0], "1706.03762");
+        assert_eq!(research_profile["events"][0]["properties"]["paperCount"], 1);
+        let profile_text = serde_json::to_string(&research_profile).unwrap();
+        for forbidden in ["otherArea", "background", "paperId", "title"] {
+            assert!(!profile_text.contains(forbidden));
+        }
 
         let project = build_payload("project_created", "did", json!({ "local": true }));
-        assert_eq!(project["event"], "cli_project_created");
-        assert_eq!(project["properties"]["local"], true);
-        let mut project_keys = property_keys(&onboarding);
-        project_keys.push("local");
-        project_keys.sort_unstable();
-        assert_eq!(property_keys(&project), project_keys);
+        assert_eq!(project["events"][0]["name"], "cli_project_created");
+        assert_eq!(project["events"][0]["properties"]["local"], true);
+        assert_eq!(property_keys(&project), vec!["local"]);
 
         let chat = build_payload("chat_session_started", "did", json!({ "harness": "codex" }));
-        assert_eq!(chat["event"], "cli_chat_session_started");
-        assert_eq!(chat["properties"]["harness"], "codex");
-        let mut chat_keys = property_keys(&onboarding);
-        chat_keys.push("harness");
-        chat_keys.sort_unstable();
-        assert_eq!(property_keys(&chat), chat_keys);
+        assert_eq!(chat["events"][0]["name"], "cli_chat_session_started");
+        assert_eq!(chat["events"][0]["properties"]["harness"], "codex");
+        assert_eq!(property_keys(&chat), vec!["harness"]);
 
         let _ = std::fs::remove_dir_all(&dir);
     }
 
     fn property_keys(payload: &serde_json::Value) -> Vec<&str> {
-        let mut keys: Vec<_> = payload["properties"]
+        let mut keys: Vec<_> = payload["events"][0]["properties"]
             .as_object()
             .unwrap()
             .keys()


### PR DESCRIPTION
## Summary
- replace the embedded PostHog capture key, hostname, path, and payload with the first-party schema-v1 OpenResearch analytics endpoint
- preserve official-build gating, installation identity, consent/opt-out behavior, background delivery, stable retry event IDs, timeout, and exit flushing
- minimize onboarding analytics to research-area categories and paper count, excluding free text, paper IDs, and titles
- restrict ORX_TELEMETRY_HOST overrides to loopback origins for local integration tests and update the telemetry disclosure

## Dependency
Requires alphaXiv/openresearch.sh#586 to be deployed before this CLI version is released.

## Automated verification
- [x] cargo fmt --all --check
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo build --locked
- [x] cargo test --locked -- --test-threads=1 (493 passed, 1 live-Slurm test ignored)
- [x] source scan finds no PostHog ingestion key or hostname
- [x] mandatory cross-family review loop (four clean reviewers)

## Release acceptance
- [ ] smoke-test an official release binary against the deployed first-party endpoint
- [ ] manually verify accepted consent, declined consent, persistent opt-out, and --no-telemetry behavior
- [ ] release only after the backend deployment and historical import/cutover readiness checks