### PR TITLE
OR-181: stop end-of-turn reconcile duplicating codex messages

### DIFF
--- a/src/local/harness/codex.rs
+++ b/src/local/harness/codex.rs
@@ -1113,20 +1113,52 @@ pub(crate) fn reconcile_interrupted_items(
 }
 
 fn reconcile_items(parts: &mut Vec<WirePart>, items: &[Value]) {
+    // History can repeat identical text; consume-once pairing keeps the Nth
+    // repeat restorable instead of collapsing every copy onto one part.
+    let mut claimed: Vec<String> = Vec::new();
     for item in items {
         let completed = item.get("status").and_then(Value::as_str) != Some("inProgress");
         let Some(part) = item_to_part(item, completed, parts) else {
             continue;
         };
-        if completed
-            && streamed_text_kind(item)
-            && part_text_is_empty(&part)
-            && parts.iter().any(|prior| prior.id == part.id)
-        {
+        let id_exists = parts.iter().any(|prior| prior.id == part.id);
+        if completed && streamed_text_kind(item) && part_text_is_empty(&part) && id_exists {
             continue;
+        }
+        // `thread/read` re-mints ids (`item-N`) for content the live stream
+        // keyed by its Responses id (`msg_…`/`rs_…`), so an unknown id whose
+        // text continues a non-empty same-kind part is that part's item
+        // renamed, not new content (OR-181) — adopt the authoritative text in
+        // place. An empty part carries no evidence of which item it is.
+        if !id_exists && renamable_text_kind(item) {
+            let incoming = part.text.as_deref().unwrap_or("");
+            let renamed = parts.iter().position(|prior| {
+                let prior_text = prior.text.as_deref().unwrap_or("");
+                !claimed.contains(&prior.id)
+                    && !prior.id.starts_with("plan-item-")
+                    && prior.kind == part.kind
+                    && !prior_text.is_empty()
+                    && incoming.starts_with(prior_text)
+            });
+            if let Some(i) = renamed {
+                claimed.push(parts[i].id.clone());
+                parts[i].text = part.text;
+                continue;
+            }
         }
         upsert_preserving_children(parts, part);
     }
+}
+
+/// Item types whose ids `thread/read` re-mints (see `reconcile_items`). Plan
+/// streams text too, but its part id is derived (`plan_part_id`), so history
+/// never renames it — and the `plan-item-` prior check is the other half of
+/// that exemption.
+fn renamable_text_kind(item: &Value) -> bool {
+    matches!(
+        item.get("type").and_then(Value::as_str),
+        Some("agentMessage") | Some("reasoning")
+    )
 }
 
 fn settle_interrupted_parts(parts: &mut [WirePart]) {
@@ -3121,6 +3153,115 @@ requires_openai_auth = false
             failed.state.as_ref().unwrap().output.as_deref(),
             Some("Operation not permitted (os error 1)\n")
         );
+    }
+
+    /// OR-181: `thread/read` re-mints item ids (`item-N`) for content the
+    /// live stream keyed by its Responses id, so reconcile must treat the
+    /// renamed item as the streamed part — not append a second copy.
+    #[test]
+    fn native_history_renamed_text_item_does_not_duplicate() {
+        let mut parts = vec![
+            WirePart::reasoning("rs_0ea484ab".to_string(), ""),
+            WirePart::text("msg_0ea484ab".to_string(), "**Decision:** no JSD."),
+        ];
+        let items = serde_json::json!([
+            { "type": "userMessage", "id": "item-11", "content": "which loss?" },
+            { "type": "agentMessage", "id": "item-12", "text": "**Decision:** no JSD." },
+            { "type": "agentMessage", "id": "item-13", "text": "A message the stream missed." }
+        ]);
+
+        reconcile_items(&mut parts, items.as_array().unwrap());
+
+        let ids: Vec<&str> = parts.iter().map(|part| part.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            ["rs_0ea484ab", "msg_0ea484ab", "item-13"],
+            "the streamed part survives under its own id; only the genuinely \
+             missing message is appended"
+        );
+        assert_eq!(parts[1].text.as_deref(), Some("**Decision:** no JSD."));
+        assert_eq!(
+            parts[2].text.as_deref(),
+            Some("A message the stream missed.")
+        );
+    }
+
+    /// A renamed item whose live part streamed only partial text completes
+    /// the streamed part in place instead of appending a sibling.
+    #[test]
+    fn native_history_renamed_item_completes_partial_streamed_text() {
+        let mut parts = vec![
+            WirePart::reasoning("rs_aa".to_string(), "Weighing"),
+            WirePart::text("msg_bb".to_string(), "**Decision:** no J"),
+        ];
+        let items = serde_json::json!([
+            { "type": "reasoning", "id": "item-1", "summary": ["Weighing the losses."] },
+            { "type": "agentMessage", "id": "item-2", "text": "**Decision:** no JSD." }
+        ]);
+
+        reconcile_items(&mut parts, items.as_array().unwrap());
+
+        assert_eq!(parts.len(), 2, "renamed items must not add parts");
+        assert_eq!(parts[0].id, "rs_aa");
+        assert_eq!(parts[0].text.as_deref(), Some("Weighing the losses."));
+        assert_eq!(parts[1].id, "msg_bb");
+        assert_eq!(parts[1].text.as_deref(), Some("**Decision:** no JSD."));
+    }
+
+    /// Consume-once matching: two identical history messages pair with at
+    /// most one streamed part each, so a genuine repeat is still restored.
+    #[test]
+    fn native_history_identical_repeat_is_still_restored() {
+        let mut parts = vec![WirePart::text("msg_aa".to_string(), "Done.")];
+        let items = serde_json::json!([
+            { "type": "agentMessage", "id": "item-1", "text": "Done." },
+            { "type": "agentMessage", "id": "item-2", "text": "Done." }
+        ]);
+
+        reconcile_items(&mut parts, items.as_array().unwrap());
+
+        let ids: Vec<&str> = parts.iter().map(|part| part.id.as_str()).collect();
+        assert_eq!(ids, ["msg_aa", "item-2"], "the second repeat is appended");
+    }
+
+    /// A plan part sharing its text with the final message must not swallow a
+    /// missing message (plan ids are derived, never re-minted by history).
+    #[test]
+    fn native_history_message_matching_plan_text_is_restored() {
+        let mut parts = vec![WirePart::text("plan-item-plan_1".to_string(), "the plan")];
+        let items = serde_json::json!([
+            { "type": "agentMessage", "id": "item-2", "text": "the plan" }
+        ]);
+
+        reconcile_items(&mut parts, items.as_array().unwrap());
+
+        let ids: Vec<&str> = parts.iter().map(|part| part.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            ["plan-item-plan_1", "item-2"],
+            "a plan part must not absorb a real message"
+        );
+    }
+
+    /// An empty streamed part carries no evidence of which item it is —
+    /// `starts_with("")` matches anything — so it never adopts history text.
+    #[test]
+    fn native_history_empty_part_is_not_a_wildcard_match() {
+        let mut parts = vec![WirePart::reasoning("rs_empty".to_string(), "")];
+        let items = serde_json::json!([
+            { "type": "reasoning", "id": "item-1", "summary": ["First thought."] }
+        ]);
+
+        reconcile_items(&mut parts, items.as_array().unwrap());
+
+        let ids: Vec<&str> = parts.iter().map(|part| part.id.as_str()).collect();
+        assert_eq!(ids, ["rs_empty", "item-1"], "the item appends, not adopts");
+        assert_eq!(
+            parts[0].text.as_deref(),
+            Some(""),
+            "the empty part stays untouched"
+        );
+        assert_eq!(parts[1].text.as_deref(), Some("First thought."));
     }
 
     #[test]


### PR DESCRIPTION
Fixes [OR-181](https://linear.app/alphaxiv/issue/OR-181/output-will-randomly-include-two-copies-of-responses): since v0.1.102 (#187 added end-of-turn reconcile), codex turns could render — and persist — the final assistant message twice.

## Cause

`reconcile_turn_items` re-reads the turn via codex's `thread/read` and merges the items as authoritative. For threads in codex's default legacy history mode, `thread/read` rebuilds history and **re-mints text item ids** (`item-N`) while the live stream keyed the same content by its Responses id (`msg_…`/`rs_…`). `reconcile_items` upserts by id, so the identical text was appended under the second id. Reproduced against codex 0.144.0 (live `msg_0bc…` vs history `item-2` for the same message), and the reporter's stored row shows exactly the `msg_…` + `item-N` pair.

## Fix

In `reconcile_items`, a history `agentMessage`/`reasoning` item under an unknown id whose text continues a non-empty same-kind part is that part's item renamed — adopt the authoritative text onto the streamed part (completing partially-streamed text) instead of appending. Guard rails:

- **Consume-once matching** (`claimed` by part id) so a genuinely repeated identical message is still restored.
- **Plan exemption on both sides** — plan parts use derived `plan-item-` ids codex never re-mints, and share kind `text` with messages.
- **Empty streamed parts never adopt** — `starts_with("")` matches anything; an empty part carries no identity.

Applies to both reconcile paths (end-of-turn and interrupted-session reopen). Claude and OpenCode harnesses are unaffected (wire-id-keyed on both sides; no reconcile step).

## Verification

- [x] 6 unit tests over `reconcile_items` incl. 5 new: rename-dedup with id ordering, partial-text completion (both kinds), identical-repeat restore, plan-text collision, empty-part wildcard regression
- [x] `cargo fmt --check`, `clippy -D warnings`, `cargo build --locked`, full `cargo test --locked` (506 passed)
- [x] 3-round independent 4-reviewer loop, final round NO BLOCKERS ×4
- [ ] Live smoke test: codex chat turn in `orx up` shows a single copy of the final message at turn end
- [ ] Live smoke test: interrupted codex turn reopened — no duplicate, tool rows settle