### PR TITLE
Gate releases on CI and fix SSH key restoration race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,19 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_call:
+    inputs:
+      plan:
+        required: true
+        type: string
 
-# Cancel in-flight runs for the same ref when new commits land.
+# Cancel superseded PR/push checks without cancelling independent releases.
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -79,7 +87,7 @@ jobs:
       - name: Test
         run: cargo test --locked
 
-  # Guards the tag-on-bump release flow (tag-release.yml): the version in
+  # Guards the version-bump release flow (release-on-bump.yml): the version in
   # Cargo.toml may only move forward, may not reuse an already-released tag,
   # and a bump must come with a regenerated Cargo.lock. Catching these here
   # means a malformed bump can't reach main, where merging it would be the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,6 +237,15 @@ jobs:
     with:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit
+
+  custom-ci:
+    needs:
+      - plan
+      - build-local-artifacts
+    uses: ./.github/workflows/ci.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit
   # Determines if we should publish/announce
   host:
     needs:
@@ -245,8 +254,9 @@ jobs:
       - build-global-artifacts
       - custom-verify-build-channel
       - custom-telemetry-contract
+      - custom-ci
     # Only run if we're "publishing", and only if plan, local and global didn't fail (skipped is fine)
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.custom-verify-build-channel.result == 'skipped' || needs.custom-verify-build-channel.result == 'success') && (needs.custom-telemetry-contract.result == 'skipped' || needs.custom-telemetry-contract.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.custom-verify-build-channel.result == 'skipped' || needs.custom-verify-build-channel.result == 'success') && (needs.custom-telemetry-contract.result == 'skipped' || needs.custom-telemetry-contract.result == 'success') && (needs.custom-ci.result == 'skipped' || needs.custom-ci.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: "ubuntu-22.04"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,3 +15,8 @@ When changing authentication, organization, sandbox, or managed-compute APIs, in
 - `ui/dist` is committed and embedded in release builds. After UI changes, run `pnpm build` in `ui/` and include the regenerated assets.
 - Prefer canonical Tailwind utilities (`flex flex-col h-full min-h-0`) and project theme aliases (`bg-background`, `text-subtext`, `border-border`). Use arbitrary values only when no project utility exists, and preserve semantic marker classes when selectors or runtime behavior depend on them.
 - Before shipping, follow the checks in `.github/workflows/ci.yml`.
+
+## CI and release gates
+
+- GitHub branch protection for `main` must require `fmt, clippy, test` and `version sanity` from GitHub Actions, require branches to be up to date, and apply to administrators. These settings are managed in GitHub, not by this file.
+- CI runs on PR merge candidates and again on `main`. Releases also call the same CI workflow on the commit being packaged; publishing requires that run to succeed. Keep `./ci` in cargo-dist's `global-artifacts-jobs` when regenerating the release workflow.

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -9,8 +9,8 @@ cargo-dist-version = "0.32.0"
 ci = "github"
 # Mark only publishing builds and verify every packaged binary before hosting.
 github-build-setup = "../build-setup.yml"
-# Mark only publishing builds and verify every packaged binary before hosting.
-global-artifacts-jobs = ["./verify-build-channel", "./telemetry-contract"]
+# Verify packaged binaries and source CI before publishing.
+global-artifacts-jobs = ["./verify-build-channel", "./telemetry-contract", "./ci"]
 # The installers to generate for each app
 installers = ["shell"]
 # Target platforms to build apps for (Rust target-triple syntax)

--- a/src/commands/ssh_key.rs
+++ b/src/commands/ssh_key.rs
@@ -93,6 +93,7 @@ async fn ensure_default_public_key(ssh_dir: &std::path::Path) -> Result<String> 
                 .open(&public)
                 .await?;
             file.write_all(&output.stdout).await?;
+            file.flush().await?;
         }
     }
     if !private.is_file() {


### PR DESCRIPTION
Release publishing now depends on the existing CI suite running on the same commit as the packaged artifacts, including manual releases. The cargo-dist configuration preserves this gate when regenerating workflows; separate concurrency groups keep release checks from cancelling ordinary CI.

Fix the intermittent SSH key restoration failure by flushing Tokio's asynchronous public-key write before reopening the file for validation.

`main` branch protection is already configured in GitHub to require `fmt, clippy, test` and `version sanity`, an up-to-date branch, and enforcement for administrators. This PR documents those settings; merging it does not apply repository settings.

Validation:
- [x] Rust formatting, clippy, locked build and tests (734 passed, 2 ignored)
- [x] SSH restoration regression: 100 consecutive passes
- [x] UI typecheck and unit tests (113 passed), localization/style checks, dev-slot tests
- [x] Actionlint, cargo-dist generation check and release plan
- [x] Publish-condition checks: failed/cancelled CI blocks publishing
- [x] Debug/release development build-channel checks
- [x] Four independent Claude reviews (final round: no blockers)
- [x] GitHub PR CI (including Linux SSH restoration test)
- [ ] Observe the gate during the next actual version-bump release

