### PR TITLE
fix: accept the renamed alphaXiv/OpenResearch repository in release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "openresearch-cli"
 version = "0.1.119"
 edition = "2021"
 description = "OpenResearch CLI (orx) — Rust port"
-repository = "https://github.com/alphaXiv/openresearch-cli"
+repository = "https://github.com/alphaXiv/OpenResearch"
 license = "MIT"
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ literature, develop hypotheses, run experiments, and produce research artifacts.
 
 [Download the desktop app](https://openresearch.sh/download) ·
 [Documentation](https://openresearch.sh/docs) ·
-[Releases](https://github.com/alphaXiv/openresearch-cli/releases)
+[Releases](https://github.com/alphaXiv/OpenResearch/releases)
 
 </div>
 

--- a/build.rs
+++ b/build.rs
@@ -7,13 +7,12 @@ fn main() {
         Ok(value)
             if value == "1"
                 && std::env::var("GITHUB_ACTIONS").as_deref() == Ok("true")
-                && std::env::var("GITHUB_REPOSITORY").as_deref()
-                    == Ok("alphaXiv/openresearch-cli") =>
+                && std::env::var("GITHUB_REPOSITORY").as_deref() == Ok("alphaXiv/OpenResearch") =>
         {
             "production"
         }
         Ok(value) if value == "1" => panic!(
-            "ORX_OFFICIAL_RELEASE_BUILD=1 is only valid in alphaXiv/openresearch-cli GitHub Actions"
+            "ORX_OFFICIAL_RELEASE_BUILD=1 is only valid in alphaXiv/OpenResearch GitHub Actions"
         ),
         Ok(value) => {
             panic!("ORX_OFFICIAL_RELEASE_BUILD must be unset or exactly `1`, got `{value}`")

--- a/macos/DISTRIBUTION.md
+++ b/macos/DISTRIBUTION.md
@@ -6,7 +6,7 @@ signs, notarizes, and packages it into a DMG. CI
 trigger caveat below) and attaches `OpenResearch.dmg`:
 
 ```
-https://github.com/alphaXiv/openresearch-cli/releases/latest/download/OpenResearch.dmg
+https://github.com/alphaXiv/OpenResearch/releases/latest/download/OpenResearch.dmg
 ```
 
 The release job is a no-op until the **repository** variable

--- a/src/updates.rs
+++ b/src/updates.rs
@@ -28,7 +28,7 @@ use crate::error::{anyhow, Result};
 pub mod macos_app;
 
 /// GitHub repo the released binaries come from.
-pub const REPO_URL: &str = "https://github.com/alphaXiv/openresearch-cli";
+pub const REPO_URL: &str = "https://github.com/alphaXiv/OpenResearch";
 
 /// The cargo-dist app name (the *package* name, not the `orx` bin name) — used
 /// in release asset names and the receipt path.
@@ -331,7 +331,7 @@ pub fn auto_update_eligible() -> bool {
 
 /// The one-liner that reinstalls orx through the release installer.
 const INSTALL_HINT: &str = "curl --proto '=https' --tlsv1.2 -LsSf \
-https://github.com/alphaXiv/openresearch-cli/releases/latest/download/openresearch-cli-installer.sh | sh";
+https://github.com/alphaXiv/OpenResearch/releases/latest/download/openresearch-cli-installer.sh | sh";
 
 /// Confirm a directory can be written before an update commits to it — root-owned
 /// installs and read-only filesystems fail here rather than after a download.


### PR DESCRIPTION
The GitHub repository was renamed from `alphaXiv/openresearch-cli` to `alphaXiv/OpenResearch`, so `build.rs` rejected `ORX_OFFICIAL_RELEASE_BUILD=1` and the v0.1.119 release failed (https://github.com/alphaXiv/OpenResearch/actions/runs/33701854561).

This updates the build guard and the release/download URLs in Cargo.toml, README, updates.rs, and DISTRIBUTION.md to the new name.

After merging, re-run the failed `Release on version bump` run for the 0.1.119 bump commit so it dispatches the release again from the fixed main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)