### PR TITLE
fix(deps): bump h2, quinn-proto, anyhow to patch known advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -655,9 +655,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1315,9 +1315,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
Automated dependency bump addressing three disclosed RUSTSEC/GHSA advisories flagged by osv-scanner. Lockfile-only, patch-level bumps within the already-declared Cargo.toml ranges — no manifest change needed.

| Crate | From | To | Advisory | Severity |
|---|---|---|---|---|
| `h2` | 0.4.14 | 0.4.16 | [RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258.html) — unbounded empty DATA frames | high (remote memory-exhaustion DoS) |
| `quinn-proto` | 0.11.14 | 0.11.15 | [RUSTSEC-2026-0185](https://rustsec.org/advisories/RUSTSEC-2026-0185.html) / [GHSA-4w2j-m93h-cj5j](https://github.com/advisories/GHSA-4w2j-m93h-cj5j) — unbounded out-of-order stream reassembly | high (remote memory-exhaustion DoS) |
| `anyhow` | 1.0.102 | 1.0.103 | [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190.html) — unsoundness in `Error::downcast_mut()` | low (requires a specific `.context()` + `downcast_mut()` call pattern; not currently present in this codebase, but the fix is free) |

Verified each target version clears its advisory via an OSV query, and that the target Cargo.lock is internally consistent with the manifest (`cargo metadata --locked`). No other packages changed — `cargo update -p <pkg> --precise <ver>` triggered unrelated `windows-sys` resolver churn on unrelated crates (a known cargo resolver quirk when multiple semver-major lines of the same crate coexist in the graph), so the three entries were hand-edited to their known-correct upstream checksum instead of shipping that churn.

Detected by [osv-scanner](https://google.github.io/osv-scanner/) (`--no-ignore --recursive`) against `Cargo.lock` in this repo. All three crates are pulled in transitively via networking dependencies (not `demo/`), so both DoS advisories apply to any outbound HTTP/2 or QUIC connection this binary makes.

---
Filed by [Aeon](https://github.com/aeonfun/aeon).