### PR TITLE
[OR-212] Fix trusted run supervision and post-cancel Codex turns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,7 +1047,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openresearch-cli"
-version = "0.1.111"
+version = "0.1.112"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openresearch-cli"
-version = "0.1.111"
+version = "0.1.112"
 edition = "2021"
 description = "OpenResearch CLI (orx) — Rust port"
 repository = "https://github.com/alphaXiv/openresearch-cli"

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -505,7 +505,7 @@ type ApiResult = std::result::Result<Json<Value>, ApiError>;
 
 /// The Run entity the API serves: StoredRun with `backend_json` parsed into an
 /// object and cancellation intent exposed for pending UI state.
-#[derive(Serialize)]
+#[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct ApiRun {
     id: String,
@@ -1664,7 +1664,9 @@ async fn compute_backends() -> Json<Value> {
     Json(json!({ "backends": crate::compute::capabilities() }))
 }
 
-#[derive(Deserialize)]
+/// Dashboard requests omit `chat_session_id`; forwarded agent CLI requests use
+/// it only for run attribution and wakeups.
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct CreateRunReq {
     experiment_id: String,
@@ -1679,6 +1681,102 @@ struct CreateRunReq {
     disk: Option<i64>,
     #[serde(default)]
     force: bool,
+    chat_session_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct CreateRunResponse {
+    run: ApiRun,
+}
+
+pub(crate) struct RunLaunchSummary {
+    pub run_id: String,
+    pub experiment_id: String,
+    pub job_id: Option<String>,
+}
+
+async fn decode_local_response<T: serde::de::DeserializeOwned>(
+    response: reqwest::Response,
+    action: &str,
+) -> Result<T> {
+    let status = response.status();
+    let body = response
+        .bytes()
+        .await
+        .map_err(|error| anyhow!("orx up {action} response failed: {error}"))?;
+    if !status.is_success() {
+        let detail = serde_json::from_slice::<Value>(&body)
+            .ok()
+            .and_then(|value| {
+                value
+                    .get("error")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+            })
+            .unwrap_or_else(|| String::from_utf8_lossy(&body).trim().to_string());
+        if status.is_client_error() {
+            return Err(anyhow!("{detail}"));
+        }
+        return Err(anyhow!("orx up could not {action}: {detail}"));
+    }
+    serde_json::from_slice(&body)
+        .map_err(|error| anyhow!("orx up returned an invalid {action} response: {error}"))
+}
+
+fn local_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(3))
+        .build()
+        .map_err(|error| anyhow!("Could not create the orx up client: {error}"))
+}
+
+pub(crate) async fn submit_run_via_up(
+    port: u16,
+    args: &crate::ExpRunArgs,
+) -> Result<RunLaunchSummary> {
+    let request = CreateRunReq {
+        experiment_id: args.exp_id.clone(),
+        backend: args.backend.clone(),
+        flavor: args.flavor.clone(),
+        host: args.host.clone(),
+        manifest: args.manifest.clone(),
+        image: args.image.clone(),
+        timeout: args.timeout.clone(),
+        org: args.org.clone(),
+        provider: args.provider.clone(),
+        disk: args.disk,
+        force: args.force,
+        chat_session_id: args.launching_chat_session(),
+    };
+    let response = local_client()?
+        .post(format!("http://127.0.0.1:{port}/api/runs"))
+        .json(&request)
+        .send()
+        .await
+        .map_err(|error| anyhow!("Could not reach the trusted orx up process: {error}"))?;
+    let response: CreateRunResponse = decode_local_response(response, "start the run").await?;
+    let job_id = response
+        .run
+        .backend
+        .as_ref()
+        .and_then(|backend| backend.get("jobId"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    Ok(RunLaunchSummary {
+        run_id: response.run.id,
+        experiment_id: args.exp_id.clone(),
+        job_id,
+    })
+}
+
+pub(crate) async fn cancel_run_via_up(port: u16, run_id: &str) -> Result<()> {
+    let response = local_client()?
+        .post(format!("http://127.0.0.1:{port}/api/runs/{run_id}/cancel"))
+        .send()
+        .await
+        .map_err(|error| anyhow!("Could not reach the trusted orx up process: {error}"))?;
+    let _: Value = decode_local_response(response, "cancel the run").await?;
+    Ok(())
 }
 
 async fn create_run(State(state): State<AppState>, Json(req): Json<CreateRunReq>) -> ApiResult {
@@ -1693,6 +1791,7 @@ async fn create_run(State(state): State<AppState>, Json(req): Json<CreateRunReq>
         .ok_or_else(|| bad_request("project deletion is in progress"))?;
     let mut backend = req.backend;
     let mut flavor = req.flavor;
+    // Dashboard callers may omit these; forwarded CLI requests arrive resolved.
     local::apply_compute_default(&mut backend, &mut flavor);
     let args = crate::ExpRunArgs {
         exp_id: req.experiment_id,
@@ -1706,7 +1805,9 @@ async fn create_run(State(state): State<AppState>, Json(req): Json<CreateRunReq>
         image: req.image,
         timeout: req.timeout,
         force: req.force,
+        chat_session_id: req.chat_session_id,
     };
+    crate::compute::validate_run_args(&args).map_err(bad_request)?;
     let run = crate::compute::submit(&args).await.map_err(bad_request)?;
     Ok(Json(json!({ "run": ApiRun::from(&run) })))
 }
@@ -1765,12 +1866,13 @@ async fn list_instances() -> ApiResult {
     Ok(Json(json!({ "instances": instances })))
 }
 
-async fn cancel_run(Path(id): Path<String>) -> ApiResult {
+async fn cancel_run(State(state): State<AppState>, Path(id): Path<String>) -> ApiResult {
+    reject_if_moving(&state)?;
     let store = Store::open()?;
     let run = local::local_run(&store, &id)?.ok_or_else(|| not_found("run"))?;
     // A terminal run must not gain a stale cancel_requested flag.
     if is_terminal(&run.status) {
-        return Err(bad_request(format!("run already {}", run.status)));
+        return Ok(Json(json!({ "ok": true, "alreadyTerminal": true })));
     }
     let backend = backend_for_run(&run)?;
     backend.cancel(&run).await.map_err(bad_request)?;
@@ -5662,6 +5764,33 @@ mod tests {
 
         let value = serde_json::to_value(ApiRun::from(&run)).unwrap();
         assert_eq!(value["cancelRequested"], true);
+    }
+
+    #[test]
+    fn create_run_request_round_trips_agent_attribution_and_force() {
+        let request = CreateRunReq {
+            experiment_id: "experiment-1".into(),
+            backend: Some("local".into()),
+            flavor: None,
+            host: None,
+            manifest: None,
+            image: None,
+            timeout: None,
+            org: None,
+            provider: None,
+            disk: None,
+            force: true,
+            chat_session_id: Some("session-1".into()),
+        };
+
+        let value = serde_json::to_value(&request).unwrap();
+        assert_eq!(value["experimentId"], "experiment-1");
+        assert_eq!(value["chatSessionId"], "session-1");
+        assert_eq!(value["force"], true);
+        assert_eq!(
+            serde_json::from_value::<CreateRunReq>(value).unwrap(),
+            request
+        );
     }
 
     #[test]

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -326,6 +326,7 @@ pub trait ComputeBackend: Send + Sync {
     }
 
     async fn cancel(&self, handle: &StoredRun) -> Result<()> {
+        // Agent-session callers route through orx up before reaching this trusted path.
         crate::commands::exp::request_local_run_cancel(&Store::open()?, &handle.id)
     }
 
@@ -627,6 +628,38 @@ pub fn capabilities() -> Vec<Capabilities> {
         .collect()
 }
 
+pub fn validate_run_args(args: &crate::ExpRunArgs) -> Result<()> {
+    if args.manifest.is_some() && args.backend.as_deref() != Some("k8s") {
+        return Err(anyhow!("--manifest only applies with --backend k8s."));
+    }
+    if args.host.is_some() && !matches!(args.backend.as_deref(), Some("ssh") | Some("slurm")) {
+        return Err(anyhow!("--host only applies with --backend ssh or slurm."));
+    }
+    if args.org.is_some() && args.backend.as_deref() != Some("openresearch") {
+        return Err(anyhow!("--org only applies with --backend openresearch."));
+    }
+    if args.disk.is_some() && args.backend.as_deref() != Some("openresearch") {
+        return Err(anyhow!("--disk only applies with --backend openresearch."));
+    }
+    if args.provider.is_some() && args.backend.as_deref() != Some("openresearch") {
+        return Err(anyhow!(
+            "--provider only applies with --backend openresearch."
+        ));
+    }
+    if let Some(backend) = args.backend.as_deref() {
+        if !crate::local::BACKENDS.contains(&backend) {
+            return Err(anyhow!(
+                "Unknown --backend '{}'. Local experiments support: hf (Hugging Face Jobs), \
+                 modal (Modal serverless GPUs), k8s (your Kubernetes cluster), ssh (your own box), \
+                 slurm (your Slurm cluster), ray (a Ray Jobs cluster), \
+                 openresearch (an ephemeral OpenResearch box), local (this machine).",
+                backend
+            ));
+        }
+    }
+    Ok(())
+}
+
 pub async fn submit(args: &crate::ExpRunArgs) -> Result<StoredRun> {
     let backend_id = args.backend.as_deref().unwrap_or("local");
     let backend = backend(backend_id)?;
@@ -691,7 +724,7 @@ pub async fn submit(args: &crate::ExpRunArgs) -> Result<StoredRun> {
         commit_sha: Some(source.0.revision.clone()),
         result_markdown: None,
         cancel_requested: false,
-        chat_session_id: crate::local::chat::launching_chat_session(),
+        chat_session_id: args.launching_chat_session(),
     };
     reserve_run(&store, &pending, args.force)?;
     let pending_backend_json = descriptor.to_json();

--- a/src/local/chat/mod.rs
+++ b/src/local/chat/mod.rs
@@ -2318,6 +2318,8 @@ impl ChatHost {
     /// hand it to the `orx mcp-gate` bridge.
     pub fn set_up_port(&self, port: u16) {
         let _ = self.up_port.set(port);
+        self.opencode.set_up_port(port);
+        self.codex.set_up_port(port);
     }
 
     /// The bound `orx up` port, if this host runs under a server (None in
@@ -7098,6 +7100,9 @@ pub const CHAT_SESSION_ENV: &str = "ORX_CHAT_SESSION_ID";
 /// attribution — presence of a session id alone no longer implies local.
 pub const LOCAL_SESSION_ENV: &str = "ORX_LOCAL_SESSION";
 
+/// Loopback port of the trusted `orx up` process that owns local agent runs.
+pub const UP_PORT_ENV: &str = "ORX_UP_PORT";
+
 fn shell_single_quote(path: &std::path::Path) -> String {
     format!("'{}'", path.to_string_lossy().replace('\'', "'\\''"))
 }
@@ -7165,9 +7170,22 @@ fn child_env_value(key: &str) -> Option<std::ffi::OsString> {
 /// Stamp the launching session id onto a harness child's env. Call *after*
 /// `prepare_env` so a dashboard-synced value can't shadow it. Harness children
 /// are one-per-session, so this is unambiguous.
-pub fn set_chat_session_env(cmd: &mut tokio::process::Command, session_id: &str) {
+pub fn set_chat_session_env(
+    cmd: &mut tokio::process::Command,
+    session_id: &str,
+    up_port: Option<u16>,
+) {
     cmd.env(CHAT_SESSION_ENV, session_id);
     cmd.env(LOCAL_SESSION_ENV, "1");
+    // Never let a child inherit a port owned by some outer orx up process.
+    match up_port {
+        Some(port) => {
+            cmd.env(UP_PORT_ENV, port.to_string());
+        }
+        None => {
+            cmd.env_remove(UP_PORT_ENV);
+        }
+    }
     cmd.env_remove(CHAT_TARGET_FILE_ENV);
     cmd.env_remove(CHAT_TARGET_POINTER_ENV);
 
@@ -7227,6 +7245,25 @@ pub fn in_local_session() -> bool {
     std::env::var(LOCAL_SESSION_ENV).is_ok_and(|v| !v.is_empty())
 }
 
+/// Resolve the trusted local server for an agent subprocess. A marked local
+/// session must never silently fall back to launching workers from its sandbox.
+pub fn trusted_up_port() -> Result<Option<u16>> {
+    if !in_local_session() {
+        return Ok(None);
+    }
+    let raw = std::env::var(UP_PORT_ENV).map_err(|_| {
+        anyhow!("This agent session lost its link to the orx up server; restart `orx up`.")
+    })?;
+    let port = raw
+        .parse::<u16>()
+        .ok()
+        .filter(|port| *port != 0)
+        .ok_or_else(|| {
+            anyhow!("This agent session has an invalid orx up link; restart `orx up`.")
+        })?;
+    Ok(Some(port))
+}
+
 /// Append-only stderr sink for a harness child (startup/debug diagnostics).
 pub fn harness_log(name: &str) -> Result<std::fs::File> {
     let path = crate::store::data_dir().join(format!("agent-{name}.log"));
@@ -7243,7 +7280,9 @@ pub fn harness_log(name: &str) -> Result<std::fs::File> {
 
 #[cfg(test)]
 mod session_env_tests {
-    use super::{in_local_session, CHAT_SESSION_ENV, LOCAL_SESSION_ENV};
+    use super::{
+        in_local_session, trusted_up_port, CHAT_SESSION_ENV, LOCAL_SESSION_ENV, UP_PORT_ENV,
+    };
     use std::sync::{Mutex, MutexGuard};
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -7297,6 +7336,16 @@ mod session_env_tests {
         let _guard = EnvGuard::new(&[CHAT_SESSION_ENV, LOCAL_SESSION_ENV]);
         std::env::set_var(LOCAL_SESSION_ENV, "");
         assert!(!in_local_session());
+    }
+
+    #[test]
+    fn local_session_requires_a_valid_trusted_port() {
+        let _guard = EnvGuard::new(&[LOCAL_SESSION_ENV, UP_PORT_ENV]);
+        std::env::set_var(LOCAL_SESSION_ENV, "1");
+        assert!(trusted_up_port().is_err());
+
+        std::env::set_var(UP_PORT_ENV, "5203");
+        assert_eq!(trusted_up_port().unwrap(), Some(5203));
     }
 }
 

--- a/src/local/claude.rs
+++ b/src/local/claude.rs
@@ -547,7 +547,7 @@ async fn spawn_client(spec: &SpawnSpec, auth_generation: u64) -> Result<Arc<Clau
     // Stamp the launching session so `orx exp run` (a fresh subprocess the
     // agent shells out) tags its run and can explicitly subscribe this chat.
     // After prepare_env so it wins.
-    crate::local::chat::set_chat_session_env(&mut cmd, &spec.session_id);
+    crate::local::chat::set_chat_session_env(&mut cmd, &spec.session_id, spec.chat.up_port());
     // Own process group: a terminal SIGINT reaches orx up alone, which then
     // tears the resident child down deliberately (kill_session / shutdown). A
     // shared group would let Ctrl-C kill a persistent child mid-turn.

--- a/src/local/codex.rs
+++ b/src/local/codex.rs
@@ -740,17 +740,32 @@ impl CodexHost {
         }
     }
 
-    /// Natively interrupt the session's in-flight turn (best-effort, bounded).
+    /// Interrupt and harvest the in-flight turn while its child is reachable,
+    /// then retire the child so a successor cannot race native cancellation.
     pub async fn interrupt_session(&self, session_id: &str) -> Option<Vec<Value>> {
-        if let Some(client) = self.client_for(session_id).await {
-            let thread_id = client.resumed_thread();
-            let turn_id = client.active_turn.lock().unwrap().clone();
-            client.interrupt_active_turn().await;
-            if let (Some(thread_id), Some(turn_id)) = (thread_id, turn_id) {
-                return client.read_turn_items(&thread_id, &turn_id).await;
+        let client = self.client_for(session_id).await?;
+        let thread_id = client.resumed_thread();
+        let turn_id = client.active_turn.lock().unwrap().clone();
+        client.interrupt_active_turn().await;
+        let items = match (thread_id, turn_id) {
+            (Some(thread_id), Some(turn_id)) => client.read_turn_items(&thread_id, &turn_id).await,
+            _ => None,
+        };
+        let retired = {
+            let mut guard = self.inner.lock().await;
+            if guard
+                .get(session_id)
+                .is_some_and(|current| Arc::ptr_eq(current, &client))
+            {
+                guard.remove(session_id)
+            } else {
+                None
             }
+        };
+        if let Some(retired) = retired {
+            let _ = retired.child.lock().await.kill().await;
         }
-        None
+        items
     }
 
     /// Kill and reap one session's child (on session delete).

--- a/src/local/codex.rs
+++ b/src/local/codex.rs
@@ -553,7 +553,7 @@ async fn read_loop(client: Arc<CodexClient>, stdout: tokio::process::ChildStdout
 /// Spawn `codex app-server` (no handshake yet — see `CodexHost::ensure`, which
 /// registers the client *before* the handshake so every kill path can reach
 /// the child even if the spawning turn task is aborted mid-handshake).
-async fn spawn_client(session_id: &str) -> Result<Arc<CodexClient>> {
+async fn spawn_client(session_id: &str, up_port: Option<u16>) -> Result<Arc<CodexClient>> {
     let bin = find_codex_required()?;
     let mut cmd = Command::new(&bin);
     cmd.arg("app-server")
@@ -565,7 +565,7 @@ async fn spawn_client(session_id: &str) -> Result<Arc<CodexClient>> {
     // Stamp the launching session (one app-server child per orx session) so a
     // run the agent starts via `orx exp run` is tagged with it and can be
     // explicitly subscribed to. After prepare_env so it isn't shadowed.
-    crate::local::chat::set_chat_session_env(&mut cmd, session_id);
+    crate::local::chat::set_chat_session_env(&mut cmd, session_id, up_port);
     // Pin the child's store to the same canonicalized dir the sandbox policy
     // grants (see harness/codex.rs `ensure_orx_data_dir`) — after prepare_env
     // so the pin beats a dashboard-synced ORX_DATA_DIR. Unconditional: the
@@ -648,6 +648,7 @@ pub struct CodexHost {
     /// the handshake traffic sane). `inner` is never held across a spawn.
     spawn_lock: Mutex<()>,
     inner: Mutex<HashMap<String, Arc<CodexClient>>>,
+    up_port: std::sync::OnceLock<u16>,
 }
 
 impl Default for CodexHost {
@@ -661,7 +662,12 @@ impl CodexHost {
         Self {
             spawn_lock: Mutex::new(()),
             inner: Mutex::new(HashMap::new()),
+            up_port: std::sync::OnceLock::new(),
         }
+    }
+
+    pub fn set_up_port(&self, port: u16) {
+        let _ = self.up_port.set(port);
     }
 
     /// Spawn (or reuse) this session's app-server child. Idempotent while the
@@ -692,7 +698,7 @@ impl CodexHost {
         let host = self.clone();
         let session = session_id.to_string();
         tokio::spawn(async move {
-            let client = spawn_client(&session).await?;
+            let client = spawn_client(&session, host.up_port.get().copied()).await?;
             // Never displace a live entry: if an abandoned bring-up's insert
             // races a successor's (spawn_lock was released by the abort), the
             // loser kills its own child and defers to the live one.

--- a/src/local/harness/codex.rs
+++ b/src/local/harness/codex.rs
@@ -3362,7 +3362,7 @@ async fn run_turn_exec(ctx: &mut TurnCtx) -> Result<()> {
     // Tag the run this sandboxed turn may launch (`orx exp run`) with the
     // session so it can be explicitly subscribed to. After prepare_env so it
     // isn't shadowed by a synced value.
-    set_chat_session_env(&mut cmd, &ctx.session_id);
+    set_chat_session_env(&mut cmd, &ctx.session_id, ctx.host.up_port());
     // Pin the sandboxed turn's store to the exact path granted above. The
     // grant was resolved from the host's env, but the child could resolve a
     // different data dir — `prepare_env` injects dashboard-synced vars (a

--- a/src/local/hf.rs
+++ b/src/local/hf.rs
@@ -144,7 +144,7 @@ pub async fn submit_local_hf_with_source(
         cancel_requested: store
             .get_run(&run_id)?
             .is_some_and(|run| run.cancel_requested),
-        chat_session_id: crate::local::chat::launching_chat_session(),
+        chat_session_id: args.launching_chat_session(),
     };
     store.upsert_run(&run)?;
 

--- a/src/local/k8s.rs
+++ b/src/local/k8s.rs
@@ -188,7 +188,7 @@ pub async fn submit_local_k8s_with_source(
         cancel_requested: store
             .get_run(&run_id)?
             .is_some_and(|run| run.cancel_requested),
-        chat_session_id: crate::local::chat::launching_chat_session(),
+        chat_session_id: args.launching_chat_session(),
     };
     store.upsert_run(&run)?;
 

--- a/src/local/localrun.rs
+++ b/src/local/localrun.rs
@@ -127,7 +127,7 @@ pub async fn submit_local_run_with_source(
         cancel_requested: store
             .get_run(&run_id)?
             .is_some_and(|run| run.cancel_requested),
-        chat_session_id: crate::local::chat::launching_chat_session(),
+        chat_session_id: args.launching_chat_session(),
     };
     store.upsert_run(&run)?;
 

--- a/src/local/modal.rs
+++ b/src/local/modal.rs
@@ -148,7 +148,7 @@ pub async fn submit_local_modal_with_source(
         cancel_requested: store
             .get_run(&run_id)?
             .is_some_and(|run| run.cancel_requested),
-        chat_session_id: crate::local::chat::launching_chat_session(),
+        chat_session_id: args.launching_chat_session(),
     };
     store.upsert_run(&run)?;
 

--- a/src/local/opencode.rs
+++ b/src/local/opencode.rs
@@ -419,6 +419,7 @@ async fn spawn_agent(
     project: &LocalProject,
     model: Option<&str>,
     session_id: &str,
+    up_port: Option<u16>,
 ) -> Result<AgentChild> {
     let bin = find_opencode()?;
     // The clone/worktree setup inside can hit the network; keep it off the
@@ -468,7 +469,7 @@ async fn spawn_agent(
     // Tag runs the agent launches (`orx exp run`) with this session so they can
     // be explicitly subscribed to. One serve child per session; set after the
     // synced-env loop so it isn't shadowed.
-    crate::local::chat::set_chat_session_env(&mut cmd, session_id);
+    crate::local::chat::set_chat_session_env(&mut cmd, session_id, up_port);
     if let Some(config) = &config_override {
         // The repo tracks its own opencode.json; ours rides OPENCODE_CONFIG.
         // Project configs load after OPENCODE_CONFIG and would override our
@@ -509,6 +510,7 @@ pub struct AgentHost {
     /// clone or health poll must not block status reads or turn replies.
     spawn_lock: Mutex<()>,
     inner: Mutex<HashMap<String, AgentChild>>,
+    up_port: std::sync::OnceLock<u16>,
 }
 
 impl AgentHost {
@@ -517,7 +519,12 @@ impl AgentHost {
             model_override,
             spawn_lock: Mutex::new(()),
             inner: Mutex::new(HashMap::new()),
+            up_port: std::sync::OnceLock::new(),
         }
+    }
+
+    pub fn set_up_port(&self, port: u16) {
+        let _ = self.up_port.set(port);
     }
 
     /// Status of every live child; reaps children that died behind our back.
@@ -556,7 +563,13 @@ impl AgentHost {
         }
         // inner released: status()/port reads keep answering while the spawn
         // (clone/fetch + health poll) is in flight instead of hanging.
-        let agent = spawn_agent(project, self.model_override.as_deref(), session_id).await?;
+        let agent = spawn_agent(
+            project,
+            self.model_override.as_deref(),
+            session_id,
+            self.up_port.get().copied(),
+        )
+        .await?;
         let status = agent.status();
         self.inner
             .lock()

--- a/src/local/openresearch.rs
+++ b/src/local/openresearch.rs
@@ -201,7 +201,7 @@ pub async fn submit_local_openresearch_with_source(
         cancel_requested: store
             .get_run(&run_id)?
             .is_some_and(|run| run.cancel_requested),
-        chat_session_id: crate::local::chat::launching_chat_session(),
+        chat_session_id: args.launching_chat_session(),
     };
 
     // From here the box is billing: never leak it behind an error the store

--- a/src/local/ray.rs
+++ b/src/local/ray.rs
@@ -161,7 +161,7 @@ pub async fn submit_local_ray_with_source(
         cancel_requested: store
             .get_run(&run_id)?
             .is_some_and(|run| run.cancel_requested),
-        chat_session_id: crate::local::chat::launching_chat_session(),
+        chat_session_id: args.launching_chat_session(),
     };
     store.upsert_run(&run)?;
 

--- a/src/local/slurm.rs
+++ b/src/local/slurm.rs
@@ -160,7 +160,7 @@ pub async fn submit_local_slurm_with_source(
         cancel_requested: store
             .get_run(&run_id)?
             .is_some_and(|run| run.cancel_requested),
-        chat_session_id: crate::local::chat::launching_chat_session(),
+        chat_session_id: args.launching_chat_session(),
     };
     store.upsert_run(&run)?;
 

--- a/src/local/ssh.rs
+++ b/src/local/ssh.rs
@@ -133,7 +133,7 @@ pub async fn submit_local_ssh_with_source(
         cancel_requested: store
             .get_run(&run_id)?
             .is_some_and(|run| run.cancel_requested),
-        chat_session_id: crate::local::chat::launching_chat_session(),
+        chat_session_id: args.launching_chat_session(),
     };
     store.upsert_run(&run)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -505,6 +505,17 @@ pub struct ExpRunArgs {
     /// Launch even when another run is already in flight for this experiment.
     #[arg(long)]
     pub force: bool,
+    /// Internal attribution forwarded through the local orx up API.
+    #[arg(skip)]
+    pub chat_session_id: Option<String>,
+}
+
+impl ExpRunArgs {
+    pub fn launching_chat_session(&self) -> Option<String> {
+        self.chat_session_id
+            .clone()
+            .or_else(crate::local::chat::launching_chat_session)
+    }
 }
 
 #[derive(Args, Debug)]

--- a/src/plane/local_plane.rs
+++ b/src/plane/local_plane.rs
@@ -253,64 +253,63 @@ impl LocalPlane {
         if args.backend.is_none() {
             args.backend = Some("local".to_string());
         }
-        if args.manifest.is_some() && args.backend.as_deref() != Some("k8s") {
-            return Err(anyhow!("--manifest only applies with --backend k8s."));
-        }
-        if args.host.is_some() && !matches!(args.backend.as_deref(), Some("ssh") | Some("slurm")) {
-            return Err(anyhow!("--host only applies with --backend ssh or slurm."));
-        }
-        if args.org.is_some() && args.backend.as_deref() != Some("openresearch") {
-            return Err(anyhow!("--org only applies with --backend openresearch."));
-        }
-        if args.disk.is_some() && args.backend.as_deref() != Some("openresearch") {
-            return Err(anyhow!("--disk only applies with --backend openresearch."));
-        }
-        if args.provider.is_some() && args.backend.as_deref() != Some("openresearch") {
-            return Err(anyhow!(
-                "--provider only applies with --backend openresearch."
-            ));
-        }
+        crate::compute::validate_run_args(&args)?;
         // Coarse backend label for analytics; the backend name is already an
         // enum, never user data. Recorded before the (borrowing) dispatch below.
         let backend_label = args.backend.clone();
-        let result = match args.backend.as_deref() {
-            Some("hf") => crate::local::hf::launch_local_hf(&args).await,
-            Some("modal") => crate::local::modal::launch_local_modal(&args).await,
-            Some("k8s") => crate::local::k8s::launch_local_k8s(&args).await,
-            Some("ssh") => crate::local::ssh::launch_local_ssh(&args).await,
-            Some("slurm") => crate::local::slurm::launch_local_slurm(&args).await,
-            Some("ray") => crate::local::ray::launch_local_ray(&args).await,
-            Some("openresearch") => {
-                crate::local::openresearch::launch_local_openresearch(&args).await
+        let result = match crate::local::chat::trusted_up_port()? {
+            Some(port) => {
+                let summary = crate::commands::up::submit_run_via_up(port, &args).await?;
+                let backend = args.backend.as_deref().unwrap_or("local");
+                println!("\u{2713} {backend} run submitted by orx up.");
+                if let Some(job_id) = summary.job_id {
+                    let label = if backend == "local" { "dir" } else { "job" };
+                    println!("  {label}  {job_id}");
+                }
+                println!("  run  {}", summary.run_id);
+                println!(
+                    "{}",
+                    crate::invocation::follow_up(&summary.experiment_id, &summary.run_id)
+                );
+                Ok(())
             }
-            Some("local") => crate::local::localrun::launch_local_run(&args).await,
-            Some(other) => Err(anyhow!(
-                "Unknown --backend '{}'. Local experiments support: hf (Hugging Face Jobs), \
-                 modal (Modal serverless GPUs), k8s (your Kubernetes cluster), ssh (your own box), \
-                 slurm (your Slurm cluster), ray (a Ray Jobs cluster), \
-                 openresearch (an ephemeral OpenResearch box), local (this machine).",
-                other
-            )),
-            None => Err(anyhow!(
-                "No --backend given and no default compute target is set. \
-                 Configure a default compute target in OpenResearch, \
-                 or pass one per launch: \
-                 `--backend hf --flavor <flavor>` (e.g. --flavor a10g-small), \
-                 `--backend modal --flavor <flavor>` (e.g. --flavor a10g), \
-                 `--backend k8s` (runs the manifest committed on the branch — \
-                 default .orx/k8s.yaml, or --manifest <path>), \
-                 `--backend ssh --host <alias>` (an ~/.ssh/config alias), \
-                 `--backend slurm [--host <alias>] [--flavor h100:2]` (your Slurm cluster), \
-                 `--backend ray [--flavor gpu:1]` (a Ray Jobs cluster), \
-                 `--backend openresearch --flavor <shape>` (an ephemeral OpenResearch box, \
-                 e.g. --flavor h100_sxm or cpu5c; needs `orx login`), \
-                 or `--backend local` (a detached process on this machine)."
-            )),
+            None => match args.backend.as_deref() {
+                Some("hf") => crate::local::hf::launch_local_hf(&args).await,
+                Some("modal") => crate::local::modal::launch_local_modal(&args).await,
+                Some("k8s") => crate::local::k8s::launch_local_k8s(&args).await,
+                Some("ssh") => crate::local::ssh::launch_local_ssh(&args).await,
+                Some("slurm") => crate::local::slurm::launch_local_slurm(&args).await,
+                Some("ray") => crate::local::ray::launch_local_ray(&args).await,
+                Some("openresearch") => {
+                    crate::local::openresearch::launch_local_openresearch(&args).await
+                }
+                Some("local") => crate::local::localrun::launch_local_run(&args).await,
+                Some(other) => Err(anyhow!(
+                    "Unknown --backend '{}'. Local experiments support: hf (Hugging Face Jobs), \
+                     modal (Modal serverless GPUs), k8s (your Kubernetes cluster), ssh (your own box), \
+                     slurm (your Slurm cluster), ray (a Ray Jobs cluster), \
+                     openresearch (an ephemeral OpenResearch box), local (this machine).",
+                    other
+                )),
+                None => Err(anyhow!(
+                    "No --backend given and no default compute target is set. \
+                     Configure a default compute target in OpenResearch, \
+                     or pass one per launch: \
+                     `--backend hf --flavor <flavor>` (e.g. --flavor a10g-small), \
+                     `--backend modal --flavor <flavor>` (e.g. --flavor a10g), \
+                     `--backend k8s` (runs the manifest committed on the branch — \
+                     default .orx/k8s.yaml, or --manifest <path>), \
+                     `--backend ssh --host <alias>` (an ~/.ssh/config alias), \
+                     `--backend slurm [--host <alias>] [--flavor h100:2]` (your Slurm cluster), \
+                     `--backend ray [--flavor gpu:1]` (a Ray Jobs cluster), \
+                     `--backend openresearch --flavor <shape>` (an ephemeral OpenResearch box, \
+                     e.g. --flavor h100_sxm or cpu5c; needs `orx login`), \
+                     or `--backend local` (a detached process on this machine)."
+                )),
+            },
         };
         // Key event, fired only on a successful launch. Coarse backend only.
-        // `backend_label` is always `Some(<known backend>)` here — every arm that
-        // yields `Ok` matched a `Some("hf"|"modal"|...)`; `None`/unknown arms
-        // return `Err`. The `"unknown"` fallback is unreachable defense.
+        // Validation above guarantees a known backend before either dispatch path.
         if result.is_ok() {
             let target = backend_label.as_deref().unwrap_or("unknown");
             crate::telemetry::capture_experiment_started("run", Some(target));
@@ -329,8 +328,12 @@ impl LocalPlane {
         if in_flight.is_empty() {
             return Err(anyhow!("No run in flight for this experiment."));
         }
+        let trusted_port = crate::local::chat::trusted_up_port()?;
         for r in &in_flight {
-            crate::commands::exp::request_local_run_cancel(store, &r.id)?;
+            match trusted_port {
+                Some(port) => crate::commands::up::cancel_run_via_up(port, &r.id).await?,
+                None => crate::commands::exp::request_local_run_cancel(store, &r.id)?,
+            }
             println!("\u{2713} Cancel requested for run {}.", r.id);
         }
         Ok(())


### PR DESCRIPTION
## Summary

- route experiment launch and cancellation from sandboxed coding-agent sessions through the trusted `orx up` process
- preserve chat-session attribution across the local API boundary while keeping direct CLI launches unchanged
- retire a cancelled Codex app-server child after harvesting interrupted items so the next turn resumes cleanly instead of hanging on Thinking
- bump the CLI version from `0.1.111` to `0.1.112`

## Validation

- [x] Four independent reviewers reported no blockers on the supervisor change
- [x] Four fresh independent reviewers reported no blockers on the cancellation follow-up
- [x] Live dev-slot MNIST run was submitted by `orx up`, remained healthy past the previous false-failure window, and completed successfully
- [x] Live dev-slot regression: interrupt a running 30-second Codex tool, immediately send another message, and verify the resumed thread streams and completes
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --locked`
- [x] `cargo test --locked` (623 passed, 0 failed, 1 ignored)
- [ ] Validate a remote compute backend manually

## Release

Merging this PR triggers the `v0.1.112` release flow.
