### PR TITLE
chore: release 0.1.107

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,7 +1025,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openresearch-cli"
-version = "0.1.106"
+version = "0.1.107"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openresearch-cli"
-version = "0.1.106"
+version = "0.1.107"
 edition = "2021"
 description = "OpenResearch CLI (orx) — Rust port"
 repository = "https://github.com/alphaXiv/openresearch-cli"


### PR DESCRIPTION
Cuts the release that puts CLI and macOS app self-update (#201) into users' hands. That merged after v0.1.106 was already cut, so **no released build contains it yet** — I verified against the published artifacts:

| v0.1.106 artifact | has the updater? |
|---|---|
| CLI tarball binary | ❌ no `install-cli`, old `version --json` shape |
| DMG app binary | ❌ same |
| `macos-app.json` | ✅ present (produced by the workflow half of #201) |

Merging this dispatches the release. No code changes — `Cargo.toml` and `Cargo.lock` only.

## For the macOS app, this is the changeover release

Self-update runs *inside* the app, so a build without the updater can never fetch one — there's no external helper or daemon. 0.1.106 and earlier are permanently stuck. **Everyone currently on the app needs one manual install of 0.1.107**; from then on it updates itself.

Worth saying in the release notes.

The release-side half is already live and verified against the real v0.1.106 artifacts: the published `macos-app.json` sha256 matches the DMG byte-for-byte, and that DMG satisfies the updater's exact `codesign` Developer ID requirement and returns `source=Notarized Developer ID` from `spctl`.

## Testing

- [x] CI's three version-guard checks pass locally: version moves forward (0.1.106 → 0.1.107), `v0.1.107` is not an existing tag, `Cargo.lock` regenerated to match
- [x] Diff is two lines, `Cargo.toml` + `Cargo.lock` only
- [ ] Merging dispatches exactly one release, and v0.1.107's binaries contain `install-cli` and the channel-aware `version --json`
- [ ] `macos-app.json` published for v0.1.107 with a digest matching its DMG

## Merge order

Merge #203 (the release-dispatch guard) **first**. If this goes first, its ~10 minute release build is exactly the window in which the old guard misfires, and merging #203 during it would re-trigger the duplicate-release failure that PR removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)