### PR TITLE
Turn SSH multiplexing off explicitly on Windows

### DIFF
--- a/src/commands/up_remote.rs
+++ b/src/commands/up_remote.rs
@@ -6,7 +6,7 @@
 //! forward itself: it starts `orx up` on the remote, tunnels the port to this
 //! machine, waits for the server to come up, and opens the browser.
 //!
-//! Transport is the `ssh` binary with the same ControlMaster/BatchMode options
+//! Transport is the `ssh` binary with the same multiplexing/BatchMode options
 //! the SSH job backend uses (`crate::jobs::ssh`); auth is the user's own
 //! `~/.ssh/config` + agent/keys — orx never reads a key.
 
@@ -2236,7 +2236,8 @@ pub(crate) fn forward_spec(local_port: u16, remote_port: u16) -> String {
 }
 
 /// Build `ssh <opts> -L <forward> -- <dest> <remote_cmd>` over the settings
-/// ControlMaster. The session launcher replaces stdin with its credential pipe.
+/// ControlMaster, where the platform has one. The session launcher replaces
+/// stdin with its credential pipe.
 pub(crate) fn ssh_forward_command(
     target: &SshTarget,
     forward: &str,
@@ -2566,7 +2567,7 @@ mod tests {
     }
 
     #[test]
-    fn tunnel_reuses_control_master_and_exits_on_forward_failure() {
+    fn tunnel_uses_the_platform_control_master_and_exits_on_forward_failure() {
         let opts = crate::jobs::ssh::forward_args(
             &SshTarget::alias("mybox"),
             "127.0.0.1:7:localhost:7",

--- a/src/commands/up_remote.rs
+++ b/src/commands/up_remote.rs
@@ -2576,7 +2576,8 @@ mod tests {
         let joined = opts.join(" ");
         assert!(joined.contains("-o ExitOnForwardFailure=yes"));
         assert!(joined.contains("-o BatchMode=yes"));
-        assert!(joined.contains("-o ControlMaster=auto"));
+        let master = if cfg!(unix) { "auto" } else { "no" };
+        assert!(joined.contains(&format!("-o ControlMaster={master}")));
         assert!(opts.contains(&"-T".to_string()));
     }
 

--- a/src/jobs/ssh.rs
+++ b/src/jobs/ssh.rs
@@ -45,21 +45,19 @@ fn prepare_control_dir() -> Result<()> {
             dir.display()
         )
     })?;
-    {
-        use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
 
-        let metadata = std::fs::symlink_metadata(&dir)?;
-        let uid = unsafe { libc::geteuid() };
-        if !metadata.file_type().is_dir() || metadata.uid() != uid {
-            return Err(anyhow!(
-                "SSH control path {} is not an owner-controlled directory.",
-                dir.display()
-            ));
-        }
-        let mut permissions = metadata.permissions();
-        permissions.set_mode(0o700);
-        std::fs::set_permissions(&dir, permissions)?;
+    let metadata = std::fs::symlink_metadata(&dir)?;
+    let uid = unsafe { libc::geteuid() };
+    if !metadata.file_type().is_dir() || metadata.uid() != uid {
+        return Err(anyhow!(
+            "SSH control path {} is not an owner-controlled directory.",
+            dir.display()
+        ));
     }
+    let mut permissions = metadata.permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(&dir, permissions)?;
     Ok(())
 }
 
@@ -148,7 +146,7 @@ fn control_path(target: &SshTarget) -> PathBuf {
 /// Shared ssh options: connection setup permits prompts; background work never
 /// does. On unix both modes share one control socket, kept for ten idle
 /// minutes, so a single interactive login covers later status, log and job
-/// commands; Windows cannot multiplex, so each call authenticates on its own.
+/// commands.
 fn ssh_opts(target: &SshTarget, batch: bool) -> Vec<String> {
     let mut opts = vec![
         "-o".into(),
@@ -587,7 +585,7 @@ mod tests {
         assert_eq!(target.dest, "mybox");
         assert!(target.extra_opts.is_empty());
         // No `-p`/`-o Strict…` beyond the shared multiplexing opts.
-        let shared = 4 + multiplexing_opts(&target).len();
+        let shared = 4 + multiplexing_opts(&target).len(); // BatchMode, ConnectTimeout
         assert_eq!(ssh_opts(&target, true).len(), shared);
     }
 
@@ -621,6 +619,15 @@ mod tests {
                 "LogLevel=ERROR",
             ]
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn multiplexing_is_on_and_persistent() {
+        let opts = multiplexing_opts(&SshTarget::alias("cluster"));
+        assert_eq!(opts[0..2], ["-o", "ControlMaster=auto"]);
+        assert!(opts[3].starts_with("ControlPath="));
+        assert_eq!(opts[4..6], ["-o", "ControlPersist=600"]);
     }
 
     /// Present and off, not absent: a user's own ssh_config would otherwise

--- a/src/jobs/ssh.rs
+++ b/src/jobs/ssh.rs
@@ -33,11 +33,7 @@ fn control_dir() -> PathBuf {
     PathBuf::from("/tmp").join(format!("orx-ssh-{uid}-{:08x}", namespace.finish() as u32))
 }
 
-#[cfg(not(unix))]
-fn control_dir() -> PathBuf {
-    crate::config::config_dir().join("ssh-cm")
-}
-
+#[cfg(unix)]
 fn prepare_control_dir() -> Result<()> {
     let dir = control_dir();
     std::fs::create_dir_all(&dir).map_err(|e| {
@@ -62,6 +58,12 @@ fn prepare_control_dir() -> Result<()> {
         permissions.set_mode(0o700);
         std::fs::set_permissions(&dir, permissions)?;
     }
+    Ok(())
+}
+
+/// No socket to place, so nothing to prepare.
+#[cfg(not(unix))]
+fn prepare_control_dir() -> Result<()> {
     Ok(())
 }
 
@@ -131,6 +133,7 @@ impl SshTarget {
     }
 }
 
+#[cfg(unix)]
 fn control_path(target: &SshTarget) -> PathBuf {
     // A 16-hex hash leaves room for ssh's temporary bind suffix. It folds in
     // the extra opts so different ports never share a control socket.
@@ -150,15 +153,36 @@ fn ssh_opts(target: &SshTarget, batch: bool) -> Vec<String> {
         format!("BatchMode={}", if batch { "yes" } else { "no" }),
         "-o".into(),
         "ConnectTimeout=10".into(),
+    ];
+    opts.extend(multiplexing_opts(target));
+    opts.extend(target.extra_opts.iter().cloned());
+    opts
+}
+
+#[cfg(unix)]
+fn multiplexing_opts(target: &SshTarget) -> Vec<String> {
+    vec![
         "-o".into(),
         "ControlMaster=auto".into(),
         "-o".into(),
         format!("ControlPath={}", control_path(target).display()),
         "-o".into(),
         "ControlPersist=600".into(),
-    ];
-    opts.extend(target.extra_opts.iter().cloned());
-    opts
+    ]
+}
+
+/// Win32-OpenSSH accepts these and then never creates a master, and a
+/// ControlPath it does honour from the user's own ssh_config fails the
+/// connection outright ("getsockname failed: Not a socket"). Turning it off
+/// explicitly is what overrides that config; omitting the options is not.
+#[cfg(not(unix))]
+fn multiplexing_opts(_target: &SshTarget) -> Vec<String> {
+    vec![
+        "-o".into(),
+        "ControlMaster=no".into(),
+        "-o".into(),
+        "ControlPath=none".into(),
+    ]
 }
 
 /// Arguments for a long-lived local forward over the same authenticated
@@ -200,6 +224,13 @@ pub(crate) fn interactive_args(target: &SshTarget) -> Result<Vec<String>> {
     Ok(args)
 }
 
+/// Win32-OpenSSH never creates a master, so there is never one running.
+#[cfg(not(unix))]
+pub(crate) async fn master_is_running(_target: &SshTarget) -> Result<bool> {
+    Ok(false)
+}
+
+#[cfg(unix)]
 pub(crate) async fn master_is_running(target: &SshTarget) -> Result<bool> {
     prepare_control_dir()?;
     let path = control_path(target);
@@ -591,6 +622,19 @@ mod tests {
 
     /// Explicit targets on the same host but different ports must not share a
     /// ControlMaster socket — the opts are part of the ControlPath hash.
+    /// Off unix the options must be present and off, not absent: a user's own
+    /// ssh_config would otherwise re-enable a ControlPath that fails the
+    /// connection.
+    #[cfg(not(unix))]
+    #[test]
+    fn multiplexing_is_turned_off_rather_than_left_unset() {
+        let opts = ssh_opts(&SshTarget::alias("cluster"), true);
+        assert!(opts.contains(&"ControlMaster=no".to_string()));
+        assert!(opts.contains(&"ControlPath=none".to_string()));
+        assert!(!opts.iter().any(|opt| opt.starts_with("ControlPersist=")));
+    }
+
+    #[cfg(unix)]
     #[test]
     fn control_path_differs_per_port() {
         let control_path = |t: &SshTarget| {
@@ -623,6 +667,7 @@ mod tests {
         assert!(path.len() + 17 < 104, "{path}");
     }
 
+    #[cfg(unix)]
     #[test]
     fn interactive_and_batch_modes_share_the_control_path() {
         let target = SshTarget::alias("cluster");

--- a/src/jobs/ssh.rs
+++ b/src/jobs/ssh.rs
@@ -3,8 +3,10 @@
 //! No scheduler: the target is a plain server you can `ssh` into. Everything
 //! shells out to the `ssh` binary (like the k8s backend shells out to
 //! `kubectl`), so auth is your `~/.ssh/config` + agent/keys — orx never reads a
-//! key. Connections are multiplexed (ControlMaster) so the many status/log
-//! polls reuse one TCP session instead of a handshake apiece.
+//! key. On unix connections are multiplexed (ControlMaster) so the many
+//! status/log polls reuse one TCP session instead of a handshake apiece.
+//! Win32-OpenSSH cannot, so on Windows every call authenticates for itself —
+//! which needs a key in the agent, or one without a passphrase.
 //!
 //! The handle is a remote run directory `~/.orx/runs/<run_id>/` holding:
 //!   run.sh      the launcher (exported env + snapshot-and-run payload)
@@ -14,6 +16,7 @@
 //! A restarted `orx supervise` reattaches purely from that directory.
 
 use std::collections::HashMap;
+#[cfg(unix)]
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::time::Duration;
@@ -42,7 +45,6 @@ fn prepare_control_dir() -> Result<()> {
             dir.display()
         )
     })?;
-    #[cfg(unix)]
     {
         use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
 
@@ -61,7 +63,6 @@ fn prepare_control_dir() -> Result<()> {
     Ok(())
 }
 
-/// No socket to place, so nothing to prepare.
 #[cfg(not(unix))]
 fn prepare_control_dir() -> Result<()> {
     Ok(())
@@ -145,8 +146,9 @@ fn control_path(target: &SshTarget) -> PathBuf {
 }
 
 /// Shared ssh options: connection setup permits prompts; background work never
-/// does. Both modes use the same control socket, kept for ten idle minutes, so
-/// one interactive login covers later status, log, and job commands.
+/// does. On unix both modes share one control socket, kept for ten idle
+/// minutes, so a single interactive login covers later status, log and job
+/// commands; Windows cannot multiplex, so each call authenticates on its own.
 fn ssh_opts(target: &SshTarget, batch: bool) -> Vec<String> {
     let mut opts = vec![
         "-o".into(),
@@ -171,10 +173,10 @@ fn multiplexing_opts(target: &SshTarget) -> Vec<String> {
     ]
 }
 
-/// Win32-OpenSSH accepts these and then never creates a master, and a
-/// ControlPath it does honour from the user's own ssh_config fails the
-/// connection outright ("getsockname failed: Not a socket"). Turning it off
-/// explicitly is what overrides that config; omitting the options is not.
+/// Win32-OpenSSH has no multiplexing (PowerShell/Win32-OpenSSH#1328), and on
+/// the builds reported there a ControlPath inherited from the user's own
+/// ssh_config fails the connection with "getsockname failed: Not a socket".
+/// Only setting them explicitly overrides that config; omitting them does not.
 #[cfg(not(unix))]
 fn multiplexing_opts(_target: &SshTarget) -> Vec<String> {
     vec![
@@ -185,8 +187,8 @@ fn multiplexing_opts(_target: &SshTarget) -> Vec<String> {
     ]
 }
 
-/// Arguments for a long-lived local forward over the same authenticated
-/// ControlMaster used by settings and background jobs.
+/// Arguments for a long-lived local forward, riding the same authenticated
+/// ControlMaster as settings and background jobs where the platform has one.
 pub(crate) fn forward_args(
     target: &SshTarget,
     forward: &str,
@@ -216,7 +218,8 @@ pub(crate) fn forward_args(
 
 /// Arguments for the short interactive login opened by Settings. `true` ends
 /// the visible session after authentication while ControlPersist keeps its
-/// master connection available to the ordinary batch-mode calls below.
+/// master available to the batch-mode calls below — on Windows there is no
+/// master, so this only proves the host reachable and primes nothing.
 pub(crate) fn interactive_args(target: &SshTarget) -> Result<Vec<String>> {
     prepare_control_dir()?;
     let mut args = ssh_opts(target, false);
@@ -224,7 +227,6 @@ pub(crate) fn interactive_args(target: &SshTarget) -> Result<Vec<String>> {
     Ok(args)
 }
 
-/// Win32-OpenSSH never creates a master, so there is never one running.
 #[cfg(not(unix))]
 pub(crate) async fn master_is_running(_target: &SshTarget) -> Result<bool> {
     Ok(false)
@@ -585,7 +587,8 @@ mod tests {
         assert_eq!(target.dest, "mybox");
         assert!(target.extra_opts.is_empty());
         // No `-p`/`-o Strict…` beyond the shared multiplexing opts.
-        assert_eq!(ssh_opts(&target, true).len(), 10);
+        let shared = 4 + multiplexing_opts(&target).len();
+        assert_eq!(ssh_opts(&target, true).len(), shared);
     }
 
     #[test]
@@ -620,20 +623,19 @@ mod tests {
         );
     }
 
-    /// Explicit targets on the same host but different ports must not share a
-    /// ControlMaster socket — the opts are part of the ControlPath hash.
-    /// Off unix the options must be present and off, not absent: a user's own
-    /// ssh_config would otherwise re-enable a ControlPath that fails the
-    /// connection.
+    /// Present and off, not absent: a user's own ssh_config would otherwise
+    /// re-enable a ControlPath that fails the connection.
     #[cfg(not(unix))]
     #[test]
-    fn multiplexing_is_turned_off_rather_than_left_unset() {
-        let opts = ssh_opts(&SshTarget::alias("cluster"), true);
-        assert!(opts.contains(&"ControlMaster=no".to_string()));
-        assert!(opts.contains(&"ControlPath=none".to_string()));
-        assert!(!opts.iter().any(|opt| opt.starts_with("ControlPersist=")));
+    fn multiplexing_is_disabled_not_omitted() {
+        assert_eq!(
+            multiplexing_opts(&SshTarget::alias("cluster")),
+            vec!["-o", "ControlMaster=no", "-o", "ControlPath=none"],
+        );
     }
 
+    /// Explicit targets on the same host but different ports must not share a
+    /// ControlMaster socket — the opts are part of the ControlPath hash.
     #[cfg(unix)]
     #[test]
     fn control_path_differs_per_port() {
@@ -679,6 +681,11 @@ mod tests {
         };
 
         assert_eq!(option(true), option(false));
+    }
+
+    #[test]
+    fn batch_mode_follows_the_mode_flag() {
+        let target = SshTarget::alias("cluster");
         assert!(ssh_opts(&target, true).contains(&"BatchMode=yes".to_string()));
         assert!(ssh_opts(&target, false).contains(&"BatchMode=no".to_string()));
     }

--- a/src/local/git.rs
+++ b/src/local/git.rs
@@ -147,7 +147,7 @@ fn git(dir: Option<&Path>, args: &[&str]) -> Result<String> {
     }
     cmd.env("GIT_TERMINAL_PROMPT", "0");
     if std::env::var_os("GIT_SSH_COMMAND").is_none() && std::env::var_os("GIT_SSH").is_none() {
-        cmd.env("GIT_SSH_COMMAND", ssh_command("ssh -oBatchMode=yes"));
+        cmd.env("GIT_SSH_COMMAND", git_ssh_command("ssh -oBatchMode=yes"));
     }
     let out = cmd
         .args(args)
@@ -1482,12 +1482,12 @@ pub fn prepare_shallow_repository_for_publication(repo_path: &Path) -> Result<bo
 /// cannot do it — a ControlPath from the user's ssh_config would otherwise fail
 /// the connection (see `jobs::ssh::multiplexing_opts`).
 #[cfg(unix)]
-fn ssh_command(base: &str) -> String {
+fn git_ssh_command(base: &str) -> String {
     base.to_string()
 }
 
 #[cfg(not(unix))]
-fn ssh_command(base: &str) -> String {
+fn git_ssh_command(base: &str) -> String {
     format!("{base} -oControlMaster=no -oControlPath=none")
 }
 
@@ -1519,7 +1519,7 @@ fn authenticated_git_command(repo_path: &Path) -> Command {
     if std::env::var_os("GIT_SSH_COMMAND").is_none() && std::env::var_os("GIT_SSH").is_none() {
         command.env(
             "GIT_SSH_COMMAND",
-            ssh_command("ssh -oBatchMode=yes -oConnectTimeout=15"),
+            git_ssh_command("ssh -oBatchMode=yes -oConnectTimeout=15"),
         );
     }
     command

--- a/src/local/git.rs
+++ b/src/local/git.rs
@@ -147,7 +147,7 @@ fn git(dir: Option<&Path>, args: &[&str]) -> Result<String> {
     }
     cmd.env("GIT_TERMINAL_PROMPT", "0");
     if std::env::var_os("GIT_SSH_COMMAND").is_none() && std::env::var_os("GIT_SSH").is_none() {
-        cmd.env("GIT_SSH_COMMAND", "ssh -oBatchMode=yes");
+        cmd.env("GIT_SSH_COMMAND", ssh_command("ssh -oBatchMode=yes"));
     }
     let out = cmd
         .args(args)
@@ -1478,6 +1478,19 @@ pub fn prepare_shallow_repository_for_publication(repo_path: &Path) -> Result<bo
     Ok(true)
 }
 
+/// git's own ssh invocation, with multiplexing turned off where the platform
+/// cannot do it — a ControlPath from the user's ssh_config would otherwise fail
+/// the connection (see `jobs::ssh::multiplexing_opts`).
+#[cfg(unix)]
+fn ssh_command(base: &str) -> String {
+    base.to_string()
+}
+
+#[cfg(not(unix))]
+fn ssh_command(base: &str) -> String {
+    format!("{base} -oControlMaster=no -oControlPath=none")
+}
+
 const GITHUB_CREDENTIAL_HELPER: &str = "!gh auth git-credential";
 
 fn redact_remote_urls(text: &str) -> String {
@@ -1504,7 +1517,10 @@ fn authenticated_git_command(repo_path: &Path) -> Command {
         command.env("PATH", paths);
     }
     if std::env::var_os("GIT_SSH_COMMAND").is_none() && std::env::var_os("GIT_SSH").is_none() {
-        command.env("GIT_SSH_COMMAND", "ssh -oBatchMode=yes -oConnectTimeout=15");
+        command.env(
+            "GIT_SSH_COMMAND",
+            ssh_command("ssh -oBatchMode=yes -oConnectTimeout=15"),
+        );
     }
     command
         .env("GH_PROMPT_DISABLED", "1")


### PR DESCRIPTION
Win32-OpenSSH implements no connection multiplexing. It parses `ControlMaster` and `ControlPath` and never creates a master ([PowerShell/Win32-OpenSSH#1328](https://github.com/PowerShell/Win32-OpenSSH/issues/1328)), and on the builds reported there a `ControlPath` inherited from the user's own `ssh_config` fails the connection with `getsockname failed: Not a socket`.

Omitting the options is not enough — that is what leaves the user's config in charge. Windows passes `ControlMaster=no ControlPath=none` instead, which is what overrides it. Nothing changes on unix, where the shared master still covers later status, log and job commands.

The socket machinery goes with it: the control directory, its path hash and its preparation are unix's, and `master_is_running` can only answer false where no master is ever created.

`git` also shells out to `ssh`, with its own `GIT_SSH_COMMAND` that never carried the override — so git-over-SSH would still have broken on Windows for exactly the same reason. Routed through one helper.

## Known issue this makes visible

`master_is_running` is `false` by construction on Windows, and `SettingsPage` renders `reachable && toolsFound && masterRunning === false` as a **"Disconnected"** badge — so a healthy Windows host will show that permanently, and its tested-at timestamp is suppressed.

This is not a regression: on `main` the Windows control socket never existed either, so the check already returned false. It is display-only and nothing gates on it. The real defect is that the endpoint cannot distinguish *no master* from *multiplexing does not exist here*; the fix is for it to report the capability as unknown and let the badge fall through to Ready. That touches the dashboard and belongs in its own change.

## Testing

- [x] `cargo fmt --all --check`, `clippy --all-targets -- -D warnings`, `build --locked`, `test --locked` — 768 tests, macOS
- [x] Two rounds of independent review, second clean
- [x] Unix option vector verified byte-identical and in the same order
- [ ] A Windows host connects from Settings and shows Ready or the known Disconnected badge, not an error
- [ ] `git clone`/`fetch` over SSH from Windows with a `ControlPath` set in the user's `ssh_config`
- [ ] Submit and poll a run over SSH from Windows, with the key in the OpenSSH agent

Nothing below the line has run — this needs a Windows machine and a real SSH host. Related: #299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)