### PR TITLE
chore: bump version to 0.1.119

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,7 +1103,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openresearch-cli"
-version = "0.1.118"
+version = "0.1.119"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openresearch-cli"
-version = "0.1.118"
+version = "0.1.119"
 edition = "2021"
 description = "OpenResearch CLI (orx) — Rust port"
 repository = "https://github.com/alphaXiv/openresearch-cli"


### PR DESCRIPTION
Bumps Cargo.toml and Cargo.lock from 0.1.118 to 0.1.119. Merging this PR dispatches the v0.1.119 release via release-on-bump.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)