### PR TITLE
Release only when a push changes the version

### DIFF
--- a/.github/workflows/release-on-bump.yml
+++ b/.github/workflows/release-on-bump.yml
@@ -23,6 +23,15 @@
 #
 # This never increments a version: the version is always a human decision made
 # in a reviewed PR, and "merge a PR that bumps Cargo.toml" is the release act.
+#
+# The trigger is the version *changing* in a push, so exactly one run can
+# dispatch a given release and later pushes will not retry it. If that run fails
+# or never dispatches, re-run it (Actions -> this workflow -> the failed run ->
+# Re-run): a re-run replays the original event, `github.event.before` included,
+# so the guard below still sees the bump. Prefer that over dispatching
+# release.yml by hand, whose `tag` input defaults to `dry-run` (which publishes
+# nothing but reports success) and which builds from main's current tip rather
+# than the bump commit.
 
 name: Release on version bump
 
@@ -30,10 +39,12 @@ on:
   push:
     branches: [main]
 
-# Serialize runs so two quick merges can't double-dispatch.
-concurrency:
-  group: release-on-bump
-  cancel-in-progress: false
+# Deliberately no `concurrency` group. It served to stop two quick merges
+# double-dispatching, which the version guard below now does per-run and
+# correctly. Worse, it cost releases: queueing a run cancels the *pending* one
+# in its group (`cancel-in-progress: false` protects only the running one), so a
+# third push could cancel the bump's run outright — and since no later push
+# re-dispatches, the release would be lost with nothing red to show for it.
 
 permissions:
   contents: read
@@ -45,6 +56,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The guard below reads Cargo.toml at the previous head. Full depth,
+          # not 2: a multi-commit push puts that commit out of range, and the
+          # guard would silently no-op back into duplicate dispatches.
+          fetch-depth: 0
 
       - name: Dispatch the release workflow
         env:
@@ -54,6 +70,7 @@ jobs:
           # the auto-attach (recover via release-macos-app.yml's workflow_dispatch).
           DISPATCH_PAT: ${{ secrets.RELEASE_DISPATCH_TOKEN }}
           FALLBACK_TOKEN: ${{ github.token }}
+          BEFORE: ${{ github.event.before }}
         run: |
           set -euo pipefail
 
@@ -61,6 +78,23 @@ jobs:
           # `version` keys never start a line with `version = `).
           version=$(grep -m1 '^version = ' Cargo.toml | sed -E 's/version = "(.*)"/\1/')
           tag="v${version}"
+
+          # Did this push change the version? The tag check below can't stand
+          # alone: the tag is only created when the release publishes, minutes
+          # after dispatch, so every push during a build would dispatch a
+          # duplicate — from a different commit, making the released content a
+          # race. An unreadable previous head (force push, first commit) leaves
+          # `previous` empty and falls through to the tag check.
+          previous=""
+          if [ -n "${BEFORE}" ] && [ "${BEFORE}" != "0000000000000000000000000000000000000000" ] \
+            && git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+            previous=$(git show "${BEFORE}:Cargo.toml" 2>/dev/null \
+              | grep -m1 '^version = ' | sed -E 's/version = "(.*)"/\1/' || true)
+          fi
+          if [ -n "${previous}" ] && [ "${previous}" = "${version}" ]; then
+            echo "Version unchanged at ${version} in this push — nothing to release."
+            exit 0
+          fi
 
           if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
             echo "Tag ${tag} already exists — nothing to release."


### PR DESCRIPTION
Fixes the duplicate-release failure seen on 2026-08-17, and the quieter problem underneath it.

## What happened

| Time | Event |
|---|---|
| 23:28:49 | #202 merges — bumps 0.1.105 → 0.1.106 → dispatches Release #1 |
| 23:28:59 → 23:39:16 | Release #1 building |
| 23:36:38 | #201 merges — **no version change** |
| 23:39:06 | Release #1 publishes, **creating tag v0.1.106** |
| 23:41:56 | Release #2 fails: `a release with the same tag name already exists` |

The guard was "skip if the tag already exists". In `dispatch-releases` mode nothing pushes a tag — `release.yml` creates it via `gh release create` at the very end of a ~10 minute build. So for those ten minutes every push to main sees no tag and dispatches a duplicate.

The failed run was the visible half. The two runs were dispatched from **different commits**, so whichever finished first decided what `v0.1.106` contained. Release #1 won, which is why v0.1.106 does not contain #201's changes.

## The fix

Guard on the version actually changing in this push, comparing `Cargo.toml` at `github.event.before`. A push that didn't touch the version can't release, whatever the tag state. The tag check stays as a second line of defense and as the fallback when the previous head is unreadable (force push, first commit) — that path degrades to exactly today's behavior.

**The concurrency group is removed**, and that part is load-bearing rather than tidying. Queueing a run cancels the *pending* run in its group (`cancel-in-progress: false` protects only the in-progress one). Since only the bump's own push can now dispatch, a third push could cancel that run and the release would be lost **silently** — a cancelled run is not a failure signal. That would have traded a loud duplicate for a quiet miss. The version guard does the de-duplication per-run and correctly, so the group buys nothing.

`fetch-depth: 0` is required: the default shallow clone lacks the previous commit, and the guard would silently no-op. `fetch-depth: 2` is *not* a valid cheaper alternative — a multi-commit push puts that commit out of range.

## Consequence worth knowing

Exactly one run can dispatch a given release, so later pushes no longer retry it. If that run fails or never dispatches, **re-run it** — a re-run replays the original event including `github.event.before`, so the guard still sees the bump. That's documented in the header, along with why it beats dispatching `release.yml` by hand (its `tag` input defaults to `dry-run`, which publishes nothing but reports success, and it builds from main's tip rather than the bump commit).

## Testing

- [x] Guard logic replayed against this repo's real history, under `set -euo pipefail`:
  - `be25acc` after `505b272` (the push that broke it) → **SKIP**
  - `505b272` after `e9d322e` (real 0.1.105→0.1.106 bump) → **dispatch**
  - multi-commit push spanning a bump (`e9d322e`..`be25acc`) → **dispatch**
  - zeroed / unreachable / empty `before` → falls through to the tag check
  - the pending 0.1.106→0.1.107 bump → **dispatch**
- [x] Shell verified safe under `set -euo pipefail`: `git cat-file -e` inside an `if` is exempt from `-e`; `|| true` binds to the whole pipeline so `pipefail` can't abort the assignment; every failure path leaves `previous` empty, which is gated before the skip
- [x] Premise confirmed in-tree: `dist-workspace.toml` sets `dispatch-releases = true`, and `gh release create` in `release.yml`'s `host` job is the only tag-creating operation in the repo
- [ ] Observed on a real push: merging this should log "Version unchanged at 0.1.106 — nothing to release" and dispatch nothing
- [ ] Observed on a real bump: the follow-up 0.1.107 PR should dispatch exactly one release

## Merge order

Merge this **before** the 0.1.107 bump. If the bump goes first, its build opens the ten-minute window in which the *old* guard is still what runs, and merging this inside that window would trigger the very failure it removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)