### PR TITLE
Keep internal CLI terminology out of agent replies (OR-270)

### DIFF
--- a/SYSTEM_PROMPT.md
+++ b/SYSTEM_PROMPT.md
@@ -40,6 +40,15 @@ Use `orx` as the source of truth for the experiment tree, runs, and logs. Use
 normal repository tools for code and file inspection. Use this project id
 (`{id}`) for every `orx` command that takes one.
 
+## User-facing language
+
+The `orx` CLI and internal skill names are implementation details: use their
+exact names in tool calls, but never mention them or show their commands in
+user-facing messages, progress updates, or generated reports. Describe observed
+results directly ("No runs remain active") and use OpenResearch for the product
+name. If sign-in is required, ask the user to sign in to OpenResearch without
+giving CLI commands.
+
 ## Python environments
 
 - Follow user instructions and established dependency tooling; inspect project

--- a/SYSTEM_PROMPT.md
+++ b/SYSTEM_PROMPT.md
@@ -40,7 +40,7 @@ Use `orx` as the source of truth for the experiment tree, runs, and logs. Use
 normal repository tools for code and file inspection. Use this project id
 (`{id}`) for every `orx` command that takes one.
 
-ORX is internal and should stay under the hood; do not mention it in user-facing responses.
+`orx` is internal and should stay under the hood; do not mention it in user-facing responses.
 
 ## Python environments
 

--- a/SYSTEM_PROMPT.md
+++ b/SYSTEM_PROMPT.md
@@ -40,14 +40,7 @@ Use `orx` as the source of truth for the experiment tree, runs, and logs. Use
 normal repository tools for code and file inspection. Use this project id
 (`{id}`) for every `orx` command that takes one.
 
-## User-facing language
-
-The `orx` CLI and internal skill names are implementation details: use their
-exact names in tool calls, but never mention them or show their commands in
-user-facing messages, progress updates, or generated reports. Describe observed
-results directly ("No runs remain active") and use OpenResearch for the product
-name. If sign-in is required, ask the user to sign in to OpenResearch without
-giving CLI commands.
+ORX is internal and should stay under the hood; do not mention it in user-facing responses.
 
 ## Python environments
 


### PR DESCRIPTION
Fixes [OR-270](https://linear.app/alphaxiv/issue/OR-270/there-should-be-no-user-facing-mention-of-orx).

Add one sentence under “Start here” in the shared agent prompt: ORX is internal, should stay under the hood, and should not be mentioned in user-facing responses. This prompt is used by Claude, Codex, and OpenCode.

- [x] Rust formatting, Clippy, locked build, and locked tests
- [x] Localization/style checks, dev-slot tests, UI typecheck, and 155 UI tests
- [x] Four independent Claude reviews; final wording simplification reviewed locally
- [ ] In an updated build, restart an agent session and verify cancellation/status replies do not mention ORX.

The prompt is embedded in the binary; existing agent processes need to restart to pick it up. Past messages are unchanged.
