### PR TITLE
OR-205 Rename browser tab to OpenResearch

### DIFF
--- a/ui/dist/index.html
+++ b/ui/dist/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <title>OpenResearch CLI</title>
+    <title>OpenResearch</title>
     <script>
       // Resolve the theme before first paint to avoid a flash of the wrong palette.
       // Storage key and resolution must match src/theme.ts.

--- a/ui/index.html
+++ b/ui/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <title>OpenResearch CLI</title>
+    <title>OpenResearch</title>
     <script>
       // Resolve the theme before first paint to avoid a flash of the wrong palette.
       // Storage key and resolution must match src/theme.ts.


### PR DESCRIPTION
## Summary

- Rename the dashboard browser tab from `OpenResearch CLI` to `OpenResearch`.
- Regenerate the committed UI build output so packaged binaries use the new title.

Closes [OR-205](https://linear.app/alphaxiv/issue/OR-205/dont-name-tab-openresearch-cli-just-name-it-openresearch).

## Test checklist

- [x] `pnpm build`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --locked`
- [x] `cargo test --locked` (624 passed, 1 ignored)
- [ ] Confirm the browser tab displays `OpenResearch`
