### PR TITLE
Use simulated PR merges without a merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-  merge_group:
   workflow_call:
     inputs:
       plan:
@@ -95,7 +94,7 @@ jobs:
   # release trigger.
   version-guard:
     name: version sanity
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -104,7 +103,7 @@ jobs:
 
       - name: Version must move forward (with a fresh lockfile)
         env:
-          BASE_SHA: ${{ github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,5 +18,6 @@ When changing authentication, organization, sandbox, or managed-compute APIs, in
 
 ## CI and release gates
 
-- GitHub protection for `main` must require the merge queue plus the `fmt, clippy, test` and `version sanity` checks from GitHub Actions, including for administrators. Disable the separate branch-up-to-date requirement: the queue validates the combined result against current `main`. These settings are managed in GitHub, not by this file.
-- CI runs on PR merge candidates, merge groups and again on `main`. Releases also call the same CI workflow on the commit being packaged; publishing requires that run to succeed. Keep `./ci` in cargo-dist's `global-artifacts-jobs` when regenerating the release workflow.
+- GitHub protection for `main` must require the `fmt, clippy, test` and `version sanity` checks from GitHub Actions, including for administrators. Do not require a merge queue or require branches to be up to date. These settings are managed in GitHub, not by this file.
+- PR CI must test GitHub's simulated merge (`refs/pull/<number>/merge`), which `actions/checkout` selects by default for `pull_request` events, rather than checking out the PR head alone. Each run tests its merge candidate; subsequent changes to `main` do not automatically rerun open PRs.
+- CI also runs on `main`. Releases call the same CI workflow on the commit being packaged; publishing requires that run to succeed. Keep `./ci` in cargo-dist's `global-artifacts-jobs` when regenerating the release workflow.


### PR DESCRIPTION
Remove merge-queue-specific CI and restore ordinary PR merging. Required GitHub Actions checks and administrator enforcement remain, with strict branch-up-to-date checks disabled.

PR CI continues to test GitHub’s simulated merge via the default `actions/checkout` behavior. A later main update does not automatically rerun every open PR. The queue ruleset has already been removed.

Validation:
- [x] Queue absent; both required checks and administrator enforcement verified through GitHub API.
- [x] Local review of the minimal rollback; the existing PR path was covered by the preceding four clean Opus reviews and successful CI.
- [x] Diff whitespace check.
- [x] GitHub CI on this correction.


- [x] Compared current alphaXiv/alphaxiv.org CI at 62f155b7c7: same pull_request/default checkout simulated-merge behavior, no queue or manual merge step. OpenResearch retains its existing required checks and admin enforcement.

Awaiting explicit user approval to merge.
