### PR TITLE
OR-182 Focus the existing dashboard tab on a Dock click

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,6 +1006,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1009,6 +1030,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags",
  "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1038,6 +1060,7 @@ dependencies = [
  "libc",
  "objc2",
  "objc2-app-kit",
+ "objc2-foundation",
  "reqwest",
  "rusqlite",
  "rust-embed",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,9 @@ libc = "0.2"
 # while the dashboard server runs on background threads. macOS-only so the
 # static musl Linux builds are untouched.
 objc2 = "0.6"
-objc2-app-kit = { version = "0.3", default-features = false, features = ["std", "NSApplication", "NSResponder", "NSRunningApplication"] }
+objc2-app-kit = { version = "0.3", default-features = false, features = ["std", "NSApplication", "NSResponder", "NSRunningApplication", "NSWorkspace"] }
+# Default-browser lookup for the Dock-click handler (NSWorkspace takes NSURLs).
+objc2-foundation = { version = "0.3", default-features = false, features = ["std", "NSArray", "NSEnumerator", "NSURL", "NSString"] }
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/macos/DISTRIBUTION.md
+++ b/macos/DISTRIBUTION.md
@@ -97,6 +97,11 @@ Also enable **Require a pull request** + **Require review from Code Owners** on
 `main` (see `.github/CODEOWNERS`) so the signing scripts can't change unreviewed.
 Never commit the `.p12`.
 
+`package-macos-app.sh` signs with `macos/entitlements.plist`, which grants the
+Apple-events entitlement the Dock-click tab focus needs. Without it that path is
+denied in signed builds only — unsigned local bundles never exercise the check —
+and the first Dock click prompts once for Automation access.
+
 ## Build / sign locally
 
 ```bash

--- a/macos/Info.plist
+++ b/macos/Info.plist
@@ -23,6 +23,10 @@
   <string>11.0</string>
   <key>NSHighResolutionCapable</key>
   <true/>
+  <!-- Shown when the Dock-icon handler asks the browser to raise the dashboard
+       tab; without it macOS denies the Apple event instead of prompting. -->
+  <key>NSAppleEventsUsageDescription</key>
+  <string>OpenResearch brings the dashboard tab to the front when you click its Dock icon.</string>
   <!-- Regular Dock app (not an agent/menubar-only app). -->
   <key>LSUIElement</key>
   <false/>

--- a/macos/entitlements.plist
+++ b/macos/entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- Lets the Dock-click handler's osascript raise the dashboard tab under the
+       hardened runtime (src/commands/app.rs; see macos/DISTRIBUTION.md). -->
+  <key>com.apple.security.automation.apple-events</key>
+  <true/>
+</dict>
+</plist>

--- a/macos/focus-dashboard-tab.js
+++ b/macos/focus-dashboard-tab.js
@@ -1,0 +1,112 @@
+// Raises the browser tab already showing the dashboard. Run by the macOS app's
+// Dock-click handler (src/commands/app.rs); prints "ok", "blocked" or "none".
+//
+// JXA rather than AppleScript: it resolves each browser's terminology at run
+// time, so this still runs on a Mac without Chrome installed — an AppleScript
+// `using terms from` block fails to *compile* there. Chromium forks all answer
+// Chrome's vocabulary; Safari needs its own. A browser missing from the list
+// degrades to the caller's later tiers, so staleness here is cosmetic.
+function run(argv) {
+  var url = argv[0];
+  var blocked = false;
+
+  // Specifiers are lazy: the Apple event fires when a count or a URL is read,
+  // not when `app.windows` is built, so those reads are what throw when a
+  // browser is unresponsive or Automation was denied. Such throws belong to the
+  // caller, which decides the whole browser's fate; only per-window and per-tab
+  // oddities are swallowed here.
+  function focusIn(app, setActive) {
+    var wins = app.windows;
+    var windowCount = wins.length;
+    for (var w = 0; w < windowCount; w++) {
+      var win = wins[w];
+      var urls;
+      try {
+        // One event for every URL in the window, rather than one per tab.
+        urls = win.tabs.url();
+      } catch (e) {
+        // No tabs to read: an inspector or settings window.
+        continue;
+      }
+      for (var t = 0; t < urls.length; t++) {
+        if (!urls[t] || urls[t].indexOf(url) !== 0) continue;
+        try {
+          setActive(win, t);
+        } catch (e) {
+          // A fork that exposes tabs but refuses the selection: keep looking so
+          // the caller still gets a chance to fall through to its own tiers.
+          continue;
+        }
+        // A minimized window is exactly the state someone clicks the Dock in.
+        // The two spellings are the Chromium and Safari names for it.
+        try {
+          win.minimized = false;
+        } catch (e) {}
+        try {
+          win.miniaturized = false;
+        } catch (e) {}
+        try {
+          win.index = 1;
+        } catch (e) {}
+        try {
+          app.activate();
+        } catch (e) {}
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // -1743 is "not authorized to send Apple events" — the user denied the
+  // Automation prompt, which is worth reporting. Anything else is a browser
+  // that is not installed or not answering, so just try the next one.
+  function search(bundleId, setActive) {
+    var app;
+    try {
+      app = Application(bundleId);
+      // Answered by the scripting runtime: it neither launches the app nor
+      // sends an Apple event, so an unauthorized browser still reaches focusIn.
+      if (!app.running()) return false;
+    } catch (e) {
+      // Only expected for a browser that is not installed, but classify anyway
+      // in case a future macOS routes `running()` through TCC too.
+      if (e && e.errorNumber === -1743) blocked = true;
+      return false;
+    }
+    try {
+      return focusIn(app, setActive);
+    } catch (e) {
+      if (e && e.errorNumber === -1743) blocked = true;
+      return false;
+    }
+  }
+
+  var chromium = [
+    "com.google.Chrome",
+    "com.google.Chrome.beta",
+    "com.google.Chrome.dev",
+    "com.google.Chrome.canary",
+    "com.brave.Browser",
+    "com.microsoft.edgemac",
+    "company.thebrowser.Browser",
+    "org.chromium.Chromium",
+    "com.vivaldi.Vivaldi",
+    "com.operasoftware.Opera",
+  ];
+  function selectChromiumTab(win, index) {
+    win.activeTabIndex = index + 1;
+  }
+  for (var i = 0; i < chromium.length; i++) {
+    if (search(chromium[i], selectChromiumTab)) return "ok";
+  }
+
+  if (
+    search("com.apple.Safari", function (win, index) {
+      win.currentTab = win.tabs[index];
+    })
+  ) {
+    return "ok";
+  }
+
+  return blocked ? "blocked" : "none";
+}

--- a/scripts/package-macos-app.sh
+++ b/scripts/package-macos-app.sh
@@ -29,8 +29,9 @@ fi
 if [[ -n "${MACOS_SIGN_IDENTITY:-}" ]]; then
   echo "==> Codesigning with hardened runtime"
   # Sign inside-out: the nested executable first, then the bundle.
-  codesign --force --options runtime --timestamp --sign "$MACOS_SIGN_IDENTITY" "$EXE"
-  codesign --force --options runtime --timestamp --sign "$MACOS_SIGN_IDENTITY" "$APP"
+  ENTITLEMENTS="$ROOT/macos/entitlements.plist"
+  codesign --force --options runtime --timestamp --entitlements "$ENTITLEMENTS" --sign "$MACOS_SIGN_IDENTITY" "$EXE"
+  codesign --force --options runtime --timestamp --entitlements "$ENTITLEMENTS" --sign "$MACOS_SIGN_IDENTITY" "$APP"
   codesign --verify --strict --verbose=2 "$APP"
 else
   echo "==> MACOS_SIGN_IDENTITY unset — building an UNSIGNED bundle (local test only)."

--- a/src/commands/app.rs
+++ b/src/commands/app.rs
@@ -141,6 +141,188 @@ async fn hydrate_shell_env() {
     }
 }
 
+/// Dock-icon click: raise the dashboard the user already has open instead of
+/// opening the URL again, which lands on a *new* tab once the SPA has navigated
+/// off `/`.
+#[cfg(target_os = "macos")]
+fn focus_or_open(url: &str) {
+    // The first attempt parks on the Automation permission prompt, which needs
+    // unbounded user time; without this, every impatient re-click stacks
+    // another blocked thread and, once they all unblock, another tab.
+    let Some(in_flight) = InFlight::claim() else {
+        return;
+    };
+    let url = url.to_string();
+    // Off the main thread for that same prompt — the AppKit run loop has to
+    // stay responsive while it is up.
+    std::thread::spawn(move || {
+        if !raise_dashboard(&url) {
+            crate::browser::open_browser(&url);
+        }
+        // Named so the closure captures it: dropping at the end of
+        // `focus_or_open` instead would end the claim before the attempt starts.
+        drop(in_flight);
+    });
+}
+
+#[cfg(target_os = "macos")]
+static ATTEMPT_IN_FLIGHT: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+#[cfg(target_os = "macos")]
+struct InFlight;
+
+#[cfg(target_os = "macos")]
+impl InFlight {
+    fn claim() -> Option<Self> {
+        // Constructed only on the winning branch: `then_some` would build one
+        // for the loser too and its `Drop` would free the winner's claim.
+        if ATTEMPT_IN_FLIGHT.swap(true, std::sync::atomic::Ordering::SeqCst) {
+            None
+        } else {
+            Some(Self)
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl Drop for InFlight {
+    /// Released here rather than on the happy path so a panic cannot latch the
+    /// claim on and kill the Dock icon for the life of the process.
+    fn drop(&mut self) {
+        ATTEMPT_IN_FLIGHT.store(false, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+/// True when a dashboard the user already had open was brought forward. False
+/// means the caller must open the URL — a duplicate tab beats a Dock icon that
+/// visibly does nothing, since app mode's port is ephemeral and the user has no
+/// other way back to the dashboard.
+#[cfg(target_os = "macos")]
+fn raise_dashboard(url: &str) -> bool {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    const NEVER: u64 = u64::MAX;
+    // Long enough to cover looking at the browser and deciding the dashboard is
+    // not there, short enough that a click minutes later still prefers a raise
+    // over a duplicate tab. Guessing wrong either way costs one tab.
+    const ACTIVATION_IS_RECENT_MS: u64 = 5_000;
+    // Only a real activation is recorded, so a click that fell through cannot
+    // slide the window forward and suppress the next one.
+    static LAST_ACTIVATION_MS: AtomicU64 = AtomicU64::new(NEVER);
+
+    if focus_existing_tab(url) {
+        return true;
+    }
+    // Firefox exposes no tab API, so a tab there can only be inferred from its
+    // event stream, and nothing finer than its whole browser can be raised.
+    // Clicking again within seconds says that did not surface the dashboard —
+    // it was left on another tab — so the repeat click opens the URL instead.
+    if !crate::commands::up::has_live_dashboard_clients() {
+        return false;
+    }
+    let last = LAST_ACTIVATION_MS.load(Ordering::SeqCst);
+    if last != NEVER && monotonic_ms() - last < ACTIVATION_IS_RECENT_MS {
+        return false;
+    }
+    if !activate_default_browser() {
+        return false;
+    }
+    LAST_ACTIVATION_MS.store(monotonic_ms(), Ordering::SeqCst);
+    true
+}
+
+/// Monotonic, so an NTP correction cannot suppress the fallback or end its
+/// window early.
+#[cfg(target_os = "macos")]
+fn monotonic_ms() -> u64 {
+    use std::sync::OnceLock;
+    use std::time::Instant;
+
+    static START: OnceLock<Instant> = OnceLock::new();
+    START.get_or_init(Instant::now).elapsed().as_millis() as u64
+}
+
+/// Activates the browser tab whose URL starts with `url`. False when no tab
+/// matches, no scriptable browser is running, or Automation permission was
+/// denied.
+#[cfg(target_os = "macos")]
+fn focus_existing_tab(url: &str) -> bool {
+    let out = std::process::Command::new("osascript")
+        .args(["-l", "JavaScript", "-e", FOCUS_TAB_SCRIPT, url])
+        .output();
+    let Ok(out) = out else {
+        return false;
+    };
+    match String::from_utf8_lossy(&out.stdout).trim() {
+        "ok" => true,
+        // Silent otherwise: "no tab open" is the ordinary case, but a denied
+        // Automation prompt is invisible without a line in the log.
+        "blocked" => {
+            eprintln!(
+                "openresearch app: not allowed to search browser tabs — grant OpenResearch \
+                 Automation access in System Settings › Privacy & Security"
+            );
+            false
+        }
+        _ => false,
+    }
+}
+
+/// Brings the default browser forward without opening anything, so the tab the
+/// user left open stays put. False when it is not running, where `open -a`
+/// would raise an empty browser instead of the dashboard.
+#[cfg(target_os = "macos")]
+fn activate_default_browser() -> bool {
+    let Some(browser) = default_browser_path() else {
+        return false;
+    };
+    if !is_running(&browser) {
+        return false;
+    }
+    std::process::Command::new("open")
+        .arg("-a")
+        .arg(&browser)
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+/// True when the app bundle at `bundle_path` is running. Both sides come from
+/// `NSURL.path`, so plain string equality is enough. The autorelease pools here
+/// and in `default_browser_path` are explicit because this runs on a plain
+/// `std::thread`, which never gets one of its own.
+#[cfg(target_os = "macos")]
+fn is_running(bundle_path: &str) -> bool {
+    use objc2_app_kit::NSWorkspace;
+
+    objc2::rc::autoreleasepool(|_| {
+        NSWorkspace::sharedWorkspace()
+            .runningApplications()
+            .iter()
+            .any(|app| {
+                app.bundleURL()
+                    .and_then(|url| url.path())
+                    .is_some_and(|path| path.to_string() == bundle_path)
+            })
+    })
+}
+
+/// macOS has no "which browser is default" call, so ask which app would open a
+/// throwaway `http://` URL.
+#[cfg(target_os = "macos")]
+fn default_browser_path() -> Option<String> {
+    use objc2_app_kit::NSWorkspace;
+    use objc2_foundation::{NSString, NSURL};
+
+    objc2::rc::autoreleasepool(|_| {
+        let probe = NSURL::URLWithString(&NSString::from_str("http://127.0.0.1/"))?;
+        let app = NSWorkspace::sharedWorkspace().URLForApplicationToOpenURL(&probe)?;
+        app.path().map(|path| path.to_string())
+    })
+}
+
+#[cfg(target_os = "macos")]
+const FOCUS_TAB_SCRIPT: &str = include_str!("../../macos/focus-dashboard-tab.js");
+
 #[cfg(target_os = "macos")]
 mod imp {
     use objc2::rc::Retained;
@@ -163,10 +345,10 @@ mod imp {
         unsafe impl NSObjectProtocol for Delegate {}
 
         unsafe impl NSApplicationDelegate for Delegate {
-            // Dock-icon click with no open windows → reopen the dashboard.
+            // Dock-icon click with no open windows → raise the dashboard.
             #[unsafe(method(applicationShouldHandleReopen:hasVisibleWindows:))]
             fn should_handle_reopen(&self, _app: &NSApplication, _has_windows: bool) -> bool {
-                crate::browser::open_browser(&self.ivars().url);
+                super::focus_or_open(&self.ivars().url);
                 true
             }
         }

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -13,6 +13,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::convert::Infallible;
+use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -4913,10 +4914,40 @@ async fn events(
             }
         }
     });
-    let stream = futures::stream::unfold(rx, |mut rx| async move {
-        rx.recv().await.map(|ev| (Ok(ev), rx))
+    // The guard rides the stream state, so the count drops when the response
+    // body is dropped — i.e. when the tab closes or navigates away.
+    let guard = DashboardClientGuard::new();
+    let stream = futures::stream::unfold((rx, guard), |(mut rx, guard)| async move {
+        rx.recv().await.map(|ev| (Ok(ev), (rx, guard)))
     });
     Sse::new(stream).keep_alive(KeepAlive::default())
+}
+
+/// Whether a dashboard is open somewhere — macOS app mode asks on a Dock click,
+/// where a live tab means "raise the browser" rather than "open the URL again".
+/// Any `/api/events` consumer counts, and a connection that vanished without a
+/// FIN lingers until a keep-alive write fails.
+// Un-gated so CI's Linux runner still type-checks it; only macOS has a caller.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub(crate) fn has_live_dashboard_clients() -> bool {
+    LIVE_DASHBOARD_CLIENTS.load(std::sync::atomic::Ordering::Relaxed) > 0
+}
+
+static LIVE_DASHBOARD_CLIENTS: AtomicUsize = AtomicUsize::new(0);
+
+struct DashboardClientGuard;
+
+impl DashboardClientGuard {
+    fn new() -> Self {
+        LIVE_DASHBOARD_CLIENTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        Self
+    }
+}
+
+impl Drop for DashboardClientGuard {
+    fn drop(&mut self) {
+        LIVE_DASHBOARD_CLIENTS.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+    }
 }
 
 /// Diff state for one SSE subscriber.


### PR DESCRIPTION
Clicking the OpenResearch Dock icon opened a new browser tab (or reloaded) instead of returning to the dashboard already open. The handler called `open <url>` every time, and once the SPA has navigated off `/` the browser has no exact-URL match to reuse.

## What it does now

The reopen handler tries, best first:

1. **The exact tab** — a JXA script scans the scriptable browsers (Chrome and forks, Safari) for a tab whose URL prefix-matches the dashboard, makes it active, un-minimizes its window, and raises it.
2. **The browser window** — Firefox exposes no tab API, so an open dashboard can only be inferred from its `/api/events` stream. When one is live and the default browser is running, `open -a` activates it: no new tab, no reload.
3. **Plain open** — unchanged from today.

A repeat click within five seconds takes step 3, so a raise that did not surface the dashboard is always recoverable. That matters because app mode binds an ephemeral port — a Dock icon that does nothing leaves no other route back.

JXA rather than AppleScript is load-bearing: it resolves each browser's terminology at run time, whereas an AppleScript `using terms from` block fails to *compile* on a Mac without Chrome installed.

## Signing

`package-macos-app.sh` now signs with `macos/entitlements.plist` (`com.apple.security.automation.apple-events`). Under the hardened runtime TCC denies the Apple event without it — and local bundles are unsigned, so that failure appears only in shipped builds. Please give this file a close look, since it touches the signing path.

## Notes

- No version bump, so this reaches users on the next release rather than on merge.
- The step-2 machinery (SSE liveness, default-browser lookup, `objc2-foundation`) exists specifically to serve Firefox and unlisted browsers. Without it those users keep today's new-tab behavior.
- CI never compiles this code — `ci.yml` is `ubuntu-latest` only and everything new in `app.rs` is macOS-gated. Verified locally instead; a `macos-latest cargo check` job would close that gap separately.

## Testing

- [x] `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build --locked`, `cargo test --locked` (519 passed), `node --test scripts/dev-slot.test.mjs`
- [x] Safari: deep-route tab found and raised from a **minimized** window, with a decoy tab whose URL merely *contains* the dashboard URL correctly ignored
- [x] Firefox (default browser), real app bundle, reopen triggered via `open -a`: first click activates the browser with no new tab; an immediate second click falls through and opens the URL
- [x] SSE counter increments on connect and returns to zero on disconnect
- [x] `InFlight` claim verified: a rejected claim no longer releases the winner's flag
- [ ] Signed + notarized build: confirm tier 1 works and the Automation prompt appears once (cannot be checked from an unsigned local bundle)
- [ ] A Chromium browser (Chrome/Brave/Edge/Arc) — none installed on the dev machine, so only Safari exercised the Chromium vocabulary path
- [ ] Denied-Automation path: confirm the fallback and the one-line stderr diagnostic