### PR TITLE
[OR-191] feat: track chat message telemetry

### DIFF
--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -4701,6 +4701,7 @@ async fn send_chat_message(
         .send_message(&id, text, overrides, req.images, annotations)
         .await
         .map_err(bad_request)?;
+    crate::telemetry::capture_chat_message_sent();
     Ok(Json(json!({ "ok": true })))
 }
 
@@ -4720,10 +4721,10 @@ async fn fork_chat_turn(
     Json(req): Json<ForkChatReq>,
 ) -> ApiResult {
     reject_if_moving(&state)?;
-    let kind = match req.text {
-        Some(text) if !text.trim().is_empty() => local::chat::ForkKind::Edit(text),
+    let (kind, is_edited_resubmission) = match req.text {
+        Some(text) if !text.trim().is_empty() => (local::chat::ForkKind::Edit(text), true),
         Some(_) => return Err(bad_request("text is required")),
-        None => local::chat::ForkKind::Retry,
+        None => (local::chat::ForkKind::Retry, false),
     };
     // A fork re-samples under the session's current settings, so it takes no
     // overrides — the turn runs in the background and streams over /api/events.
@@ -4732,6 +4733,9 @@ async fn fork_chat_turn(
         .fork_turn(&id, &req.message_id, kind)
         .await
         .map_err(bad_request)?;
+    if is_edited_resubmission {
+        crate::telemetry::capture_chat_message_sent();
+    }
     Ok(Json(json!({ "ok": true })))
 }
 

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -699,8 +699,9 @@ fn pending() -> &'static std::sync::Mutex<Vec<tokio::task::JoinHandle<()>>> {
 /// await.
 fn capture(event: impl Into<String>, extra: serde_json::Value) {
     if let Some(handle) = spawn_event(event, extra) {
-        if let Ok(mut v) = pending().lock() {
-            v.push(handle);
+        if let Ok(mut handles) = pending().lock() {
+            handles.retain(|pending| !pending.is_finished());
+            handles.push(handle);
         }
     }
 }
@@ -783,6 +784,10 @@ pub(crate) fn capture_project_created() {
 
 pub(crate) fn capture_chat_session_started(harness: &str) {
     capture("chat_session_started", json!({ "harness": harness }));
+}
+
+pub(crate) fn capture_chat_message_sent() {
+    capture("chat_message_sent", json!({}));
 }
 
 /// Flush every pending event send (the session's `cli_command` plus any key
@@ -1319,6 +1324,7 @@ mod tests {
             ),
             ("project_created", "cli_project_created"),
             ("chat_session_started", "cli_chat_session_started"),
+            ("chat_message_sent", "cli_chat_message_sent"),
             ("experiment_started", "cli_experiment_started"),
             ("telemetry_consent", "cli_telemetry_consent"),
         ] {
@@ -1467,6 +1473,10 @@ mod tests {
         assert_eq!(chat["events"][0]["name"], "cli_chat_session_started");
         assert_eq!(chat["events"][0]["properties"]["harness"], "codex");
         assert_eq!(property_keys(&chat), vec!["harness"]);
+
+        let message = build_payload("chat_message_sent", "did", json!({}));
+        assert_eq!(message["events"][0]["name"], "cli_chat_message_sent");
+        assert!(property_keys(&message).is_empty());
 
         let _ = std::fs::remove_dir_all(&dir);
     }


### PR DESCRIPTION
## Summary
- emit a property-free `cli_chat_message_sent` event after accepted message submissions and edited resubmissions
- keep plain retries and rejected submissions out of the count
- reap completed telemetry handles so long-running `orx up` sessions stay bounded

Dashboard/API counterpart: https://github.com/alphaXiv/openresearch.sh/pull/597
[OR-191](https://linear.app/alphaxiv/issue/OR-191/add-additional-graphs-to-admin-dashboard)

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --locked`
- [x] `cargo test --locked` (521 passed, 1 live-cluster test ignored)
- [ ] Send, queue, and edit-resubmit messages in an official build against the counterpart API
- [ ] Confirm message content is absent from the received telemetry payload