### PR TITLE
chore: bump version to 0.1.123

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,7 +1162,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openresearch-cli"
-version = "0.1.122"
+version = "0.1.123"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openresearch-cli"
-version = "0.1.122"
+version = "0.1.123"
 edition = "2021"
 description = "OpenResearch CLI (orx) — Rust port"
 repository = "https://github.com/alphaXiv/OpenResearch"


### PR DESCRIPTION
Bumps the package version to 0.1.123. **Merging this PR cuts release v0.1.123** — the first to ship a Windows build.

Releases everything since v0.1.122: #305, #299 (Windows support), #306.

Also replaces the macOS DMG now served as latest: v0.1.122's `OpenResearch.dmg` and `macos-app.json` were overwritten on 2026-09-11 01:53 UTC by an attach run chained off a release dry run, so they no longer match the v0.1.122 tag.

## Pre-merge checks

- [x] Release dry run on the Windows branch ([run 34550579194](https://github.com/alphaXiv/OpenResearch/actions/runs/34550579194)) built and verified all five targets, including `x86_64-pc-windows-msvc`
- [x] `ui/dist` is current — rebuilt from `ui/src` at `eaba866`, all 66 files byte-identical to the committed bundle
- [x] No new telemetry events in the range, so the production contract is unchanged
- [x] `RELEASE_DISPATCH_TOKEN` is set, so the macOS DMG should auto-attach
- [ ] Hold other merges to `main` until the Release run publishes — `release.yml` tags main's tip at dispatch
- [ ] Watch the Release run. The dry run exercised only the development build; this is the first Windows build with `ORX_OFFICIAL_RELEASE_BUILD=1` and a `production` channel check. A failure in any Windows job skips `host` for every platform — fix, then re-run the release-on-bump run.

## Verified locally

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --locked`
- [x] `cargo test --locked` — 781 passed, 0 failed
- [x] Version guard: 0.1.122 → 0.1.123 moves forward, `Cargo.lock` regenerated, `v0.1.123` tag unclaimed

## What Windows testers get

`openresearch-cli-x86_64-pc-windows-msvc.zip` (extract, double-click `orx.exe`) and `openresearch-cli-installer.ps1`. Both are unsigned, so SmartScreen warns on first run; see `docs/windows.md`.

Windows is a beta. Starting the dashboard by double-click is verified on real hardware; the demo, SSH, and cancelling a local run on Windows have not yet been exercised by a person (see #299's checklist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
