### PR TITLE
OR-263: Guide agents to organize project artifacts

### DIFF
--- a/SYSTEM_PROMPT.md
+++ b/SYSTEM_PROMPT.md
@@ -25,6 +25,7 @@ private to this chat session.
 {paper_line}{compute_bullet}
 - Artifacts directory: `{artifacts}` — durable project outputs such as reports,
   figures, images, CSVs, and PDFs are stored as project artifacts. Load
+  `orx-reports` before creating or organizing artifacts. Load
   `orx-figures` before writing plotting code; default matplotlib output is not
   publishable
 

--- a/agent-skills/orx-experiment-tree/SKILL.md
+++ b/agent-skills/orx-experiment-tree/SKILL.md
@@ -190,7 +190,7 @@ intended flow — do **not** edit a frozen node or rewrite the run command:
 
 Stop when the goal is met, or after ~3 consecutive failed or regressed runs.
 When you stop, write up the tree as a descriptively named project artifact — see
-the `orx-reports` skill for naming and optional folder guidance.
+the `orx-reports` skill for naming and folder guidance.
 
 Close any turn that ran or changed experiments with a short experiment summary:
 one line per relevant node with what it tested, its status, and the headline

--- a/agent-skills/orx-figures/SKILL.md
+++ b/agent-skills/orx-figures/SKILL.md
@@ -80,7 +80,7 @@ link.
 | The figure is for | Write it to | Cite it as |
 | --- | --- | --- |
 | A paper (`.tex`) | `figs/` beside the `.tex` in the working tree — `\includegraphics` resolves paths relative to the source, and the artifacts directory is not beside it | `<file path="figs/loss_curve.pdf" />` — repository-relative, **no** `artifacts/` prefix |
-| A report, a summary, an answer in chat | The artifacts directory from the session playbook, per the `orx-reports` module | `<file path="artifacts/loss_curve.pdf" />` |
+| A report, a summary, an answer in chat | Load `orx-reports` and use the relevant topic or deliverable folder under the artifacts directory, e.g. `transformer-sweep/figures/` | `<file path="artifacts/transformer-sweep/figures/loss_curve.pdf" />` |
 
 **The tag must match the destination.** A figure written to the worktree but
 cited with an `artifacts/` prefix is looked for in the artifacts directory and
@@ -186,9 +186,8 @@ Pick by the question the figure answers, not by the shape you have in mind.
 | What is the method, architecture, or pipeline? | [references/diagram.md](references/diagram.md) |
 
 Every reference's template writes to `figs/`, which is the paper destination.
-For a report or a chat answer, put both the script and its `save()` stem under
-the artifacts directory — they stay together either way — and cite the output
-with the `artifacts/` prefix.
+For a report or a chat answer, adapt the template's script and output paths to
+the folder chosen per `orx-reports`.
 
 Do not read references for figures you are not making. If an installed
 reference cannot be read, `orx skill figures/<name>` prints it.

--- a/agent-skills/orx-reports/SKILL.md
+++ b/agent-skills/orx-reports/SKILL.md
@@ -1,24 +1,49 @@
 ---
 name: orx-reports
-description: "Write durable outputs into the artifacts directory. Use when a line of work concludes or the user asks for a write-up, summary, comparison, figures, or exported data."
+description: "Write and organize durable outputs in the artifacts directory. Use before creating or organizing artifacts, including reports, summaries, comparisons, figures, and exported data, or when a line of work concludes."
 ---
 
 Write reports, figures, CSVs, PDFs, and other outputs directly into the artifacts
 directory shown in the session playbook. Written files become project artifacts
 immediately.
 
-When a line of work concludes, use a descriptive filename that explains the
-output without relying on its directory, for example:
+Before writing, inspect the existing artifacts directory and follow its
+organization. Reuse the relevant folder for follow-up outputs. Group related
+outputs by research topic or deliverable instead of accumulating files at the
+artifacts root. Add subfolders such as `figures/`, `data/`, or `models/` only
+when they help; do not create empty scaffolding.
 
-- `<artifacts-dir>/scaling-analysis.md`
-- `<artifacts-dir>/benchmark-results.csv`
-- `<artifacts-dir>/ablation-comparison.pdf`
+Use a descriptive filename for each output. For example:
+
+```text
+<artifacts-dir>/
+  transformer-sweep/
+    transformer-sweep-report.md
+    figures/
+      orx_figstyle.py
+      patch-size.pdf
+      patch-size.svg
+      patch-size.py
+      learning-rate.pdf
+      learning-rate.svg
+      learning-rate.py
+    data/
+      sweep-results.csv
+```
+
+Keep reproducibility scripts beside their figures. Keep temporary logs and
+scratch files outside the artifacts directory.
+
+Keep already-published outputs at their existing paths. Reorganize other older
+outputs only when requested, updating affected document links and verifying they
+still resolve.
 
 Read the `orx-figures` module before writing any figure; a default
 matplotlib plot does not meet the bar the reports are held to.
 
-Write at the artifacts root unless a folder is useful. Markdown may reference
-nearby images by relative path; no name such as `project/`, an experiment slug,
-or `report.md` is reserved. In the chat handoff, link every finished output using
-the session playbook's evidence-and-links contract. Load `orx-evidence` when the
-report makes claims derived from run results.
+Use relative links within reports, for example
+`![Patch size](figures/patch-size.svg)` from `transformer-sweep-report.md`.
+In the chat handoff, link every finished output using the session playbook's
+evidence-and-links contract, including the full nested path, for example
+`<file path="artifacts/transformer-sweep/figures/patch-size.svg" />`.
+Load `orx-evidence` when the report makes claims derived from run results.

--- a/src/local/agent_skills.rs
+++ b/src/local/agent_skills.rs
@@ -185,7 +185,7 @@ const S_CREATE: AgentSkill = AgentSkill {
 };
 const S_REPORTS: AgentSkill = AgentSkill {
     name: "orx-reports",
-    description: "Write durable outputs into the artifacts directory. Use when a line of work concludes or the user asks for a write-up, summary, comparison, figures, or exported data.",
+    description: "Write and organize durable outputs in the artifacts directory. Use before creating or organizing artifacts, including reports, summaries, comparisons, figures, and exported data, or when a line of work concludes.",
     content: REPORTS,
     resources: &[],
 };
@@ -662,7 +662,7 @@ mod tests {
             .contains(r#"<file path="figs/loss_curve.pdf" />"#));
         assert!(figures
             .content
-            .contains(r#"<file path="artifacts/loss_curve.pdf" />"#));
+            .contains(r#"<file path="artifacts/transformer-sweep/figures/loss_curve.pdf" />"#));
         assert!(figures
             .content
             .contains("The tag must match the destination"));

--- a/src/local/opencode.rs
+++ b/src/local/opencode.rs
@@ -766,8 +766,11 @@ mod tests {
     fn reports_skill_owns_artifact_output_policy() {
         let md = sample_playbook();
         let reports = agent_skills::find("orx-reports", SkillSet::Local).unwrap();
-        assert!(reports.content.contains("descriptive filename"));
-        assert!(reports.content.contains("artifacts root"));
+        assert!(md.contains("`orx-reports` before creating or organizing artifacts"));
+        assert!(reports.content.contains("Reuse the relevant folder"));
+        assert!(reports
+            .content
+            .contains("<file path=\"artifacts/transformer-sweep/figures/patch-size.svg\" />"));
         assert!(!md.contains("PROJECT.md"));
     }
 


### PR DESCRIPTION
Agents now load `orx-reports` before creating or organizing artifacts. The skill groups related outputs by topic, reuses existing folders, keeps reproducibility files together, and demonstrates relative report links and nested chat links. Published output paths stay stable. Figures guidance, the experiment-tree cross-reference, and existing policy tests are aligned.

Fixes [OR-263](https://linear.app/alphaxiv/issue/OR-263/instruct-agents-to-organize-the-artifacts-tab-well).

Validation:
- [x] Rust formatting, clippy, locked debug/release builds, and development telemetry checks.
- [x] `cargo test --locked`: 733 passed, 2 ignored, including skill metadata, installation, and playbook tests.
- [x] Localization/style checks, 9 dev-slot tests, UI typecheck, and 113 UI tests.
- [x] Isolated browser fixture: nested reports render multiple images; a follow-up reuses the folder; report, data, and chat file links resolve.
- [x] Four independent Codex subagent reviews: no blockers (user-requested replacement for Claude).
- [ ] User-led research session confirms the agent's organization matches expectations.
