### PR TITLE
Label version-bump PRs with a shared version-bump label

### DIFF
--- a/.github/workflows/release-on-bump.yml
+++ b/.github/workflows/release-on-bump.yml
@@ -49,7 +49,8 @@ on:
 permissions:
   contents: read
   actions: write # github.token fallback path dispatches release.yml
-  statuses: write # to set the version-bump commit status chip
+  issues: write # to create/apply the version label on the bump's PR
+  pull-requests: read # to resolve the bump commit to its squash-merged PR
 
 jobs:
   dispatch:
@@ -103,13 +104,24 @@ jobs:
             exit 0
           fi
 
-          # Chip on the bump commit showing which version it shipped. Best-effort:
-          # a status API hiccup must never block the release dispatch below.
-          if ! GH_TOKEN="$FALLBACK_TOKEN" gh api "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
-            -f state=success \
-            -f context="version" \
-            -f description="Bumped to ${tag}" >/dev/null; then
-            echo "::warning::Failed to set version status chip for ${GITHUB_SHA}"
+          # Label the bump's PR with the new version (e.g. "v1.0.101") so the
+          # version a bump PR released is visible from the PR list. Best-effort:
+          # a labeling hiccup must never block the release dispatch below.
+          if pr=$(GH_TOKEN="$FALLBACK_TOKEN" gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
+            --jq '.[0].number // empty' 2>/dev/null); then
+            if [ -n "${pr}" ]; then
+              # Create the label first (422 if it already exists — ignored) so
+              # the add below never depends on auto-creation behavior.
+              GH_TOKEN="$FALLBACK_TOKEN" gh api "repos/${GITHUB_REPOSITORY}/labels" \
+                -f name="${tag}" -f color="0e8a16" >/dev/null 2>&1 || true
+              GH_TOKEN="$FALLBACK_TOKEN" gh api "repos/${GITHUB_REPOSITORY}/issues/${pr}/labels" \
+                -f "labels[]=${tag}" >/dev/null \
+                || echo "::warning::Failed to label PR #${pr} with ${tag}"
+            else
+              echo "No PR associated with ${GITHUB_SHA} — skipping the version label."
+            fi
+          else
+            echo "::warning::Could not look up the PR for ${GITHUB_SHA} — skipping the version label."
           fi
 
           echo "Dispatching release.yml with tag=${tag} (version is unreleased)."

--- a/.github/workflows/release-on-bump.yml
+++ b/.github/workflows/release-on-bump.yml
@@ -49,6 +49,7 @@ on:
 permissions:
   contents: read
   actions: write # github.token fallback path dispatches release.yml
+  statuses: write # to set the version-bump commit status chip
 
 jobs:
   dispatch:
@@ -100,6 +101,15 @@ jobs:
             echo "Tag ${tag} already exists — nothing to release."
             echo "(If you meant to cut a release, bump the version in Cargo.toml.)"
             exit 0
+          fi
+
+          # Chip on the bump commit showing which version it shipped. Best-effort:
+          # a status API hiccup must never block the release dispatch below.
+          if ! GH_TOKEN="$FALLBACK_TOKEN" gh api "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
+            -f state=success \
+            -f context="version" \
+            -f description="Bumped to ${tag}" >/dev/null; then
+            echo "::warning::Failed to set version status chip for ${GITHUB_SHA}"
           fi
 
           echo "Dispatching release.yml with tag=${tag} (version is unreleased)."

--- a/.github/workflows/release-on-bump.yml
+++ b/.github/workflows/release-on-bump.yml
@@ -104,24 +104,26 @@ jobs:
             exit 0
           fi
 
-          # Label the bump's PR with the new version (e.g. "v1.0.101") so the
-          # version a bump PR released is visible from the PR list. Best-effort:
-          # a labeling hiccup must never block the release dispatch below.
+          # Mark the bump's PR with a shared "version-bump" label so releases
+          # are visible from the PR list (one reused label, not one per
+          # version). Best-effort: a labeling hiccup must never block the
+          # release dispatch below.
           if pr=$(GH_TOKEN="$FALLBACK_TOKEN" gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
             --jq '.[0].number // empty' 2>/dev/null); then
             if [ -n "${pr}" ]; then
               # Create the label first (422 if it already exists — ignored) so
               # the add below never depends on auto-creation behavior.
               GH_TOKEN="$FALLBACK_TOKEN" gh api "repos/${GITHUB_REPOSITORY}/labels" \
-                -f name="${tag}" -f color="0e8a16" >/dev/null 2>&1 || true
+                -f name="version-bump" -f color="0e8a16" \
+                -f description="Bumps the CLI version; merging cuts a release" >/dev/null 2>&1 || true
               GH_TOKEN="$FALLBACK_TOKEN" gh api "repos/${GITHUB_REPOSITORY}/issues/${pr}/labels" \
-                -f "labels[]=${tag}" >/dev/null \
-                || echo "::warning::Failed to label PR #${pr} with ${tag}"
+                -f "labels[]=version-bump" >/dev/null \
+                || echo "::warning::Failed to label PR #${pr} with version-bump"
             else
-              echo "No PR associated with ${GITHUB_SHA} — skipping the version label."
+              echo "No PR associated with ${GITHUB_SHA} — skipping the version-bump label."
             fi
           else
-            echo "::warning::Could not look up the PR for ${GITHUB_SHA} — skipping the version label."
+            echo "::warning::Could not look up the PR for ${GITHUB_SHA} — skipping the version-bump label."
           fi
 
           echo "Dispatching release.yml with tag=${tag} (version is unreleased)."


### PR DESCRIPTION
## Summary
- When `release-on-bump.yml` detects an unreleased version on a push to `main`, it now resolves that squash commit back to its PR (via the `commits/{sha}/pulls` API) and applies a single shared `version-bump` label to it, right before dispatching `release.yml`.
- One reused label rather than one per version, so the repo's label list doesn't grow forever. The released version stays visible via the PR title and the `v<version>` tag/release.
- The label is created idempotently (green `0e8a16`, with a description) if it doesn't exist yet.
- Best-effort throughout: a failed PR lookup or labeling call prints a `::warning::` and continues — it can never block the actual release dispatch. A direct push to `main` with no associated PR just skips the label.

## Why this shape
- `release-on-bump.yml` already computes the release decision at the exact point it knows "this push is the bump" — reusing that avoids duplicating version-diff logic.
- A PR label is visible on the PR conversation page and in the PR list, unlike a commit status on the squash commit.
- Permissions added are narrow: `issues: write` (create/apply labels) + `pull-requests: read` (commit→PR lookup).

## Test plan
- [x] YAML parses (`yaml.safe_load`)
- [x] Verified `commits/{sha}/pulls` resolves a real squash commit (`3e93476`) to its PR (#141) against the live repo
- [x] Independent Codex review round on the labeling logic: 4/4 NO BLOCKERS (round 1 caught a fatal-failure path under `set -euo pipefail`; fixed, and lookup-failure vs no-PR cases are distinguished). The follow-up commit only renames the label to the shared one.
- [ ] Confirm the `version-bump` label lands on the next real version-bump PR after it merges to `main`