### PR TITLE
Validate merge queue candidates with required CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
   workflow_call:
     inputs:
       plan:
@@ -94,7 +95,7 @@ jobs:
   # release trigger.
   version-guard:
     name: version sanity
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -102,13 +103,14 @@ jobs:
           fetch-depth: 0
 
       - name: Version must move forward (with a fresh lockfile)
+        env:
+          BASE_SHA: ${{ github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
 
           pkg_version() { grep -m1 '^version = ' "$1" | sed -E 's/version = "(.*)"/\1/'; }
 
-          git fetch --quiet origin "${{ github.base_ref }}"
-          git show "origin/${{ github.base_ref }}:Cargo.toml" > /tmp/base-Cargo.toml
+          git show "${BASE_SHA}:Cargo.toml" > /tmp/base-Cargo.toml
           base=$(pkg_version /tmp/base-Cargo.toml)
           head=$(pkg_version Cargo.toml)
           echo "base: ${base}  pr: ${head}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,5 +18,5 @@ When changing authentication, organization, sandbox, or managed-compute APIs, in
 
 ## CI and release gates
 
-- GitHub branch protection for `main` must require `fmt, clippy, test` and `version sanity` from GitHub Actions, require branches to be up to date, and apply to administrators. These settings are managed in GitHub, not by this file.
-- CI runs on PR merge candidates and again on `main`. Releases also call the same CI workflow on the commit being packaged; publishing requires that run to succeed. Keep `./ci` in cargo-dist's `global-artifacts-jobs` when regenerating the release workflow.
+- GitHub protection for `main` must require the merge queue plus the `fmt, clippy, test` and `version sanity` checks from GitHub Actions, including for administrators. Disable the separate branch-up-to-date requirement: the queue validates the combined result against current `main`. These settings are managed in GitHub, not by this file.
+- CI runs on PR merge candidates, merge groups and again on `main`. Releases also call the same CI workflow on the commit being packaged; publishing requires that run to succeed. Keep `./ci` in cargo-dist's `global-artifacts-jobs` when regenerating the release workflow.


### PR DESCRIPTION
Run the existing required CI checks on merge-queue candidates so GitHub can validate each PR against current main without requiring manual branch updates. The version guard reads the candidate’s exact base SHA. No application or release behavior changes.

Merge this bootstrap before enabling the main-only squash merge queue and disabling strict branch-up-to-date checks. Preserve both required GitHub Actions checks and administrator enforcement.

Validation:
- [x] Four independent Claude Opus reviews: no blockers.
- [x] Version guard exercised for unchanged version, downgrade, stale lockfile, valid bump and existing release tag.
- [x] Local Rust formatting, clippy and debug build.
- [x] Full GitHub CI (local test compilation exhausted disk; temporary build output removed).
- [ ] First real merge-queue run after activation.


- [x] Main merge queue activated with no bypass, one PR per squash merge; only the strict up-to-date flag was changed in existing protection.
