### PR TITLE
feat: capture richer CLI telemetry

### DIFF
--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -10,6 +10,7 @@ const CONFIRM_DATABASE: &str = "DELETE DATABASE";
 const CONFIRM_CLI: &str = "DELETE CLI";
 const CONFIRM_ALL: &str = "DELETE ALL";
 const AGENT_SESSION_ENV_VARS: &[&str] = &[
+    crate::local::chat::CHAT_HARNESS_ENV,
     crate::local::chat::CHAT_SESSION_ENV,
     crate::local::chat::LOCAL_SESSION_ENV,
     "CODEX_THREAD_ID",

--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -13,14 +13,21 @@ fn current_skill_set() -> SkillSet {
     }
 }
 
+fn capture_invocation(skill: &str) {
+    let harness = crate::local::chat::launching_chat_harness();
+    crate::telemetry::capture_skill_invoked(skill, "orx_skill", harness.as_deref());
+}
+
 pub async fn run(args: crate::SkillArgs) -> Result<()> {
     if let Some(path) = args.path {
         if let Some(skill) = agent_skills::find(&path, current_skill_set()) {
             println!("{}", skill.content.trim_end());
+            capture_invocation(skill.name);
             return Ok(());
         }
-        if let Some((_, resource)) = agent_skills::find_resource(&path, current_skill_set()) {
+        if let Some((skill, resource)) = agent_skills::find_resource(&path, current_skill_set()) {
             println!("{}", resource.content.trim_end());
+            capture_invocation(skill.name);
             return Ok(());
         }
         let available = agent_skills::skills(current_skill_set())
@@ -39,6 +46,8 @@ pub async fn run(args: crate::SkillArgs) -> Result<()> {
     for s in agent_skills::skills(current_skill_set()) {
         println!("  {:<20} {}", s.name, s.description);
     }
+
+    capture_invocation("overview");
 
     Ok(())
 }

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -5294,6 +5294,15 @@ async fn send_chat_message(
     Json(req): Json<SendChatReq>,
 ) -> ApiResult {
     reject_if_moving(&state)?;
+    let store = Store::open()?;
+    let session = store
+        .get_chat_session(&id)?
+        .ok_or_else(|| not_found("chat session"))?;
+    let project = store
+        .get_local_project(&session.project_id)?
+        .ok_or_else(|| not_found("project"))?;
+    let harness = session.harness;
+    let slash_skills = local::chat::builtin_slash_skill_names(&project, &req.text);
     let text = req.text.trim().to_string();
     let annotations = req
         .annotations
@@ -5313,7 +5322,7 @@ async fn send_chat_message(
         reasoning_level: req.reasoning_level,
     };
     // The turn runs in the background; progress streams over /api/events.
-    let response = if matches!(req.mode, Some(SendMode::Steer)) {
+    let (response, capture_message) = if matches!(req.mode, Some(SendMode::Steer)) {
         let result = state
             .chat
             .steer_message(
@@ -5333,8 +5342,11 @@ async fn send_chat_message(
                 }
             })?;
         match result {
-            Some(turn) => json!({ "ok": true, "turn": turn }),
-            None => json!({ "ok": true, "steered": true }),
+            Some(turn) => {
+                let capture = !turn.existing;
+                (json!({ "ok": true, "turn": turn }), capture)
+            }
+            None => (json!({ "ok": true, "steered": true }), true),
         }
     } else {
         let result = state
@@ -5355,9 +5367,15 @@ async fn send_chat_message(
                     bad_request(error)
                 }
             })?;
-        json!({ "ok": true, "turn": result })
+        let capture = !result.existing;
+        (json!({ "ok": true, "turn": result }), capture)
     };
-    crate::telemetry::capture_chat_message_sent();
+    if capture_message {
+        crate::telemetry::capture_chat_message_sent(&harness);
+        for skill in slash_skills {
+            crate::telemetry::capture_skill_invoked(skill, "slash", Some(&harness));
+        }
+    }
     Ok(Json(response))
 }
 
@@ -5426,20 +5444,41 @@ async fn fork_chat_turn(
     Json(req): Json<ForkChatReq>,
 ) -> ApiResult {
     reject_if_moving(&state)?;
-    let (kind, is_edited_resubmission) = match req.text {
-        Some(text) if !text.trim().is_empty() => (local::chat::ForkKind::Edit(text), true),
+    let edit_text = match req.text {
+        Some(text) if !text.trim().is_empty() => Some(text),
         Some(_) => return Err(bad_request("text is required")),
-        None => (local::chat::ForkKind::Retry, false),
+        None => None,
     };
+    let invocation = if let Some(text) = edit_text.as_deref() {
+        let store = Store::open()?;
+        let session = store
+            .get_chat_session(&id)?
+            .ok_or_else(|| not_found("chat session"))?;
+        let project = store
+            .get_local_project(&session.project_id)?
+            .ok_or_else(|| not_found("project"))?;
+        let skills = local::chat::builtin_slash_skill_names(&project, text);
+        Some((session.harness, skills))
+    } else {
+        None
+    };
+    let kind = edit_text
+        .map(local::chat::ForkKind::Edit)
+        .unwrap_or(local::chat::ForkKind::Retry);
     // A fork re-samples under the session's current settings, so it takes no
     // overrides — the turn runs in the background and streams over /api/events.
-    state
+    let started = state
         .chat
         .fork_turn(&id, &req.message_id, kind)
         .await
         .map_err(bad_request)?;
-    if is_edited_resubmission {
-        crate::telemetry::capture_chat_message_sent();
+    if started {
+        if let Some((harness, skills)) = invocation {
+            crate::telemetry::capture_chat_message_sent(&harness);
+            for skill in skills {
+                crate::telemetry::capture_skill_invoked(skill, "slash", Some(&harness));
+            }
+        }
     }
     Ok(Json(json!({ "ok": true })))
 }

--- a/src/local/chat/mod.rs
+++ b/src/local/chat/mod.rs
@@ -1864,8 +1864,13 @@ fn transcript_parts(
 }
 
 enum SelectedSlashSkill {
-    Builtin(&'static str),
-    User { instructions: String },
+    Builtin {
+        name: &'static str,
+        instructions: String,
+    },
+    User {
+        instructions: String,
+    },
 }
 
 fn slash_skill_name(token: &str) -> Option<String> {
@@ -1876,9 +1881,11 @@ fn slash_skill_name(token: &str) -> Option<String> {
     Some(name.to_ascii_lowercase())
 }
 
-/// Slash tokens select supplementary instructions. The transcript keeps the
-/// exact message, while every recognized selection shares that complete request.
-fn expand_slash_skills(project: &LocalProject, text: &str) -> String {
+fn selected_slash_skills(project: &LocalProject, text: &str) -> (Vec<SelectedSlashSkill>, bool) {
+    let has_request = text
+        .split_whitespace()
+        .filter(|token| slash_skill_name(token).is_none())
+        .any(|token| token.chars().any(char::is_alphanumeric));
     let mut seen = HashSet::new();
     let mut selected = Vec::new();
     for token in text.split_whitespace() {
@@ -1892,8 +1899,17 @@ fn expand_slash_skills(project: &LocalProject, text: &str) -> String {
             .iter()
             .find(|skill| skill.name.eq_ignore_ascii_case(&name))
         {
-            seen.insert(name);
-            selected.push(SelectedSlashSkill::Builtin(skill.name));
+            if let Some(instructions) = crate::local::skills::instructions(
+                skill.name,
+                has_request,
+                project.github_enabled(),
+            ) {
+                seen.insert(name);
+                selected.push(SelectedSlashSkill::Builtin {
+                    name: skill.name,
+                    instructions,
+                });
+            }
         } else if let Some(instructions) =
             crate::local::user_skills::instructions(&name, &project.id)
         {
@@ -1901,26 +1917,35 @@ fn expand_slash_skills(project: &LocalProject, text: &str) -> String {
             selected.push(SelectedSlashSkill::User { instructions });
         }
     }
+    (selected, has_request)
+}
+
+/// Bundled catalog only: user skill names are free text and stay local.
+pub(crate) fn builtin_slash_skill_names(project: &LocalProject, text: &str) -> Vec<&'static str> {
+    selected_slash_skills(project, text)
+        .0
+        .into_iter()
+        .filter_map(|skill| match skill {
+            SelectedSlashSkill::Builtin { name, .. } => Some(name),
+            SelectedSlashSkill::User { .. } => None,
+        })
+        .collect()
+}
+
+/// Slash tokens select supplementary instructions. The transcript keeps the
+/// exact message, while every recognized selection shares that complete request.
+fn expand_slash_skills(project: &LocalProject, text: &str) -> String {
+    let (selected, has_request) = selected_slash_skills(project, text);
     if selected.is_empty() {
         return text.to_string();
     }
 
-    let has_request = text
-        .split_whitespace()
-        .filter(|token| slash_skill_name(token).is_none())
-        .any(|token| token.chars().any(char::is_alphanumeric));
     let mut sections = Vec::with_capacity(selected.len());
     for skill in selected {
-        match skill {
-            SelectedSlashSkill::Builtin(name) => {
-                if let Some(instructions) =
-                    crate::local::skills::instructions(name, has_request, project.github_enabled())
-                {
-                    sections.push(instructions);
-                }
-            }
-            SelectedSlashSkill::User { instructions } => sections.push(instructions),
-        }
+        sections.push(match skill {
+            SelectedSlashSkill::Builtin { instructions, .. }
+            | SelectedSlashSkill::User { instructions } => instructions,
+        });
     }
 
     let mut expanded = format!(
@@ -1936,7 +1961,7 @@ fn expand_slash_skills(project: &LocalProject, text: &str) -> String {
 
 #[cfg(test)]
 mod slash_skill_tests {
-    use super::{expand_slash_skills, LocalProject};
+    use super::{builtin_slash_skill_names, expand_slash_skills, LocalProject};
 
     fn project() -> LocalProject {
         LocalProject {
@@ -1975,6 +2000,13 @@ mod slash_skill_tests {
         assert_eq!(
             expand_slash_skills(&project(), "plain /unknown text"),
             "plain /unknown text"
+        );
+        assert_eq!(
+            builtin_slash_skill_names(
+                &project(),
+                "/REPRODUCE-PAPER /unknown /reproduce-paper /write-paper"
+            ),
+            vec!["reproduce-paper", "write-paper"]
         );
     }
 
@@ -3775,7 +3807,7 @@ impl ChatHost {
         session_id: &str,
         message_id: &str,
         kind: ForkKind,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         let mut overrides = TurnOverrides::default();
         let store = Store::open()?;
         let messages = store.list_chat_messages(session_id)?;
@@ -3873,7 +3905,8 @@ impl ChatHost {
         // behind it silently continues from the older harness thread. Best-effort
         // and harness id first, because a half-applied restore that kept the
         // rewind is worse than either end state.
-        if !matches!(submitted, Ok(TurnSubmission::Started(_))) {
+        let started = matches!(&submitted, Ok(TurnSubmission::Started(_)));
+        if !started {
             if rewind.is_some() {
                 let _ = store
                     .set_chat_session_native_id(session_id, session.native_session_id.as_deref());
@@ -3885,7 +3918,7 @@ impl ChatHost {
                 json!({ "sessionId": session_id, "activeLeafId": session.active_leaf_id }),
             );
         }
-        submitted.map(|_| ())
+        submitted.map(|_| started)
     }
 
     /// Show a different fork of a turn. The whole branch under `leaf_id` comes
@@ -7140,6 +7173,9 @@ pub fn prepare_env(cmd: &mut tokio::process::Command) {
 /// `launching_chat_session`) and `orx exp wake` can register the current chat.
 pub const CHAT_SESSION_ENV: &str = "ORX_CHAT_SESSION_ID";
 
+/// Harness label paired with [`CHAT_SESSION_ENV`] for child telemetry.
+pub const CHAT_HARNESS_ENV: &str = "ORX_CHAT_HARNESS";
+
 /// Marks a process as a child of a local `orx up` harness. Separate from
 /// [`CHAT_SESSION_ENV`], which the cloud box's opencode plugin also exports for
 /// attribution — presence of a session id alone no longer implies local.
@@ -7218,9 +7254,11 @@ fn child_env_value(key: &str) -> Option<std::ffi::OsString> {
 pub fn set_chat_session_env(
     cmd: &mut tokio::process::Command,
     session_id: &str,
+    harness: &str,
     up_port: Option<u16>,
 ) {
     cmd.env(CHAT_SESSION_ENV, session_id);
+    cmd.env(CHAT_HARNESS_ENV, harness);
     cmd.env(LOCAL_SESSION_ENV, "1");
     // Never let a child inherit a port owned by some outer orx up process.
     match up_port {
@@ -7281,6 +7319,12 @@ pub fn launching_chat_session() -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
+pub fn launching_chat_harness() -> Option<String> {
+    std::env::var(CHAT_HARNESS_ENV)
+        .ok()
+        .filter(|harness| !harness.is_empty())
+}
+
 /// Whether this process is running inside a local `orx up` session.
 /// [`LOCAL_SESSION_ENV`] is exported only by [`set_chat_session_env`] onto
 /// `orx up` harness children, so its presence means this process is one (or a
@@ -7326,7 +7370,8 @@ pub fn harness_log(name: &str) -> Result<std::fs::File> {
 #[cfg(test)]
 mod session_env_tests {
     use super::{
-        in_local_session, trusted_up_port, CHAT_SESSION_ENV, LOCAL_SESSION_ENV, UP_PORT_ENV,
+        in_local_session, launching_chat_harness, trusted_up_port, CHAT_HARNESS_ENV,
+        CHAT_SESSION_ENV, LOCAL_SESSION_ENV, UP_PORT_ENV,
     };
     use std::sync::{Mutex, MutexGuard};
 
@@ -7367,10 +7412,13 @@ mod session_env_tests {
     /// `orx skill` serves the Local skill bodies on every cloud box.
     #[test]
     fn chat_session_alone_is_not_a_local_session() {
-        let _guard = EnvGuard::new(&[CHAT_SESSION_ENV, LOCAL_SESSION_ENV]);
+        let _guard = EnvGuard::new(&[CHAT_HARNESS_ENV, CHAT_SESSION_ENV, LOCAL_SESSION_ENV]);
 
         std::env::set_var(CHAT_SESSION_ENV, "ses_cloud_box");
         assert!(!in_local_session());
+
+        std::env::set_var(CHAT_HARNESS_ENV, "opencode");
+        assert_eq!(launching_chat_harness().as_deref(), Some("opencode"));
 
         std::env::set_var(LOCAL_SESSION_ENV, "1");
         assert!(in_local_session());

--- a/src/local/claude.rs
+++ b/src/local/claude.rs
@@ -560,7 +560,12 @@ async fn spawn_client(spec: &SpawnSpec, auth_generation: u64) -> Result<Arc<Clau
     // Stamp the launching session so `orx exp run` (a fresh subprocess the
     // agent shells out) tags its run and can explicitly subscribe this chat.
     // After prepare_env so it wins.
-    crate::local::chat::set_chat_session_env(&mut cmd, &spec.session_id, spec.chat.up_port());
+    crate::local::chat::set_chat_session_env(
+        &mut cmd,
+        &spec.session_id,
+        "claude-code",
+        spec.chat.up_port(),
+    );
     // Own process group: a terminal SIGINT reaches orx up alone, which then
     // tears the resident child down deliberately (kill_session / shutdown). A
     // shared group would let Ctrl-C kill a persistent child mid-turn.

--- a/src/local/codex.rs
+++ b/src/local/codex.rs
@@ -584,7 +584,7 @@ async fn spawn_client(
     // Stamp the launching session (one app-server child per orx session) so a
     // run the agent starts via `orx exp run` is tagged with it and can be
     // explicitly subscribed to. After prepare_env so it isn't shadowed.
-    crate::local::chat::set_chat_session_env(&mut cmd, session_id, up_port);
+    crate::local::chat::set_chat_session_env(&mut cmd, session_id, "codex", up_port);
     // Pin the child's store to the same canonicalized dir the sandbox policy
     // grants (see harness/codex.rs `ensure_orx_data_dir`) — after prepare_env
     // so the pin beats a dashboard-synced ORX_DATA_DIR. Unconditional: the

--- a/src/local/harness/codex.rs
+++ b/src/local/harness/codex.rs
@@ -3364,7 +3364,7 @@ async fn run_turn_exec(ctx: &mut TurnCtx) -> Result<()> {
     // Tag the run this sandboxed turn may launch (`orx exp run`) with the
     // session so it can be explicitly subscribed to. After prepare_env so it
     // isn't shadowed by a synced value.
-    set_chat_session_env(&mut cmd, &ctx.session_id, ctx.host.up_port());
+    set_chat_session_env(&mut cmd, &ctx.session_id, "codex", ctx.host.up_port());
     // Pin the sandboxed turn's store to the exact path granted above. The
     // grant was resolved from the host's env, but the child could resolve a
     // different data dir — `prepare_env` injects dashboard-synced vars (a

--- a/src/local/opencode.rs
+++ b/src/local/opencode.rs
@@ -473,7 +473,7 @@ async fn spawn_agent(
     // Tag runs the agent launches (`orx exp run`) with this session so they can
     // be explicitly subscribed to. One serve child per session; set after the
     // synced-env loop so it isn't shadowed.
-    crate::local::chat::set_chat_session_env(&mut cmd, session_id, up_port);
+    crate::local::chat::set_chat_session_env(&mut cmd, session_id, "opencode", up_port);
     if let Some(config) = &config_override {
         // The repo tracks its own opencode.json; ours rides OPENCODE_CONFIG.
         // Project configs load after OPENCODE_CONFIG and would override our

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -3,8 +3,8 @@
 //! Why this exists: `orx` shipped with no telemetry, so we had no way to see
 //! installs, DAU/WAU, retention, or which commands people actually use. This
 //! module sends events under a random per-install UUID that is not tied to an
-//! account. Only coarse research-area categories and paper count are included
-//! from the onboarding profile; free text and paper identifiers stay local.
+//! account. The onboarding research profile includes selected categories and
+//! user-entered area/background text; paper identifiers stay local.
 //!
 //! Guarantees, enforced by this module:
 //! - **Official builds only.** Source builds never send production telemetry or
@@ -891,6 +891,8 @@ pub(crate) fn capture_onboarding_research_profile(profile: &ResearchProfile) {
         "onboarding_research_profile_submitted",
         json!({
             "researchAreas": profile.research_areas,
+            "otherArea": profile.other_area,
+            "background": profile.background,
             "paperCount": profile.papers.len(),
         }),
     );
@@ -904,8 +906,16 @@ pub(crate) fn capture_chat_session_started(harness: &str) {
     capture("chat_session_started", json!({ "harness": harness }));
 }
 
-pub(crate) fn capture_chat_message_sent() {
-    capture("chat_message_sent", json!({}));
+pub(crate) fn capture_chat_message_sent(harness: &str) {
+    capture("chat_message_sent", json!({ "harness": harness }));
+}
+
+pub(crate) fn capture_skill_invoked(skill: &str, source: &str, harness: Option<&str>) {
+    let mut properties = json!({ "skill": skill, "source": source });
+    if let Some(harness) = harness {
+        properties["harness"] = json!(harness);
+    }
+    capture("skill_invoked", properties);
 }
 
 /// Flush every pending event send (the session's `cli_command` plus any key
@@ -1511,6 +1521,7 @@ mod tests {
             ("chat_retry_started", "cli_chat_retry_started"),
             ("chat_retry_exhausted", "cli_chat_retry_exhausted"),
             ("chat_recovery_action", "cli_chat_recovery_action"),
+            ("skill_invoked", "cli_skill_invoked"),
             ("experiment_started", "cli_experiment_started"),
             ("telemetry_consent", "cli_telemetry_consent"),
         ] {
@@ -1716,7 +1727,11 @@ mod tests {
                 "cli-release-contract-test",
                 json!({ "harness": "codex" }),
             ),
-            build_payload("chat_message_sent", "cli-release-contract-test", json!({})),
+            build_payload(
+                "chat_message_sent",
+                "cli-release-contract-test",
+                json!({ "harness": "codex" }),
+            ),
             build_payload(
                 "chat_retry_started",
                 "cli-release-contract-test",
@@ -1731,6 +1746,11 @@ mod tests {
                 "chat_recovery_action",
                 "cli-release-contract-test",
                 json!({ "harness": "codex", "owner": "orx", "reason": "terminal_turn", "attempt": 2, "action": "continue" }),
+            ),
+            build_payload(
+                "skill_invoked",
+                "cli-release-contract-test",
+                json!({ "skill": "reproduce-paper", "source": "slash", "harness": "codex" }),
             ),
             build_payload(
                 "experiment_started",
@@ -1786,6 +1806,8 @@ mod tests {
             "did",
             json!({
                 "researchAreas": ["AI/ML", "Other"],
+                "otherArea": "AI for theorem proving",
+                "background": "I study formal reasoning systems.",
                 "paperCount": 1,
             }),
         );
@@ -1797,9 +1819,17 @@ mod tests {
             research_profile["events"][0]["properties"]["researchAreas"][1],
             "Other"
         );
+        assert_eq!(
+            research_profile["events"][0]["properties"]["otherArea"],
+            "AI for theorem proving"
+        );
+        assert_eq!(
+            research_profile["events"][0]["properties"]["background"],
+            "I study formal reasoning systems."
+        );
         assert_eq!(research_profile["events"][0]["properties"]["paperCount"], 1);
         let profile_text = serde_json::to_string(&research_profile).unwrap();
-        for forbidden in ["otherArea", "background", "paperId", "title"] {
+        for forbidden in ["paperId", "title"] {
             assert!(!profile_text.contains(forbidden));
         }
 
@@ -1813,9 +1843,21 @@ mod tests {
         assert_eq!(chat["events"][0]["properties"]["harness"], "codex");
         assert_eq!(property_keys(&chat), vec!["harness"]);
 
-        let message = build_payload("chat_message_sent", "did", json!({}));
+        let message = build_payload("chat_message_sent", "did", json!({ "harness": "codex" }));
         assert_eq!(message["events"][0]["name"], "cli_chat_message_sent");
-        assert!(property_keys(&message).is_empty());
+        assert_eq!(message["events"][0]["properties"]["harness"], "codex");
+        assert_eq!(property_keys(&message), vec!["harness"]);
+
+        let skill = build_payload(
+            "skill_invoked",
+            "did",
+            json!({ "skill": "reproduce-paper", "source": "slash", "harness": "codex" }),
+        );
+        assert_eq!(skill["events"][0]["name"], "cli_skill_invoked");
+        assert_eq!(skill["events"][0]["properties"]["skill"], "reproduce-paper");
+        assert_eq!(skill["events"][0]["properties"]["source"], "slash");
+        assert_eq!(skill["events"][0]["properties"]["harness"], "codex");
+        assert_eq!(property_keys(&skill), vec!["harness", "skill", "source"]);
 
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -1866,6 +1908,8 @@ mod tests {
         capture_onboarding_research_profile(&ResearchProfile::default());
         capture_project_created(true);
         capture_chat_session_started("codex");
+        capture_chat_message_sent("codex");
+        capture_skill_invoked("reproduce-paper", "slash", Some("codex"));
         capture_experiment_started("run", true, Some("local"));
 
         assert!(pending().lock().unwrap().is_empty());


### PR DESCRIPTION
## Summary

- attach the active harness to accepted chat messages without double-counting idempotent retries
- emit skill-invocation telemetry for bundled slash workflows and explicit `orx skill` reads
- transmit the onboarding "Other" research area and research-background text
- pass harness identity to agent subprocesses so skill usage remains attributable without reopening SQLite

Companion API ingestion PR: https://github.com/alphaXiv/openresearch.sh/pull/612

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --locked`
- [x] `cargo test --locked` (668 passed, 2 ignored)
- [ ] Verify the new events arrive after a production CLI release
