### PR TITLE
Find the LaTeX toolchain on the user's PATH, and recommend Tectonic

### DIFF
--- a/src/invocation.rs
+++ b/src/invocation.rs
@@ -43,12 +43,7 @@ pub fn no_run_command(project_id: &str) -> String {
 }
 
 fn resolves_on_path(bin: &str) -> bool {
-    let Some(paths) = crate::local::shell_env::search_path() else {
-        return false;
-    };
-    std::env::split_paths(&paths)
-        .filter(|dir| !dir.as_os_str().is_empty())
-        .any(|dir| dir.join(bin).is_file())
+    crate::local::shell_env::find_on_path(bin).is_some()
 }
 
 fn quote_for_shell(path: &str) -> String {

--- a/src/local/harness/claude.rs
+++ b/src/local/harness/claude.rs
@@ -30,8 +30,7 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
 use super::detect::{
-    bin_version, find_on_path, nonempty_str, parse_version, read_json, HarnessAuthState,
-    HarnessInfo, ModelInfo,
+    bin_version, nonempty_str, parse_version, read_json, HarnessAuthState, HarnessInfo, ModelInfo,
 };
 use super::options::{
     HarnessOptions, OptionChoice, PermissionMode, PlanActivation, REASONING_DEFAULT_ID,
@@ -46,6 +45,7 @@ use crate::local::chat::{
 };
 use crate::local::claude::{SpawnConfig, SpawnSpec, TurnEvent};
 use crate::local::opencode::ensure_playbook;
+use crate::local::shell_env::find_on_path;
 
 /// FALLBACK model list, used only when the `list_models` control request fails
 /// (a CLI too old to answer it, or a spawn/timeout failure). The primary source

--- a/src/local/harness/codex.rs
+++ b/src/local/harness/codex.rs
@@ -38,8 +38,8 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
 use super::detect::{
-    bin_version, find_on_path, jwt_payload, nonempty_str, parse_version, read_json,
-    resolve_symlinks, title_case, HarnessInfo, ModelInfo,
+    bin_version, jwt_payload, nonempty_str, parse_version, read_json, resolve_symlinks, title_case,
+    HarnessInfo, ModelInfo,
 };
 use super::options::{
     resolve_reasoning, HarnessOptions, OptionChoice, PermissionMode, PlanActivation,
@@ -57,6 +57,7 @@ use crate::local::chat::{
 };
 use crate::local::codex::{CodexClient, JsonRpcError, ServerReqKind, TurnEvent};
 use crate::local::opencode::ensure_playbook;
+use crate::local::shell_env::find_on_path;
 use crate::store::{Store, StoredChatMessage};
 
 // FALLBACK model table, used only when the app-server catalog is unreachable

--- a/src/local/harness/detect.rs
+++ b/src/local/harness/detect.rs
@@ -166,16 +166,6 @@ impl HarnessInfo {
     }
 }
 
-pub(super) fn find_on_path(bin: &str) -> Option<PathBuf> {
-    let paths = crate::local::shell_env::search_path()?;
-    std::env::split_paths(&paths)
-        // An empty component (`PATH=":/usr/bin"`) means cwd — never a place to
-        // pick up a binary we are about to execute.
-        .filter(|dir| !dir.as_os_str().is_empty())
-        .map(|dir| dir.join(bin))
-        .find(|c| c.is_file())
-}
-
 /// Dereference symlinks to the real installed binary. Installers commonly drop
 /// a lone symlink into `~/.local/bin`, but some CLIs locate sibling helper
 /// executables relative to the path they were *invoked as*, without resolving

--- a/src/local/latex.rs
+++ b/src/local/latex.rs
@@ -204,8 +204,9 @@ pub fn find_engine() -> Option<&'static str> {
         .find(|binary| on_path(binary))
 }
 
-/// Guidance for the no-engine case. A full distribution comes first because it
-/// is what matches Overleaf — every engine, biber, and the whole of CTAN.
+/// Guidance for the no-engine case. Tectonic comes first because it is the one
+/// a user can finish, and its XeTeX-only trade is named here because this is
+/// the last screen that can say so — the hint is gone once an engine exists.
 pub fn install_hint() -> String {
     let distribution = if cfg!(target_os = "macos") {
         "MacTeX"
@@ -213,9 +214,10 @@ pub fn install_hint() -> String {
         "TeX Live"
     };
     format!(
-        "No LaTeX toolchain found on PATH. Install {distribution} for the same \
-         engines and packages Overleaf runs, or Tectonic for a smaller \
-         XeTeX-only setup that needs no distribution."
+        "No LaTeX toolchain found on PATH. Install Tectonic — one self-contained \
+         binary that fetches each document's packages, though it runs only XeTeX. \
+         For every engine and package, install {distribution} instead, which is \
+         what Overleaf runs."
     )
 }
 
@@ -223,7 +225,7 @@ pub fn install_hint() -> String {
 /// known to work — a wrong command pasted into a terminal is worse than none.
 pub fn install_command() -> Option<&'static str> {
     if cfg!(target_os = "macos") {
-        Some("brew install --cask mactex")
+        Some("brew install tectonic")
     } else {
         None
     }
@@ -851,16 +853,29 @@ mod tests {
     }
 
     #[test]
-    fn the_no_engine_guidance_points_at_a_full_distribution_first() {
+    fn the_no_engine_guidance_points_at_tectonic_first() {
         let hint = install_hint();
+        let distribution = if cfg!(target_os = "macos") {
+            "MacTeX"
+        } else {
+            "TeX Live"
+        };
+        let tectonic = hint.find("Tectonic").expect("the recommendation is named");
+        let fallback = hint.find(distribution).expect("the fallback is named");
         assert!(
-            hint.contains("Overleaf"),
-            "parity is the reason to install it"
+            tectonic < fallback,
+            "the install a user can finish comes first"
         );
-        // The prose must not duplicate the copyable command.
+        // The caveat has to sit in Tectonic's own clause: recommending it
+        // without one sends a user to an engine that silently retypesets their
+        // pdfLaTeX document, and this hint is the only place that says so.
+        let xetex = hint.find("XeTeX").expect("the limitation is named");
+        assert!(tectonic < xetex && xetex < fallback);
+        // The prose must not duplicate the copyable command, but the command
+        // must install what the prose leads with.
         assert!(!hint.contains("brew install"));
         #[cfg(target_os = "macos")]
-        assert_eq!(install_command(), Some("brew install --cask mactex"));
+        assert_eq!(install_command(), Some("brew install tectonic"));
         #[cfg(not(target_os = "macos"))]
         assert_eq!(install_command(), None);
     }

--- a/src/local/latex.rs
+++ b/src/local/latex.rs
@@ -19,6 +19,7 @@ use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 use crate::error::{anyhow, Result};
+use crate::local::shell_env::{find_on_path, search_path};
 
 /// The TeX engine a document is written for. Overleaf's default is pdfLaTeX and
 /// so is ours; a document says otherwise with a `% !TeX program` line.
@@ -133,15 +134,27 @@ pub struct Compilation {
     pub log: String,
 }
 
-/// True when a binary answers `--version` on this machine's PATH.
+/// True when a file of that name sits on the shell's PATH — not the process's,
+/// which in app mode is launchd's and has no TeX on it. That it runs is not
+/// checked; `find_engine` probes on every `.tex` tab and spawning five engines
+/// to ask their versions cost more than the case it caught.
 fn on_path(binary: &str) -> bool {
-    Command::new(binary)
-        .arg("--version")
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .is_ok_and(|status| status.success())
+    find_on_path(binary).is_some()
+}
+
+/// A TeX tool, with the shell's PATH in its environment: latexmk finds the
+/// engine, biber and bibtex on PATH, so resolving latexmk alone is not enough.
+fn tex_command(binary: &str) -> Command {
+    // biber is never probed — it is chosen from what a pass wrote — so a bare
+    // name here is what makes a machine without it fail as ENOENT at spawn.
+    let mut command = match find_on_path(binary) {
+        Some(path) => Command::new(path),
+        None => Command::new(binary),
+    };
+    if let Some(paths) = search_path() {
+        command.env("PATH", paths);
+    }
+    command
 }
 
 /// Pick how to compile a document written for `program`. Split from the PATH
@@ -298,7 +311,7 @@ fn run_bibliography(
     // cwd is the aux dir (bibtex refuses to write outside it), so `.` no longer
     // means the paper's directory — both search paths have to say so.
     let search = format!("{}:", source_dir.to_string_lossy());
-    let mut command = Command::new(tool);
+    let mut command = tex_command(tool);
     command
         .arg(stem)
         .current_dir(outdir)
@@ -353,7 +366,7 @@ struct Run {
 }
 
 fn run_pass(binary: &str, dir: &Path, args: &[String]) -> Result<Run> {
-    let mut command = Command::new(binary);
+    let mut command = tex_command(binary);
     command.args(args).current_dir(dir);
     run_command(command, binary)
 }
@@ -850,6 +863,19 @@ mod tests {
         assert_eq!(install_command(), Some("brew install --cask mactex"));
         #[cfg(not(target_os = "macos"))]
         assert_eq!(install_command(), None);
+    }
+
+    #[test]
+    fn a_tex_tool_is_handed_the_path_its_own_children_need() {
+        // `sh` stands in for a TeX tool; all that matters is that it is on PATH.
+        let command = tex_command("sh");
+        let (_, value) = command
+            .get_envs()
+            .find(|(key, _)| *key == "PATH")
+            .expect("the child is given an explicit PATH");
+        assert_eq!(value, search_path().as_deref());
+        // And the tool itself is resolved, not left to the child's own lookup.
+        assert!(Path::new(command.get_program()).is_absolute());
     }
 
     #[test]

--- a/src/local/opencode.rs
+++ b/src/local/opencode.rs
@@ -31,15 +31,8 @@ const HEALTH_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// `opencode` on PATH, else the installer's default drop location.
 pub fn find_opencode() -> Result<PathBuf> {
-    if let Some(paths) = crate::local::shell_env::search_path() {
-        // An empty component (`PATH=":/usr/bin"`) means cwd — never a place to
-        // pick up a binary we are about to execute. Mirrors `find_on_path`.
-        for dir in std::env::split_paths(&paths).filter(|dir| !dir.as_os_str().is_empty()) {
-            let candidate = dir.join("opencode");
-            if candidate.is_file() {
-                return Ok(candidate);
-            }
-        }
+    if let Some(found) = crate::local::shell_env::find_on_path("opencode") {
+        return Ok(found);
     }
     if let Some(home) = dirs::home_dir() {
         let fallback = home.join(".opencode").join("bin").join("opencode");

--- a/src/local/shell_env.rs
+++ b/src/local/shell_env.rs
@@ -17,7 +17,8 @@
 //! `publish-branch` worker — still inherit the process environment.
 
 use std::collections::HashMap;
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
+use std::path::PathBuf;
 use std::sync::OnceLock;
 
 /// Deliberately short. These are the variables whose divergence makes the app
@@ -35,9 +36,27 @@ pub fn var(key: &str) -> Option<OsString> {
         .or_else(|| std::env::var_os(key))
 }
 
-/// The PATH to search for harness binaries and hand to harness children.
+/// The PATH to search for the binaries orx spawns, and to hand its children.
 pub fn search_path() -> Option<OsString> {
     var("PATH")
+}
+
+/// Where `binary` lives, or None when this machine has no such tool. The path
+/// is returned as it sits on PATH; a caller that needs the real binary behind a
+/// symlink composes with `resolve_symlinks`.
+pub fn find_on_path(binary: &str) -> Option<PathBuf> {
+    search_in(&search_path()?, binary)
+}
+
+/// Split from the PATH lookup so the search is testable without a probe.
+fn search_in(paths: &OsStr, binary: &str) -> Option<PathBuf> {
+    // A relative entry (`""`, meaning cwd, or `bin`) names no fixed directory —
+    // it resolves against whichever cwd is current, so it is never a place to
+    // pick up a binary.
+    std::env::split_paths(paths)
+        .filter(|dir| dir.is_absolute())
+        .map(|dir| dir.join(binary))
+        .find(|candidate| candidate.is_file())
 }
 
 /// Hand the imported variables to a child process. Every `orx` child re-resolves
@@ -101,6 +120,29 @@ mod tests {
 
     fn fenced(payload: &str) -> String {
         format!("nvm loaded\n{M}{payload}{M}")
+    }
+
+    #[test]
+    fn the_search_skips_relative_entries_and_takes_the_first_absolute_hit() {
+        let root = std::env::temp_dir().join(format!("orx-path-search-{}", std::process::id()));
+        let (early, late) = (root.join("early"), root.join("late"));
+        std::fs::create_dir_all(&early).expect("early");
+        std::fs::create_dir_all(&late).expect("late");
+        std::fs::write(early.join("tool"), "").expect("early tool");
+        std::fs::write(late.join("tool"), "").expect("late tool");
+
+        let paths =
+            std::env::join_paths([PathBuf::new(), PathBuf::from("bin"), early.clone(), late])
+                .expect("join");
+        assert_eq!(search_in(&paths, "tool"), Some(early.join("tool")));
+        assert_eq!(search_in(&paths, "absent"), None);
+
+        // A relative entry is rejected even when it does resolve: cargo runs
+        // tests from the package root, so `src/main.rs` is a real hit here.
+        let relative = std::env::join_paths([PathBuf::from("src")]).expect("join");
+        assert_eq!(search_in(&relative, "main.rs"), None);
+
+        std::fs::remove_dir_all(&root).ok();
     }
 
     #[test]


### PR DESCRIPTION
Opening a `.tex` file in the macOS app reported **"No LaTeX toolchain found on PATH"** on a machine with tectonic installed.

The bundle is started by launchd with `PATH=/usr/bin:/bin:/usr/sbin:/sbin`, where no TeX lives. `src/local/latex.rs` was the one binary lookup still resolving against the process environment — every harness already went through `shell_env`'s probed shell PATH for exactly this reason. Read straight off the running app: the same process that could not see `/opt/homebrew/bin/tectonic` resolved `claude` at `~/.local/bin`.

### What changed

- **`shell_env` owns the PATH search.** `find_on_path` was `pub(super)` in `harness::detect`, so `find_opencode` and `resolves_on_path` each carried their own copy — one commented "Mirrors `find_on_path`". It moves to `shell_env`, which already owns `search_path()`, and all four call sites point at it. `other_orx_on_path` keeps its own loop; it needs every candidate and canonicalizes them.
- **The shared lookup now drops relative PATH entries, not just empty ones.** A relative entry resolved against orx's own cwd — never where a user's tool lives — and the child that ran it would resolve the same name somewhere else again. This tightens harness, opencode and orx-hint detection too; all three were re-checked against a launchd-environment bundle.
- **TeX tools are spawned with that PATH in the child.** latexmk finds the engine, biber and bibtex on PATH itself, so resolving latexmk alone is not enough. Symlinks are deliberately left unresolved: TeX picks its format file from the name it was invoked as, so canonicalizing `pdflatex` to `pdftex` would silently run plain TeX.
- **`on_path` no longer spawns `--version`.** It costs a probe a present-but-unrunnable binary would have failed, and buys back five subprocesses on every `.tex` tab open.
- **The no-engine hint leads with Tectonic**, and the copyable command is `brew install tectonic` rather than `brew install --cask mactex`. The distribution stays named second because Tectonic runs only XeTeX — the hint says so, since it is the last screen that can.

Three commits so the recommendation change can be reverted without disturbing the PATH fix.

### Verification

Built the bundle and launched it with launchd's exact environment (`env -i … PATH=/usr/bin:/bin:/usr/sbin:/sbin`), confirming the process PATH was the minimal one, then compared against the installed build running with the same PATH:

| `/api/latex/engine` | result |
| --- | --- |
| installed build | `{"engine":null,"hint":"…Install MacTeX…"}` |
| this branch | `{"engine":"tectonic","hint":null}` |

`/api/harnesses` on the same instance still resolved `claude`, `codex` and `opencode` at their real paths, so the tightened filter cost nothing.

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --locked`, `cargo test --locked` (618 pass)
- [x] `node --test scripts/dev-slot.test.mjs`, `node --test ui/tests/*.test.mjs`
- [x] Bundle under launchd's PATH detects tectonic; harness detection unaffected
- [x] A document compiles to a real PDF with only the injected PATH available
- [ ] A machine with **no** LaTeX at all shows the new hint and `brew install tectonic` in the file viewer
- [ ] A machine with **latexmk + a distribution** still prefers latexmk over tectonic
- [ ] A `.tex` with a bibliography still resolves citations (biber/bibtex reached via the child PATH)

### Known gaps, not addressed here

- The amber "Tectonic ran instead" note still fires only for a document carrying `% !TeX program`. A default pdfLaTeX document on a Tectonic-only machine is retypeset by XeTeX with no indication — `Compilation.engine` crosses the API but `useLatexCompile` never renders it. Widening the note would put a banner on essentially every compile for the now-recommended install, so the limitation is stated in the install hint instead. Rendering the engine label is the cheaper follow-up.
- `install_command()` still returns `None` off macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)