### PR TITLE
Bound Claude worker lifetimes

### DIFF
--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -61,6 +61,7 @@ pub async fn run(args: UpArgs) -> Result<()> {
     let agent = Arc::new(AgentHost::new(args.model.clone()));
     let codex = Arc::new(local::codex::CodexHost::new());
     let claude = Arc::new(local::claude::ClaudeHost::new());
+    claude.start_reaper();
     let state = AppState {
         agent: agent.clone(),
         chat: Arc::new(ChatHost::new(agent.clone(), codex.clone(), claude.clone())),

--- a/src/local/claude.rs
+++ b/src/local/claude.rs
@@ -30,17 +30,17 @@
 //! Non-goals (separate tasks): MCP config isolation (`--strict-mcp-config`);
 //! codex/opencode paths; the UI rendering fix.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::process::Stdio;
-use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use serde_json::{json, Value};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, Command};
-use tokio::sync::{mpsc, oneshot, Mutex};
+use tokio::sync::{mpsc, oneshot, Mutex, Notify};
 
 use crate::error::{anyhow, Result};
 use crate::local::harness::claude::{
@@ -52,6 +52,70 @@ use crate::local::harness::{HarnessAuthState, PermissionMode};
 /// Ceiling on a control request's response wait. Control requests (`set_model`)
 /// are quick; a wedged child must never hold the respawn path for long.
 const CONTROL_TIMEOUT: Duration = Duration::from_secs(10);
+const TERMINATION_TIMEOUT: Duration = Duration::from_secs(5);
+
+const IDLE_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+const STALE_AFTER: Duration = Duration::from_secs(90 * 60);
+const REAPER_INTERVAL: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LifecycleStopReason {
+    IdleExpired,
+    Stale,
+}
+
+impl LifecycleStopReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::IdleExpired => "idle-expired",
+            Self::Stale => "stale",
+        }
+    }
+}
+
+struct TurnSlot {
+    sender: Option<mpsc::UnboundedSender<TurnEvent>>,
+    idle_since: Instant,
+}
+
+impl TurnSlot {
+    fn new(now: Instant) -> Self {
+        Self {
+            sender: None,
+            idle_since: now,
+        }
+    }
+
+    fn stop_reason(&self, started_at: Instant, now: Instant) -> Option<LifecycleStopReason> {
+        if self.sender.is_some() {
+            return None;
+        }
+        if now.duration_since(started_at) >= STALE_AFTER {
+            return Some(LifecycleStopReason::Stale);
+        }
+        if now.duration_since(self.idle_since) >= IDLE_TIMEOUT {
+            return Some(LifecycleStopReason::IdleExpired);
+        }
+        None
+    }
+
+    fn register(&mut self, sender: mpsc::UnboundedSender<TurnEvent>) {
+        self.sender = Some(sender);
+    }
+
+    fn release(&mut self, sender: &mpsc::UnboundedSender<TurnEvent>, now: Instant) -> bool {
+        if !self
+            .sender
+            .as_ref()
+            .is_some_and(|current| current.same_channel(sender))
+        {
+            return false;
+        }
+        self.sender = None;
+        self.idle_since = now;
+        true
+    }
+}
 
 /// What the resident child was spawned with. Any field that can only be applied
 /// at launch (permission mode, effort, the mcp-gate bridge) forces a respawn
@@ -148,7 +212,10 @@ pub fn classify_line(line: &str) -> ClaudeLine {
 
 /// A live connection to one session's resident `claude` child.
 pub struct ClaudeClient {
+    session_id: String,
     child: Mutex<Child>,
+    #[cfg(unix)]
+    process_group_id: u32,
     /// Held open for the life of the child: stdin EOF ends the session, so we
     /// never drop it between turns. One JSON line per user message / control
     /// request.
@@ -160,11 +227,13 @@ pub struct ClaudeClient {
     pending: std::sync::Mutex<HashMap<String, oneshot::Sender<Result<Value, String>>>>,
     /// The session's in-flight turn, if any (one per session-child). The
     /// registration guard drops synchronously on task abort, hence sync mutex.
-    turn: std::sync::Mutex<Option<mpsc::UnboundedSender<TurnEvent>>>,
+    turn: std::sync::Mutex<TurnSlot>,
     /// What this child was spawned with — the reuse/respawn decision reads it,
     /// and a successful `set_model` updates its `model` in place.
     config: std::sync::Mutex<SpawnConfig>,
     auth_generation: u64,
+    started_at: Instant,
+    terminated: AtomicBool,
 }
 
 impl ClaudeClient {
@@ -249,12 +318,31 @@ impl ClaudeClient {
 
     /// Register the session's turn event sink. The returned guard deregisters on
     /// drop (including task abort mid-turn).
-    pub fn register_turn(self: &Arc<Self>, tx: mpsc::UnboundedSender<TurnEvent>) -> TurnRoute {
-        *self.turn.lock().unwrap() = Some(tx.clone());
+    fn register_turn(
+        self: &Arc<Self>,
+        tx: mpsc::UnboundedSender<TurnEvent>,
+        reaper_notify: Arc<Notify>,
+    ) -> TurnRoute {
+        self.turn.lock().unwrap().register(tx.clone());
         TurnRoute {
             client: self.clone(),
             tx,
+            reaper_notify,
         }
+    }
+
+    fn stop_reason(&self, now: Instant) -> Option<LifecycleStopReason> {
+        self.turn.lock().unwrap().stop_reason(self.started_at, now)
+    }
+
+    fn age_and_idle(&self, now: Instant) -> (Duration, Option<Duration>) {
+        let turn = self.turn.lock().unwrap();
+        (
+            now.duration_since(self.started_at),
+            turn.sender
+                .is_none()
+                .then(|| now.duration_since(turn.idle_since)),
+        )
     }
 }
 
@@ -266,13 +354,21 @@ impl ClaudeClient {
 pub struct TurnRoute {
     client: Arc<ClaudeClient>,
     tx: mpsc::UnboundedSender<TurnEvent>,
+    reaper_notify: Arc<Notify>,
+}
+
+impl TurnRoute {
+    pub fn client(&self) -> &Arc<ClaudeClient> {
+        &self.client
+    }
 }
 
 impl Drop for TurnRoute {
     fn drop(&mut self) {
         let mut turn = self.client.turn.lock().unwrap();
-        if turn.as_ref().is_some_and(|t| t.same_channel(&self.tx)) {
-            *turn = None;
+        if turn.release(&self.tx, Instant::now()) {
+            drop(turn);
+            self.reaper_notify.notify_one();
         }
     }
 }
@@ -292,7 +388,7 @@ async fn read_loop(client: Arc<ClaudeClient>, stdout: tokio::process::ChildStdou
                 // Route to the live turn; dropped if none is listening (a
                 // between-turns line, or an aborted turn's tail).
                 let turn = client.turn.lock().unwrap();
-                if let Some(tx) = turn.as_ref() {
+                if let Some(tx) = turn.sender.as_ref() {
                     let _ = tx.send(TurnEvent::Line(value));
                 }
             }
@@ -302,13 +398,54 @@ async fn read_loop(client: Arc<ClaudeClient>, stdout: tokio::process::ChildStdou
     // EOF or read error: the connection is unusable. Kill the child if it is
     // somehow still alive (a half-dead child left in the registry would fail
     // every turn until restart), then fail everything still waiting.
-    let _ = client.child.lock().await.kill().await;
+    terminate_client(&client).await;
     for (_, tx) in client.pending.lock().unwrap().drain() {
         let _ = tx.send(Err("claude exited".into()));
     }
-    if let Some(tx) = client.turn.lock().unwrap().as_ref() {
+    if let Some(tx) = client.turn.lock().unwrap().sender.as_ref() {
         let _ = tx.send(TurnEvent::Closed);
     }
+}
+
+async fn terminate_client(client: &ClaudeClient) {
+    if client.terminated.swap(true, Ordering::AcqRel) {
+        return;
+    }
+    #[cfg(unix)]
+    if let Ok(process_group_id) = i32::try_from(client.process_group_id) {
+        // SAFETY: spawn assigns the child its own process group before this id is captured.
+        unsafe {
+            libc::kill(-process_group_id, libc::SIGKILL);
+        }
+    }
+    let mut child = client.child.lock().await;
+    let _ = child.start_kill();
+    if tokio::time::timeout(TERMINATION_TIMEOUT, child.wait())
+        .await
+        .is_err()
+    {
+        eprintln!(
+            "orx up: timed out reaping Claude worker session={}",
+            client.session_id
+        );
+    }
+}
+
+async fn stop_client(client: Arc<ClaudeClient>, reason: &str) {
+    stop_client_at(client, reason, Instant::now()).await;
+}
+
+async fn stop_client_at(client: Arc<ClaudeClient>, reason: &str, now: Instant) {
+    let (age, idle) = client.age_and_idle(now);
+    eprintln!(
+        "orx up: stopping Claude worker session={} reason={} age_s={} idle_s={}",
+        client.session_id,
+        reason,
+        age.as_secs(),
+        idle.map(|duration| duration.as_secs().to_string())
+            .unwrap_or_else(|| "active".to_string())
+    );
+    terminate_client(&client).await;
 }
 
 /// Spawn a resident `claude` child for one session. Mirrors the flag block the
@@ -346,8 +483,8 @@ async fn spawn_client(spec: &SpawnSpec, auth_generation: u64) -> Result<Arc<Clau
     .stdout(Stdio::piped())
     .stderr(Stdio::from(crate::local::chat::harness_log("claude")?))
     // Backstop only: the child is deliberately kept resident across turns, so
-    // its lifetime is managed by kill_session/shutdown, not by dropping a
-    // per-turn handle. kill_on_drop still reaps it if the whole host is dropped.
+    // its lifetime is managed by the host reaper and explicit stop paths, not
+    // by dropping a per-turn handle.
     .kill_on_drop(true);
     if let Some(model) = &spec.config.model {
         cmd.args(["--model", model]);
@@ -420,6 +557,10 @@ async fn spawn_client(spec: &SpawnSpec, auth_generation: u64) -> Result<Arc<Clau
     let mut child = cmd
         .spawn()
         .map_err(|e| anyhow!("Could not spawn {}: {}", bin.display(), e))?;
+    #[cfg(unix)]
+    let process_group_id = child
+        .id()
+        .ok_or_else(|| anyhow!("claude: spawned child has no process id"))?;
     let stdout = child
         .stdout
         .take()
@@ -429,14 +570,20 @@ async fn spawn_client(spec: &SpawnSpec, auth_generation: u64) -> Result<Arc<Clau
         .take()
         .ok_or_else(|| anyhow!("claude: no stdin"))?;
 
+    let started_at = Instant::now();
     let client = Arc::new(ClaudeClient {
+        session_id: spec.session_id.clone(),
         child: Mutex::new(child),
+        #[cfg(unix)]
+        process_group_id,
         stdin: Mutex::new(stdin),
         next_id: AtomicI64::new(1),
         pending: std::sync::Mutex::new(HashMap::new()),
-        turn: std::sync::Mutex::new(None),
+        turn: std::sync::Mutex::new(TurnSlot::new(started_at)),
         config: std::sync::Mutex::new(config),
         auth_generation,
+        started_at,
+        terminated: AtomicBool::new(false),
     });
     tokio::spawn(read_loop(client.clone(), stdout));
     Ok(client)
@@ -488,6 +635,10 @@ pub struct ClaudeHost {
     auth_recovery_lock: Mutex<()>,
     announced_generation: AtomicU64,
     next_spawn_epoch: AtomicU64,
+    reaper_notify: Arc<Notify>,
+    /// Session ids are UUIDs and never reused; tombstones block turns queued
+    /// before deletion from registering a replacement worker afterward.
+    forgotten_sessions: Mutex<HashSet<String>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -519,6 +670,58 @@ impl ClaudeHost {
             auth_recovery_lock: Mutex::new(()),
             announced_generation: AtomicU64::new(0),
             next_spawn_epoch: AtomicU64::new(1),
+            reaper_notify: Arc::new(Notify::new()),
+            forgotten_sessions: Mutex::new(HashSet::new()),
+        }
+    }
+
+    pub fn start_reaper(self: &Arc<Self>) {
+        let host = Arc::downgrade(self);
+        let notify = self.reaper_notify.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(REAPER_INTERVAL);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {}
+                    _ = notify.notified() => {}
+                }
+                let Some(host) = host.upgrade() else {
+                    break;
+                };
+                host.reap_expired().await;
+            }
+        });
+    }
+
+    async fn reap_expired(&self) {
+        self.reap_expired_at(Instant::now()).await;
+    }
+
+    async fn reap_expired_at(&self, now: Instant) {
+        let sessions = self.inner.lock().await.keys().cloned().collect::<Vec<_>>();
+        for session_id in sessions {
+            let session_lock = {
+                let mut locks = self.spawn_locks.lock().await;
+                locks
+                    .entry(session_id.clone())
+                    .or_insert_with(|| Arc::new(Mutex::new(())))
+                    .clone()
+            };
+            let _spawning = session_lock.lock().await;
+            let expired = {
+                let mut clients = self.inner.lock().await;
+                let Some(client) = clients.get(&session_id) else {
+                    continue;
+                };
+                let Some(reason) = client.stop_reason(now) else {
+                    continue;
+                };
+                clients.remove(&session_id).map(|client| (client, reason))
+            };
+            if let Some((client, reason)) = expired {
+                stop_client_at(client, reason.as_str(), now).await;
+            }
         }
     }
 
@@ -657,17 +860,20 @@ impl ClaudeHost {
         self.auth_snapshot()
     }
 
-    /// Spawn (or reuse) this session's resident child, reconciled to `spec`'s
-    /// config. Idempotent while the child is alive and its config matches; a
-    /// model-only change retunes live, any launch-flag change (or a dead child)
-    /// respawns with `--resume`.
+    /// Acquire this session's resident child for one turn, reconciled to
+    /// `spec`'s config. The turn route is registered while the per-session
+    /// spawn lock is still held, so the lifecycle reaper cannot race the send.
     ///
     /// The spawn runs in a *detached* task: the calling turn task is abortable
     /// (interrupt / delete), and an aborted future would drop its `Arc` while
     /// the reader task keeps the child alive — an unregistered client would be
     /// unreachable by every kill path and leak the process for the rest of `orx
     /// up`'s life. Detached, the bring-up always runs to completion.
-    pub async fn ensure(self: &Arc<Self>, spec: SpawnSpec) -> Result<Arc<ClaudeClient>> {
+    pub async fn acquire_turn(
+        self: &Arc<Self>,
+        spec: SpawnSpec,
+        tx: mpsc::UnboundedSender<TurnEvent>,
+    ) -> Result<TurnRoute> {
         let session = spec.session_id.clone();
         let session_lock = {
             let mut locks = self.spawn_locks.lock().await;
@@ -677,6 +883,9 @@ impl ClaudeHost {
                 .clone()
         };
         let _spawning = session_lock.lock().await;
+        if self.forgotten_sessions.lock().await.contains(&session) {
+            return Err(anyhow!("Claude session was deleted"));
+        }
         let mut auth = self.auth_snapshot();
         if auth.state == HarnessAuthState::Unknown && !auth.runtime_rejected {
             auth = self.resolve_unknown().await;
@@ -697,62 +906,52 @@ impl ClaudeHost {
             }
             HarnessAuthState::Ready => {}
         }
-        // Reconcile against a live child under the lock.
-        {
-            let mut guard = self.inner.lock().await;
-            if let Some(client) = guard.get(&session) {
-                if matches!(client.child.lock().await.try_wait(), Ok(None)) {
-                    let live = client.clone();
-                    let current = live.config();
-                    if live.auth_generation() != auth.generation {
-                        let _ = live.child.lock().await.kill().await;
-                        guard.remove(&session);
-                        // Continue below to spawn with the current generation.
-                    } else {
-                        match child_action(&current, &spec.config) {
-                            ChildAction::Reuse => {
-                                let latest = self.auth_snapshot();
-                                if latest.state == HarnessAuthState::Ready
-                                    && live.auth_generation() == latest.generation
-                                {
-                                    return Ok(live);
-                                }
-                                let _ = live.child.lock().await.kill().await;
-                                guard.remove(&session);
-                            }
-                            ChildAction::SetModel(model) => {
-                                drop(guard);
-                                match live.set_model(&model).await {
-                                    Ok(()) => {
-                                        let latest = self.auth_snapshot();
-                                        if latest.state == HarnessAuthState::Ready
-                                            && live.auth_generation() == latest.generation
-                                        {
-                                            return Ok(live);
-                                        }
-                                        let _ = live.child.lock().await.kill().await;
-                                        self.inner.lock().await.remove(&session);
-                                    }
-                                    // set_model failed (transport/child error): fall
-                                    // through to a respawn with --resume.
-                                    Err(e) => {
-                                        eprintln!(
-                                            "orx up: claude set_model failed, respawning: {e}"
-                                        );
-                                        let _ = live.child.lock().await.kill().await;
-                                        self.inner.lock().await.remove(&session);
-                                    }
-                                }
-                            }
-                            ChildAction::Respawn => {
-                                let _ = live.child.lock().await.kill().await;
-                                guard.remove(&session);
-                            }
+        let live = self.inner.lock().await.get(&session).cloned();
+        if let Some(live) = live {
+            if live.terminated.load(Ordering::Acquire)
+                || !matches!(live.child.lock().await.try_wait(), Ok(None))
+            {
+                self.inner.lock().await.remove(&session);
+                stop_client(live, "exited").await;
+            } else if let Some(reason) = live.stop_reason(Instant::now()) {
+                self.inner.lock().await.remove(&session);
+                stop_client(live, reason.as_str()).await;
+            } else if live.auth_generation() != auth.generation {
+                self.inner.lock().await.remove(&session);
+                stop_client(live, "authentication-changed").await;
+            } else {
+                match child_action(&live.config(), &spec.config) {
+                    ChildAction::Reuse => {
+                        let latest = self.auth_snapshot();
+                        if latest.state == HarnessAuthState::Ready
+                            && live.auth_generation() == latest.generation
+                        {
+                            return Ok(live.register_turn(tx, self.reaper_notify.clone()));
                         }
+                        self.inner.lock().await.remove(&session);
+                        stop_client(live, "authentication-changed").await;
                     }
-                } else {
-                    // Dead child: replace it.
-                    guard.remove(&session);
+                    ChildAction::SetModel(model) => match live.set_model(&model).await {
+                        Ok(()) => {
+                            let latest = self.auth_snapshot();
+                            if latest.state == HarnessAuthState::Ready
+                                && live.auth_generation() == latest.generation
+                            {
+                                return Ok(live.register_turn(tx, self.reaper_notify.clone()));
+                            }
+                            self.inner.lock().await.remove(&session);
+                            stop_client(live, "authentication-changed").await;
+                        }
+                        Err(e) => {
+                            eprintln!("orx up: claude set_model failed, respawning: {e}");
+                            self.inner.lock().await.remove(&session);
+                            stop_client(live, "set-model-failed").await;
+                        }
+                    },
+                    ChildAction::Respawn => {
+                        self.inner.lock().await.remove(&session);
+                        stop_client(live, "configuration-changed").await;
+                    }
                 }
             }
         }
@@ -768,7 +967,7 @@ impl ClaudeHost {
             .await
             .insert(session.clone(), spawn_epoch);
         let host = self.clone();
-        tokio::spawn(async move {
+        let client = tokio::spawn(async move {
             let client = spawn_client(&spec, auth.generation).await?;
             {
                 let mut guard = host.inner.lock().await;
@@ -785,14 +984,14 @@ impl ClaudeHost {
                     || latest.generation != client.auth_generation()
                 {
                     drop(guard);
-                    let _ = client.child.lock().await.kill().await;
+                    stop_client(client, "startup-superseded").await;
                     return Err(anyhow!("Claude Code authentication changed during startup"));
                 }
                 if let Some(existing) = guard.get(&session) {
                     if matches!(existing.child.lock().await.try_wait(), Ok(None)) {
                         let stale = existing.clone();
                         guard.remove(&session);
-                        let _ = stale.child.lock().await.kill().await;
+                        stop_client(stale, "duplicate-worker").await;
                     }
                 }
                 guard.insert(session.clone(), client.clone());
@@ -800,20 +999,25 @@ impl ClaudeHost {
             Ok(client)
         })
         .await
-        .map_err(|e| anyhow!("claude bring-up task failed: {e}"))?
+        .map_err(|e| anyhow!("claude bring-up task failed: {e}"))??;
+        Ok(client.register_turn(tx, self.reaper_notify.clone()))
     }
 
     /// Kill and reap one session's child. The load-bearing interrupt/delete
     /// path: a resident child survives task-abort/`kill_on_drop`, so it must be
     /// killed explicitly; the next turn respawns with `--resume`.
     pub async fn kill_session(&self, session_id: &str) {
+        self.kill_session_for(session_id, "session-stop").await;
+    }
+
+    async fn kill_session_for(&self, session_id: &str, reason: &str) {
         let epoch = self.next_spawn_epoch.fetch_add(1, Ordering::AcqRel);
         self.spawn_epochs
             .lock()
             .await
             .insert(session_id.to_string(), epoch);
         if let Some(client) = self.inner.lock().await.remove(session_id) {
-            let _ = client.child.lock().await.kill().await;
+            stop_client(client, reason).await;
         }
     }
 
@@ -827,15 +1031,27 @@ impl ClaudeHost {
                 .clone()
         };
         let _spawning = session_lock.lock().await;
-        self.kill_session(session_id).await;
+        self.forgotten_sessions
+            .lock()
+            .await
+            .insert(session_id.to_string());
+        self.kill_session_for(session_id, "session-deleted").await;
+        drop(_spawning);
         self.spawn_epochs.lock().await.remove(session_id);
         self.spawn_locks.lock().await.remove(session_id);
     }
 
     /// Kill and reap every child (also happens via kill_on_drop on exit).
     pub async fn shutdown(&self) {
-        for (_, client) in self.inner.lock().await.drain() {
-            let _ = client.child.lock().await.kill().await;
+        let clients = self
+            .inner
+            .lock()
+            .await
+            .drain()
+            .map(|(_, client)| client)
+            .collect::<Vec<_>>();
+        for client in clients {
+            stop_client(client, "shutdown").await;
         }
     }
 }
@@ -843,6 +1059,53 @@ impl ClaudeHost {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    async fn test_client(
+        session_id: &str,
+        started_at: Instant,
+        idle_since: Instant,
+        shell: &str,
+    ) -> Arc<ClaudeClient> {
+        let mut command = Command::new("sh");
+        command
+            .args(["-c", shell])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .process_group(0);
+        let mut child = command.spawn().unwrap();
+        let process_group_id = child.id().unwrap();
+        let stdin = child.stdin.take().unwrap();
+        Arc::new(ClaudeClient {
+            session_id: session_id.to_string(),
+            child: Mutex::new(child),
+            process_group_id,
+            stdin: Mutex::new(stdin),
+            next_id: AtomicI64::new(1),
+            pending: std::sync::Mutex::new(HashMap::new()),
+            turn: std::sync::Mutex::new(TurnSlot {
+                sender: None,
+                idle_since,
+            }),
+            config: std::sync::Mutex::new(cfg(None, None, None, false)),
+            auth_generation: 0,
+            started_at,
+            terminated: AtomicBool::new(false),
+        })
+    }
+
+    #[cfg(unix)]
+    async fn install_test_client(host: &ClaudeHost, client: Arc<ClaudeClient>) {
+        host.spawn_locks
+            .lock()
+            .await
+            .insert(client.session_id.clone(), Arc::new(Mutex::new(())));
+        host.inner
+            .lock()
+            .await
+            .insert(client.session_id.clone(), client);
+    }
 
     fn cfg(
         mode: Option<PermissionMode>,
@@ -970,6 +1233,206 @@ mod tests {
                 &cfg(Some(PermissionMode::Plan), None, Some("sonnet"), false),
             ),
             ChildAction::Respawn
+        );
+    }
+
+    #[test]
+    fn lifecycle_reaps_idle_and_stale_workers_at_the_boundaries() {
+        let now = Instant::now();
+        let recent_start = now - Duration::from_secs(20 * 60);
+        let mut slot = TurnSlot::new(now - IDLE_TIMEOUT + Duration::from_secs(1));
+
+        assert_eq!(slot.stop_reason(recent_start, now), None);
+
+        slot.idle_since = now - IDLE_TIMEOUT;
+        assert_eq!(
+            slot.stop_reason(recent_start, now),
+            Some(LifecycleStopReason::IdleExpired)
+        );
+
+        slot.idle_since = now;
+        assert_eq!(
+            slot.stop_reason(now - STALE_AFTER, now),
+            Some(LifecycleStopReason::Stale)
+        );
+    }
+
+    #[test]
+    fn lifecycle_never_reaps_an_active_turn_and_release_starts_idle_clock() {
+        let now = Instant::now();
+        let started_at = now - STALE_AFTER - Duration::from_secs(1);
+        let mut slot = TurnSlot::new(started_at);
+        let (tx, _rx) = mpsc::unbounded_channel();
+        slot.register(tx.clone());
+
+        assert_eq!(slot.stop_reason(started_at, now), None);
+
+        let released_at = now + Duration::from_secs(5);
+        assert!(slot.release(&tx, released_at));
+        assert_eq!(slot.idle_since, released_at);
+        assert_eq!(
+            slot.stop_reason(started_at, released_at),
+            Some(LifecycleStopReason::Stale)
+        );
+    }
+
+    #[test]
+    fn stale_route_drop_cannot_clear_a_successor_turn() {
+        let now = Instant::now();
+        let mut slot = TurnSlot::new(now);
+        let (old_tx, _old_rx) = mpsc::unbounded_channel();
+        let (new_tx, _new_rx) = mpsc::unbounded_channel();
+        slot.register(old_tx.clone());
+        slot.register(new_tx);
+
+        assert!(!slot.release(&old_tx, now + Duration::from_secs(1)));
+        assert!(slot.sender.is_some());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn reaper_keeps_active_stale_worker_then_reaps_it_after_release() {
+        let now = Instant::now();
+        let host = ClaudeHost::new();
+        let client = test_client(
+            "active-stale",
+            now - STALE_AFTER - Duration::from_secs(1),
+            now,
+            "sleep 600",
+        )
+        .await;
+        install_test_client(&host, client.clone()).await;
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let route = client.register_turn(tx, host.reaper_notify.clone());
+
+        host.reap_expired_at(now).await;
+        assert!(host.inner.lock().await.contains_key("active-stale"));
+
+        drop(route);
+        host.reap_expired_at(Instant::now() + Duration::from_secs(60))
+            .await;
+        assert!(!host.inner.lock().await.contains_key("active-stale"));
+        assert!(client.terminated.load(Ordering::Acquire));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn reaper_honors_idle_timeout_and_stale_age() {
+        let now = Instant::now();
+        let host = ClaudeHost::new();
+        let idle = test_client(
+            "idle",
+            now - Duration::from_secs(20 * 60),
+            now - IDLE_TIMEOUT,
+            "sleep 600",
+        )
+        .await;
+        let stale = test_client("stale", now - STALE_AFTER, now, "sleep 600").await;
+        install_test_client(&host, idle.clone()).await;
+        install_test_client(&host, stale.clone()).await;
+
+        host.reap_expired_at(now).await;
+
+        let clients = host.inner.lock().await;
+        assert!(!clients.contains_key("idle"));
+        assert!(!clients.contains_key("stale"));
+        drop(clients);
+        assert!(idle.terminated.load(Ordering::Acquire));
+        assert!(stale.terminated.load(Ordering::Acquire));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn turn_registration_wins_a_race_with_the_reaper() {
+        let now = Instant::now();
+        let host = Arc::new(ClaudeHost::new());
+        let client = test_client(
+            "racing",
+            now - Duration::from_secs(20 * 60),
+            now - IDLE_TIMEOUT,
+            "sleep 600",
+        )
+        .await;
+        install_test_client(&host, client.clone()).await;
+        let session_lock = host.spawn_locks.lock().await.get("racing").unwrap().clone();
+        let acquiring = session_lock.lock().await;
+        let (started_tx, started_rx) = oneshot::channel();
+        let reaping = {
+            let host = host.clone();
+            tokio::spawn(async move {
+                let _ = started_tx.send(());
+                host.reap_expired_at(now).await;
+            })
+        };
+        started_rx.await.unwrap();
+
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let route = client.register_turn(tx, host.reaper_notify.clone());
+        drop(acquiring);
+        reaping.await.unwrap();
+
+        assert!(host.inner.lock().await.contains_key("racing"));
+        drop(route);
+        host.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn deleted_session_tombstone_rejects_future_turns() {
+        let host = Arc::new(ClaudeHost::new());
+        let chat = Arc::new(crate::local::chat::ChatHost::new(
+            Arc::new(crate::local::opencode::AgentHost::new(None)),
+            Arc::new(crate::local::codex::CodexHost::new()),
+            host.clone(),
+        ));
+        host.forget_session("deleted").await;
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let result = host
+            .acquire_turn(
+                SpawnSpec {
+                    chat,
+                    session_id: "deleted".to_string(),
+                    repo: PathBuf::new(),
+                    playbook: PathBuf::new(),
+                    resume: None,
+                    config: cfg(None, None, None, false),
+                },
+                tx,
+            )
+            .await;
+
+        assert_eq!(
+            result.err().unwrap().to_string(),
+            "Claude session was deleted"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn termination_kills_the_worker_process_group() {
+        let now = Instant::now();
+        let client = test_client("tree", now, now, "sleep 600 & echo $!; wait").await;
+        let descendant_pid = {
+            let mut child = client.child.lock().await;
+            let stdout = child.stdout.take().unwrap();
+            drop(child);
+            let mut line = String::new();
+            BufReader::new(stdout).read_line(&mut line).await.unwrap();
+            line.trim().parse::<u32>().unwrap()
+        };
+
+        terminate_client(&client).await;
+
+        let mut live = true;
+        for _ in 0..50 {
+            live = unsafe { libc::kill(descendant_pid as i32, 0) == 0 };
+            if !live {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(
+            !live,
+            "descendant process {descendant_pid} survived group kill"
         );
     }
 

--- a/src/local/harness/claude.rs
+++ b/src/local/harness/claude.rs
@@ -1669,12 +1669,11 @@ const FIRST_EVENT_TIMEOUT: Duration = Duration::from_secs(120);
 const BACKGROUND_RESUME_GRACE: Duration = Duration::from_secs(3);
 
 async fn run_attempt(ctx: &mut TurnCtx, spec: SpawnSpec) -> Result<(TurnState, u64)> {
-    let client = ctx.host.claude.ensure(spec).await?;
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let route = ctx.host.claude.acquire_turn(spec, tx).await?;
+    let client = route.client();
     let auth_generation = client.auth_generation();
     let bridge_active = client.config().bridge_active;
-
-    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-    let _route = client.register_turn(tx);
     if let Err(e) = client.send_user_message(&ctx.text).await {
         ctx.host.claude.kill_session(&ctx.session_id).await;
         return Err(anyhow!(


### PR DESCRIPTION
Linear: [OR-147 — Claude Reauth Issue](https://linear.app/alphaxiv/issue/OR-147/claude-reauth-issue)

## Summary
- reap Claude workers after 15 idle minutes
- retire workers older than 90 minutes only at a safe turn boundary
- serialize turn acquisition with reaping and terminate complete process groups
- preserve native Claude sessions so replacement workers resume conversation context

## Test plan
- [x] cargo fmt --all --check
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo build --locked
- [x] cargo test --locked
- [x] Four-reviewer Claude static review completed with no blockers
- [ ] Confirm a real idle Claude worker exits after 15 minutes
- [ ] Confirm a real active Claude turn continues past 90 minutes and rotates afterward