### PR TITLE
fix: clarify asynchronous instance termination

### DIFF
--- a/src/commands/instance.rs
+++ b/src/commands/instance.rs
@@ -55,7 +55,10 @@ async fn list(creds: &crate::config::Credentials, args: InstanceListArgs) -> Res
 /// `orx instance delete <sandboxId>` — terminate the box and its provider machine.
 async fn delete(creds: &crate::config::Credentials, args: InstanceDeleteArgs) -> Result<()> {
     delete_sandbox(creds, &args.sandbox_id).await?;
-    println!("\u{2713} Instance {} deleted.", args.sandbox_id);
+    println!(
+        "\u{2713} Termination requested for instance {}.",
+        args.sandbox_id
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- report instance deletion as a termination request instead of claiming the provider instance is already deleted

The API enqueues teardown asynchronously and returns before provider termination finishes. Production logs confirmed the reported RunPod instances were terminated successfully; the old CLI message made the lifecycle state misleading.

## Verification

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --locked`
- [x] `cargo test --locked` (665 passed, 2 ignored)
- [x] Four independent read-only reviews; no blockers
- [ ] User-visible smoke test against the deployed API

