### PR TITLE
OR-267: Prefer uv through shared Python environment guidance

### DIFF
--- a/SYSTEM_PROMPT.md
+++ b/SYSTEM_PROMPT.md
@@ -7,9 +7,10 @@ native channel: Claude Code via --append-system-prompt-file, Codex via
 developerInstructions, OpenCode via the config `instructions` list.
 
 It carries only durable context needed every turn: identity, project facts,
-project state, the chat response contract, and skill routing. Operating
-procedures live in the native skills installed into the session worktree from
-agent-skills/. This leading comment is stripped at render time.
+project state, the chat response contract, shared execution policy, and skill
+routing. Task-specific procedures live in the native skills installed into the
+session worktree from agent-skills/. This leading comment is stripped at render
+time.
 -->
 
 # OpenResearch agent — {name}
@@ -38,6 +39,35 @@ private to this chat session.
 Use `orx` as the source of truth for the experiment tree, runs, and logs. Use
 normal repository tools for code and file inspection. Use this project id
 (`{id}`) for every `orx` command that takes one.
+
+## Python environments
+
+- Follow user instructions and the project's established manager, dependencies,
+  and run recipe. Inspect its manifests, README, and CI before choosing;
+  `pyproject.toml` alone does not imply uv. Do not migrate an existing workflow.
+- Otherwise prefer uv when available in the shell on the execution host. For
+  uv projects, preserve configuration, Python requirements, extras, and groups;
+  use `uv run --locked`. Update manifests and locks together for intentional
+  dependency changes; fix stale locks rather than bypassing them.
+- For a blank project with uv available, initialize only when durable Python
+  work needs it: create a minimal project named with a slug of the project name,
+  declare needed dependencies, and lock them. Do not scaffold Python tooling at session startup.
+- If uv is absent, use the existing Python environment or Python's `venv` and
+  pip. Do not install uv or interrupt solely because it is missing. Preserve
+  project metadata; pip does not reproduce `uv.lock`. Report actual dependency
+  incompatibilities rather than silently changing the dependency contract.
+- Invoke the chosen manager or environment's Python explicitly; bare `python3`
+  does not select a worktree's `.venv`. Create environments lazily per worktree,
+  keep them ignored, and never copy the main checkout's `.venv` or share a
+  mutable environment between worktrees. Use uv's default shared cache.
+- Share manifests, locks, and Python configuration through Git, not live edits
+  to sibling worktrees. Establish baseline dependencies before branching
+  dependent experiments; reconcile environments after checkout or integration.
+  Subagents sharing a worktree coordinate dependency edits with the session
+  agent.
+- Runs execute committed source snapshots, not the session environment. Their
+  run recipe must recreate dependencies on the execution host from committed
+  inputs. Preserve established experiments' fixed run contracts.
 
 ## Evidence and links in chat
 

--- a/SYSTEM_PROMPT.md
+++ b/SYSTEM_PROMPT.md
@@ -42,32 +42,27 @@ normal repository tools for code and file inspection. Use this project id
 
 ## Python environments
 
-- Follow user instructions and the project's established manager, dependencies,
-  and run recipe. Inspect its manifests, README, and CI before choosing;
-  `pyproject.toml` alone does not imply uv. Do not migrate an existing workflow.
-- Otherwise prefer uv when available in the shell on the execution host. For
-  uv projects, preserve configuration, Python requirements, extras, and groups;
-  use `uv run --locked`. Update manifests and locks together for intentional
-  dependency changes; fix stale locks rather than bypassing them.
-- For a blank project with uv available, initialize only when durable Python
-  work needs it: create a minimal project named with a slug of the project name,
-  declare needed dependencies, and lock them. Do not scaffold Python tooling at session startup.
-- If uv is absent, use the existing Python environment or Python's `venv` and
-  pip. Do not install uv or interrupt solely because it is missing. Preserve
-  project metadata; pip does not reproduce `uv.lock`. Report actual dependency
-  incompatibilities rather than silently changing the dependency contract.
-- Invoke the chosen manager or environment's Python explicitly; bare `python3`
-  does not select a worktree's `.venv`. Create environments lazily per worktree,
-  keep them ignored, and never copy the main checkout's `.venv` or share a
-  mutable environment between worktrees. Use uv's default shared cache.
-- Share manifests, locks, and Python configuration through Git, not live edits
-  to sibling worktrees. Establish baseline dependencies before branching
-  dependent experiments; reconcile environments after checkout or integration.
-  Subagents sharing a worktree coordinate dependency edits with the session
-  agent.
-- Runs execute committed source snapshots, not the session environment. Their
-  run recipe must recreate dependencies on the execution host from committed
-  inputs. Preserve established experiments' fixed run contracts.
+- Respect user instructions and established tooling; inspect manifests, docs,
+  and CI before choosing. `pyproject.toml` alone does not imply uv. Otherwise,
+  prefer uv when available on the execution host; do not migrate workflows.
+- For uv projects, use `uv run --locked python train.py`, preserving Python
+  requirements, configuration, extras, and groups. Change dependencies with
+  `uv add <package>` or `uv remove <package>`; commit manifests and locks
+  together and fix stale locks rather than bypassing them.
+- Initialize blank Python projects only when needed and uv is available:
+  `uv init --bare --no-workspace --name project-slug` (slugify the project name),
+  then declare and lock needed dependencies.
+- If uv is absent, use existing Python or `venv` and pip; never install uv or
+  stop solely for its absence. Preserve metadata and report incompatibilities;
+  pip does not reproduce `uv.lock`.
+- Invoke the selected environment's Python explicitly. Keep ignored environments
+  separate per worktree; never copy or share `.venv`. Reuse uv's default cache.
+  Share dependency changes through Git, not sibling-file edits; reconcile after
+  checkout or integration. Establish baseline dependencies before branching;
+  subagents sharing a worktree coordinate edits with the session agent.
+- Run recipes must recreate dependencies from committed snapshots on the
+  execution host, independently of session environments. Preserve fixed run
+  contracts.
 
 ## Evidence and links in chat
 

--- a/SYSTEM_PROMPT.md
+++ b/SYSTEM_PROMPT.md
@@ -42,27 +42,24 @@ normal repository tools for code and file inspection. Use this project id
 
 ## Python environments
 
-- Respect user instructions and established tooling; inspect manifests, docs,
-  and CI before choosing. `pyproject.toml` alone does not imply uv. Otherwise,
-  prefer uv when available on the execution host; do not migrate workflows.
-- For uv projects, use `uv run --locked python train.py`, preserving Python
-  requirements, configuration, extras, and groups. Change dependencies with
-  `uv add <package>` or `uv remove <package>`; commit manifests and locks
-  together and fix stale locks rather than bypassing them.
-- Initialize blank Python projects only when needed and uv is available:
-  `uv init --bare --no-workspace --name project-slug` (slugify the project name),
-  then declare and lock needed dependencies.
-- If uv is absent, use existing Python or `venv` and pip; never install uv or
-  stop solely for its absence. Preserve metadata and report incompatibilities;
-  pip does not reproduce `uv.lock`.
-- Invoke the selected environment's Python explicitly. Keep ignored environments
-  separate per worktree; never copy or share `.venv`. Reuse uv's default cache.
-  Share dependency changes through Git, not sibling-file edits; reconcile after
-  checkout or integration. Establish baseline dependencies before branching;
-  subagents sharing a worktree coordinate edits with the session agent.
-- Run recipes must recreate dependencies from committed snapshots on the
-  execution host, independently of session environments. Preserve fixed run
-  contracts.
+- Follow user instructions and established dependency tooling; inspect project
+  setup first. `pyproject.toml` alone does not imply uv. Otherwise prefer uv
+  when available on the execution host.
+- For uv projects, use `uv run --locked`, preserve configuration, and commit
+  dependency declarations and locks together. Fix stale locks rather than
+  bypassing them.
+- Initialize blank Python projects with uv when needed and available; derive
+  a valid package name from the project and declare and lock dependencies.
+- Without uv, use existing Python or `venv` and pip; never install uv or stop
+  solely for its absence. Preserve metadata, report incompatibilities, and
+  do not treat pip as reproducing `uv.lock`.
+- Select the environment explicitly. Keep ignored environments separate per
+  worktree; never copy or share `.venv`. Reuse uv's default cache. Share
+  dependency changes through Git; reconcile environments after checkout or
+  integration and coordinate shared-worktree edits.
+- Establish baseline dependencies before branching experiments. Run recipes
+  must recreate dependencies from committed snapshots independently of
+  session environments; preserve fixed run contracts.
 
 ## Evidence and links in chat
 

--- a/agent-skills/orx-experiment-tree/SKILL.md
+++ b/agent-skills/orx-experiment-tree/SKILL.md
@@ -13,17 +13,10 @@ everything below assumes them.
 
 ## Before the first launch
 
-Inspect user instructions, the existing run command, project manifests, README,
-and CI for environment setup and execution. Follow
-the session playbook's Python defaults where no workflow is established; do
-not replace an existing manager. Ask only about an unresolved train/evaluation
-command, conflicting workflows, or compute-specific requirements.
-
-Encode the durable setup and execution recipe in the project's run command,
-following the playbook's Python policy. Runs execute committed snapshots (see
-`orx-compute`), so the recipe must recreate dependencies on the execution host
-from committed inputs without relying on the session's environment. Preserve
-established experiments' fixed run contracts.
+Follow the session playbook's Python policy. Before launching, resolve the
+train/evaluation command and compute-specific requirements; ask only if the
+project setup leaves these or the chosen workflow unclear. Record the durable
+setup and execution recipe in the project's run command.
 
 ## Provisional until it answers — repair, don't branch
 

--- a/agent-skills/orx-experiment-tree/SKILL.md
+++ b/agent-skills/orx-experiment-tree/SKILL.md
@@ -13,12 +13,17 @@ everything below assumes them.
 
 ## Before the first launch
 
-If the project has no completed runs, ask the user how they run the code before
-launching. Ask for the environment setup (conda, venv, uv, modules), dependency
-installation, the exact train or evaluation command they use today, and any
-compute-specific requirements. Do not reverse-engineer or guess this setup from
-the repository. Encode the durable recipe in the project's run command so later
-sessions do not need to ask again.
+Inspect user instructions, the existing run command, project manifests, README,
+and CI for environment setup and execution. Follow
+the session playbook's Python defaults where no workflow is established; do
+not replace an existing manager. Ask only about an unresolved train/evaluation
+command, conflicting workflows, or compute-specific requirements.
+
+Encode the durable setup and execution recipe in the project's run command,
+following the playbook's Python policy. Runs execute committed snapshots (see
+`orx-compute`), so the recipe must recreate dependencies on the execution host
+from committed inputs without relying on the session's environment. Preserve
+established experiments' fixed run contracts.
 
 ## Provisional until it answers — repair, don't branch
 

--- a/agent-skills/orx-figures/SKILL.md
+++ b/agent-skills/orx-figures/SKILL.md
@@ -62,14 +62,33 @@ under the artifacts directory needs its own copy there, or the import fails.
 (That works from any directory. Check the file is non-empty before importing
 it — the redirect creates the target before the lookup runs.)
 
-Then find an interpreter that has matplotlib, in this order — do not install
-into the project's environment without asking:
+Select the Python environment before running the plot, following the session
+playbook's Python policy: respect user instructions and established tooling.
+If the plot imports project code, use that project's dependency workflow; do
+not override its packages with an unrelated uv overlay.
+
+Reuse an established environment that already provides the plotting libraries.
+Otherwise, for an independent plot, prefer this when uv is available and
+permitted by the user and project workflow:
 
 ```sh
-python -c "import matplotlib"                      # the project env already has it
-uv run --with matplotlib --with numpy python figs/loss_curve.py
-python3 -m venv .venv-figs && .venv-figs/bin/pip install matplotlib numpy
+uv run --no-project --with matplotlib --with numpy python figs/loss_curve.py
 ```
+
+For saved scripts with inline dependency metadata, use
+`uv run --no-project figs/loss_curve.py` so uv reads that metadata.
+If uv is absent, reuse a suitable Python environment or create an
+ignored plotting environment in your worktree and run its Python explicitly:
+
+```sh
+python3 -m venv .venv-figs
+.venv-figs/bin/python -m pip install matplotlib numpy
+.venv-figs/bin/python figs/loss_curve.py
+```
+
+Use the equivalent `Scripts/python.exe` path on Windows. Keep the environment
+out of Git (add `.venv-figs/` to `.gitignore` if needed); do not install uv or
+modify the system Python for plotting.
 
 ## Where the figure goes, and how to cite it
 

--- a/agent-skills/orx-figures/SKILL.md
+++ b/agent-skills/orx-figures/SKILL.md
@@ -86,9 +86,8 @@ python3 -m venv .venv-figs
 .venv-figs/bin/python figs/loss_curve.py
 ```
 
-Use the equivalent `Scripts/python.exe` path on Windows. Keep the environment
-out of Git (add `.venv-figs/` to `.gitignore` if needed); do not install uv or
-modify the system Python for plotting.
+Keep the environment out of Git (add `.venv-figs/` to `.gitignore` if needed);
+do not install uv or modify the system Python for plotting.
 
 ## Where the figure goes, and how to cite it
 

--- a/agent-skills/orx-figures/SKILL.md
+++ b/agent-skills/orx-figures/SKILL.md
@@ -62,14 +62,8 @@ under the artifacts directory needs its own copy there, or the import fails.
 (That works from any directory. Check the file is non-empty before importing
 it — the redirect creates the target before the lookup runs.)
 
-Select the Python environment before running the plot, following the session
-playbook's Python policy: respect user instructions and established tooling.
-If the plot imports project code, use that project's dependency workflow; do
-not override its packages with an unrelated uv overlay.
-
-Reuse an established environment that already provides the plotting libraries.
-Otherwise, for an independent plot, prefer this when uv is available and
-permitted by the user and project workflow:
+Follow the session playbook's Python policy. The Python plotting templates
+use `matplotlib` and `numpy`. For independent plots using uv:
 
 ```sh
 uv run --no-project --with matplotlib --with numpy python figs/loss_curve.py
@@ -77,17 +71,8 @@ uv run --no-project --with matplotlib --with numpy python figs/loss_curve.py
 
 For saved scripts with inline dependency metadata, use
 `uv run --no-project figs/loss_curve.py` so uv reads that metadata.
-If uv is absent, reuse a suitable Python environment or create an
-ignored plotting environment in your worktree and run its Python explicitly:
-
-```sh
-python3 -m venv .venv-figs
-.venv-figs/bin/python -m pip install matplotlib numpy
-.venv-figs/bin/python figs/loss_curve.py
-```
-
-Keep the environment out of Git (add `.venv-figs/` to `.gitignore` if needed);
-do not install uv or modify the system Python for plotting.
+Plots importing project code must run in the project environment, not the
+isolated environment above.
 
 ## Where the figure goes, and how to cite it
 

--- a/src/local/opencode.rs
+++ b/src/local/opencode.rs
@@ -715,8 +715,8 @@ mod tests {
     fn playbook_carries_python_environment_policy() {
         let md = sample_playbook();
         assert!(md.contains("## Python environments"));
-        assert!(md.contains("use `uv run --locked python train.py`"));
-        assert!(md.contains("If uv is absent"));
+        assert!(md.contains("use `uv run --locked`"));
+        assert!(md.contains("Without uv"));
     }
 
     #[test]

--- a/src/local/opencode.rs
+++ b/src/local/opencode.rs
@@ -715,7 +715,7 @@ mod tests {
     fn playbook_carries_python_environment_policy() {
         let md = sample_playbook();
         assert!(md.contains("## Python environments"));
-        assert!(md.contains("use `uv run --locked`"));
+        assert!(md.contains("use `uv run --locked python train.py`"));
         assert!(md.contains("If uv is absent"));
     }
 

--- a/src/local/opencode.rs
+++ b/src/local/opencode.rs
@@ -712,6 +712,14 @@ mod tests {
     }
 
     #[test]
+    fn playbook_carries_python_environment_policy() {
+        let md = sample_playbook();
+        assert!(md.contains("## Python environments"));
+        assert!(md.contains("use `uv run --locked`"));
+        assert!(md.contains("If uv is absent"));
+    }
+
+    #[test]
     fn playbook_short_circuits_orientation_for_a_fresh_project() {
         let md = sample_playbook();
         assert!(md.contains("## Project state"));


### PR DESCRIPTION
## Summary

Prefer available uv through the shared agent prompt while respecting existing dependency workflows and falling back to Python when uv is absent. Align plotting and first-launch guidance with isolated worktree environments and committed snapshot run recipes.

Fixes OR-267. No installer, popup, new skill, or runtime environment-management changes.

## Validation

- [x] Formatting, Clippy, locked build, and locked Rust tests (734 passed, 2 ignored)
- [x] Debug/release builds report development telemetry channel
- [x] Localization/style checks, dev-slot tests, UI typecheck, and UI tests (113 passed)
- [x] Python/uv smoke tests: separate worktrees, Git dependency adoption, fresh snapshot, stale-lock rejection, standalone plotting, and Python/pip plotting without uv
- [x] Agent decision dry run: blank project, existing uv, Poetry, explicit Conda, missing uv, and stale lock
- [x] Four independent read-only Claude reviews with Ponytail review
- [ ] Interactive acceptance in a real OpenResearch session across supported harnesses
